### PR TITLE
🎨 Palette: Improve table accessibility with semantic buttons

### DIFF
--- a/src/layout/table.tsx
+++ b/src/layout/table.tsx
@@ -248,20 +248,22 @@ export default React.memo(
                           type="checkbox"
                           className="w-4 h-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:ring-blue-500"
                           name={name}
+                          aria-label={`Select ${name}`}
                           onChange={() => onSelect(name)}
                           checked={selected.includes(name)}
                         />
                       </td>
                       <td className="p-2 border border-gray-700 text-center align-middle">
-                        <span
-                          role="button"
+                        <button
+                          type="button"
                           onClick={() => toggleExpand(row.id)}
-                          style={{ cursor: "pointer", fontSize: "1.2em" }}
-                          title="Toggle Chart"
-                          className="block"
+                          className="block w-full text-lg hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+                          title={isExpanded ? "Collapse Chart" : "Expand Chart"}
+                          aria-label={isExpanded ? "Collapse Chart" : "Expand Chart"}
+                          aria-expanded={isExpanded}
                         >
                           {isExpanded ? "➖" : "📈"}
-                        </span>
+                        </button>
                       </td>
                       <th
                         className="p-2 border border-gray-700 whitespace-nowrap sticky-left bg-dark-table-row"


### PR DESCRIPTION
This PR implements a micro-UX improvement by enhancing the accessibility of the main data table. 

Key changes:
1.  **Semantic HTML:** Converted the chart expansion toggle from a non-interactive `<span>` to a proper `<button>`. This ensures native keyboard support (Tab, Enter/Space) without requiring custom handlers.
2.  **Accessibility Attributes:** Added dynamic `aria-label` (Expand/Collapse Chart) and `aria-expanded` state to the toggle button. Added `aria-label` to the row selection checkboxes to identify which row is being selected.
3.  **Visual Polish:** Added standard Tailwind focus ring styles (`focus:ring-2`) to the toggle button to make keyboard navigation visible and clear. Replaced inline styles with utility classes.

These changes make the table more robust for screen reader users and keyboard navigators.

---
*PR created automatically by Jules for task [7841053068154297067](https://jules.google.com/task/7841053068154297067) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve table accessibility by converting the chart toggle to a semantic button with native keyboard support, dynamic aria-label/aria-expanded, and visible focus styles. Also add aria-labels to row selection checkboxes and replace inline font sizing with Tailwind utilities.

<sup>Written for commit dde635ee7093721d9ee476a1d2d42a58f9fd6dcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

