### PR TITLE
⚡ Bolt: Optimize visibleDataAtom filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-18 - [Optimization Pattern] Hoisting Filter Logic
+**Learning:** Jotai atoms like `visibleDataAtom` often run filtering logic. Ensure invariant transformations (like splitting a filter string) happen *before* the loop (O(1)) rather than inside it (O(N)).
+**Action:** Review all `array.filter` and `array.map` blocks in atoms for hoisting opportunities.

--- a/src/atom/dataAtom.ts
+++ b/src/atom/dataAtom.ts
@@ -45,13 +45,17 @@ export const visibleDataAtom = atom((get) => {
   const filterText = get(filterTextAtom);
   const tag = get(tagAtom);
   if (data && (filterText || tag)) {
+    // Optimization: Pre-calculate filter words outside the loop
+    const filterWords = filterText
+      ? filterText.toLowerCase().split(" ").filter(Boolean)
+      : [];
+
     data = data.filter((entry) => {
       const matchedTag = !tag || entry[3]?.tag.includes(tag);
       let matchedText = !filterText;
       if (!matchedText) {
-        const words = filterText.toLowerCase().split(" ").filter(Boolean);
         const title = entry[0].toLowerCase();
-        matchedText = words.some((word) => title.includes(word));
+        matchedText = filterWords.some((word) => title.includes(word));
       }
       return matchedText && matchedTag;
     });


### PR DESCRIPTION
Moved `filterText.toLowerCase().split(" ")` outside the filter loop in `src/atom/dataAtom.ts` to improve performance.

---
*PR created automatically by Jules for task [11367912108199385634](https://jules.google.com/task/11367912108199385634) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized visibleDataAtom filtering by precomputing filter words from filterText once, outside the loop. This removes redundant per-item string splits and speeds up filtering on large lists; also adds a short note in .jules/bolt.md documenting the pattern.

<sup>Written for commit 9df69bea0e288d660453c85c7b4823638fd72b63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

