### PR TITLE
🎨 Palette: Add visible labels to settings inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-01-25 - Improving Accessibility and Interaction in React Components
 **Learning:** Found that direct DOM manipulation (e.g., `e.target.disabled = true`) in React event handlers leads to poor UX because it doesn't trigger re-renders for visual updates (like text changes "Asking..."). Transitioning to React state (`isAsking`) not only fixes this but makes the logic more declarative and testable.
 **Action:** Always prefer React state over direct DOM manipulation for interactive states. Also, icon-only buttons consistently missed `aria-label`s, which is a common pattern to watch out for in this codebase.
+
+## 2025-05-21 - Form Accessibility Patterns
+**Learning:** Critical configuration inputs relied solely on placeholders, causing context loss when filled. Found duplicate `name` attributes in these ad-hoc forms, likely from copy-paste coding.
+**Action:** Enforce visible labels for all inputs using a vertical flex container pattern (`flex-col gap-1`) to maintain layout while improving usability. Always audit `name` and `id` attributes when cloning form fields.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -177,36 +177,52 @@ export default function App() {
       {chartKeys?.length > 0 && chartType === 'scatter' && <ScatterChart data={data} keys={chartKeys} />}
       <Table {...tableProps} />
       <div className="flex flex-wrap justify-center gap-4 mt-4 pb-8">
-        <select
-          className="px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500"
-          value={aiModel}
-          onChange={onAiModelChange}
-        >
-          <option value="gemini-2.5-flash">Gemini 2.5 Flash</option>
-          <option value="gemini-2.5-pro">Gemini 2.5 Pro</option>
-          <option value="gemini-3-flash">Gemini 3 Flash</option>
-          <option value="gemini-3-pro">Gemini 3 Pro</option>
-          <option value="gemini-3-flash-preview">Gemini 3 Flash Preview</option>
-          <option value="gemini-3-pro-preview">Gemini 3 Pro Preview</option>
-        </select>
-        <input
-          className="px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500"
-          name="key"
-          value={aiKey || ""}
-          onChange={onAiKeyChange}
-          id="gemini-key"
-          placeholder="Gemini key"
-          autoComplete="gemini-key"
-        />
-        <input
-          className="px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500"
-          name="key"
-          value={gistToken || ""}
-          onChange={onGistTokenChange}
-          id="gist-token"
-          placeholder="Gist token"
-          autoComplete="gist-token"
-        />
+        <div className="flex flex-col gap-1">
+          <label htmlFor="ai-model" className="text-xs text-gray-400 font-medium ml-1">
+            AI Model
+          </label>
+          <select
+            id="ai-model"
+            className="px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500"
+            value={aiModel}
+            onChange={onAiModelChange}
+          >
+            <option value="gemini-2.5-flash">Gemini 2.5 Flash</option>
+            <option value="gemini-2.5-pro">Gemini 2.5 Pro</option>
+            <option value="gemini-3-flash">Gemini 3 Flash</option>
+            <option value="gemini-3-pro">Gemini 3 Pro</option>
+            <option value="gemini-3-flash-preview">Gemini 3 Flash Preview</option>
+            <option value="gemini-3-pro-preview">Gemini 3 Pro Preview</option>
+          </select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="gemini-key" className="text-xs text-gray-400 font-medium ml-1">
+            Gemini API Key
+          </label>
+          <input
+            className="px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500"
+            name="key"
+            value={aiKey || ""}
+            onChange={onAiKeyChange}
+            id="gemini-key"
+            placeholder="Gemini key"
+            autoComplete="gemini-key"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="gist-token" className="text-xs text-gray-400 font-medium ml-1">
+            Gist Token
+          </label>
+          <input
+            className="px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500"
+            name="gist_token"
+            value={gistToken || ""}
+            onChange={onGistTokenChange}
+            id="gist-token"
+            placeholder="Gist token"
+            autoComplete="gist-token"
+          />
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
🎨 **Palette: Add visible labels to settings inputs**

**💡 What:**
Added visible `<label>` elements above the "AI Model", "Gemini API Key", and "Gist Token" inputs in `src/App.tsx`. Wrapped these inputs in `flex-col` containers to stack the label neatly above the input field.

**🎯 Why:**
Previously, these important configuration fields relied solely on placeholders ("Gemini key", "Gist token").
- **Usability:** Placeholders disappear once the user starts typing or if the browser autofills the field, causing users to lose context of what the field is for.
- **Accessibility:** Screen readers and assistive technologies rely on explicit labels (via `htmlFor` and `id` association) to correctly announce form fields.

**📸 Changes:**
- Wrapped inputs in `<div className="flex flex-col gap-1">`
- Added `<label className="text-xs text-gray-400 font-medium ml-1">`
- Fixed a bug where both API key and Gist token inputs shared the name `"key"`. The Gist token input is now named `"gist_token"`.

**♿ Accessibility:**
- Added `htmlFor` to labels and matching `id`s to inputs.
- Ensured sufficient contrast for label text (`text-gray-400` on dark background).


---
*PR created automatically by Jules for task [11522510180749040039](https://jules.google.com/task/11522510180749040039) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add visible labels to the AI Model, Gemini API Key, and Gist Token settings to improve clarity and accessibility. Also fixes a duplicate input name on the Gist Token field.

- New Features
  - Added label elements with htmlFor/id associations for all three inputs.
  - Stacked labels above fields using flex-col gap-1 for a clean layout.

- Bug Fixes
  - Renamed Gist Token input name from "key" to "gist_token" to avoid conflicts.

<sup>Written for commit fbaa8a7ab664bd1706f13a8781342d6f390baba8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

