### PR TITLE
Make table layout responsive for small viewports

### DIFF
--- a/fix_aria_duplicate.py
+++ b/fix_aria_duplicate.py
@@ -1,0 +1,37 @@
+import re
+
+file_path = 'src/layout/table.tsx'
+
+with open(file_path, 'r') as f:
+    lines = f.readlines()
+
+new_lines = []
+skip_next = False
+for i, line in enumerate(lines):
+    # Check if this line is aria-label and the previous one (or recent one) was also aria-label
+    # But here they are separated by onChange and checked.
+    # Pattern:
+    # aria-label={...}
+    # ...
+    # aria-label={...}
+
+    # Specific fix for the known block
+    if 'aria-label={`Select ${name}`}' in line:
+        # Check if we already have this in the last few lines for the same input
+        # It's simpler to just match the exact block via replace
+        pass
+
+content = "".join(lines)
+# The block is:
+#                           aria-label={`Select ${name}`}
+#                           onChange={() => onSelect(name)}
+#                           checked={selected.includes(name)}
+#                           aria-label={`Select ${name}`}
+
+pattern = r'(aria-label={`Select \${name}`}\s+onChange=\{\(\) => onSelect\(name\)}\s+checked=\{selected\.includes\(name\)}\s+)aria-label={`Select \${name}`}'
+replacement = r'\1'
+
+content = re.sub(pattern, replacement, content)
+
+with open(file_path, 'w') as f:
+    f.write(content)

--- a/fix_duplication.py
+++ b/fix_duplication.py
@@ -1,0 +1,15 @@
+import re
+
+file_path = 'src/layout/table.tsx'
+
+with open(file_path, 'r') as f:
+    content = f.read()
+
+# Fix duplicated className block in labels.map
+# We'll look for the pattern where the block repeats
+pattern = r'(className: \(\(\) => \{[^}]+\}\)\(\),)\s+className: \(\(\) => \{[^}]+\}\)\(\),'
+# Replace with single occurrence
+content = re.sub(pattern, r'\1', content, flags=re.DOTALL)
+
+with open(file_path, 'w') as f:
+    f.write(content)

--- a/server.log
+++ b/server.log
@@ -1,0 +1,10 @@
+
+> myhealth@1.0.0 dev /app
+> vite
+
+
+  VITE v7.1.12  ready in 394 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+[baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`

--- a/src/layout/table.tsx
+++ b/src/layout/table.tsx
@@ -64,6 +64,13 @@ const columns: ColumnDef<DisplayedEntry, any>[] = [
         isRecord: true,
         isLatest: index === labels.length - 1,
         title: label,
+        className: (() => {
+          const dist = labels.length - 1 - index;
+          if (dist === 0) return "";
+          if (dist === 1) return "hidden sm:table-cell";
+          if (dist === 2) return "hidden md:table-cell";
+          return "hidden lg:table-cell";
+        })(),
       },
     })
   ),
@@ -71,6 +78,7 @@ const columns: ColumnDef<DisplayedEntry, any>[] = [
     header: "",
     meta: {
       placehoder: true,
+      className: "hidden lg:table-cell",
     },
   }),
   columnHelper.accessor("range" as any, {
@@ -78,18 +86,21 @@ const columns: ColumnDef<DisplayedEntry, any>[] = [
     meta: {
       ref: true,
       align: "center",
+      className: "hidden md:table-cell",
     },
   }),
   columnHelper.accessor("unit" as any, {
     header: "Unit",
     meta: {
       ref: true,
+      className: "hidden sm:table-cell",
     },
   }),
   columnHelper.accessor("origUnit" as any, {
     header: "Orig Unit",
     meta: {
       ref: true,
+      className: "hidden lg:table-cell",
     },
   }),
 ];
@@ -200,7 +211,7 @@ export default React.memo(
                       "is-latest": (header.column.columnDef.meta as any)?.isLatest,
                       "sticky-left bg-dark-table-header": header.id === "name",
                       "w-1/4": (header.column.columnDef.meta as any)?.placehoder,
-                    })}
+                    }, (header.column.columnDef.meta as any)?.className)}
                   >
                     {flexRender(
                       header.column.columnDef.header,
@@ -252,7 +263,7 @@ export default React.memo(
                           aria-label={`Select ${name}`}
                           onChange={() => onSelect(name)}
                           checked={selected.includes(name)}
-                          aria-label={`Select ${name}`}
+
                         />
                       </td>
                       <td className="p-2 border border-gray-700 text-center align-middle">
@@ -284,6 +295,9 @@ export default React.memo(
                               className={cn("p-2 border border-gray-700 text-right cursor-pointer relative", {
                                 "v-bad": extra.isNotOptimal(value),
                                 "is-latest": index === array.length - 1,
+                                "hidden sm:table-cell": array.length - 1 - index === 1,
+                                "hidden md:table-cell": array.length - 1 - index === 2,
+                                "hidden lg:table-cell": array.length - 1 - index > 2,
                               })}
                               key={index}
                               onClick={onCellClick}
@@ -302,7 +316,7 @@ export default React.memo(
                               )}
                             </td>
                           ))}
-                      <td className="p-2 border border-gray-700">
+                      <td className="p-2 border border-gray-700 hidden lg:table-cell">
                         {averageCountValue
                           ? extra.getSamples(+averageCountValue)
                           .join(", ")
@@ -313,12 +327,12 @@ export default React.memo(
                         extra.originValues?.map((value: any, index: number) => (
                           <td key={index} className="p-2 border border-gray-700">{value}</td>
                         ))}
-                      <td className="p-2 border border-gray-700 whitespace-nowrap text-center">
+                      <td className="p-2 border border-gray-700 whitespace-nowrap text-center hidden md:table-cell">
                         {extra.range as any}
                       </td>
-                      <td className="p-2 border border-gray-700">{unit as any}</td>
+                      <td className="p-2 border border-gray-700 hidden sm:table-cell">{unit as any}</td>
                       {showOrigColumns && extra.hasOrigin && (
-                        <td className="p-2 border border-gray-700">{extra.originUnit}</td>
+                        <td className="p-2 border border-gray-700 hidden lg:table-cell">{extra.originUnit}</td>
                       )}
                     </tr>
                     {isExpanded && (
@@ -347,7 +361,7 @@ export default React.memo(
                       "is-latest": (header.column.columnDef.meta as any)?.isLatest,
                       "sticky-left bg-dark-table-row": header.id === "name",
                       "w-1/4": (header.column.columnDef.meta as any)?.placehoder,
-                    })}
+                    }, (header.column.columnDef.meta as any)?.className)}
                   >
                     {notes[(header.column.columnDef.meta as any)?.title as string]?.supps ? "?" : null}
                   </th>

--- a/update_table.py
+++ b/update_table.py
@@ -1,0 +1,103 @@
+import re
+
+file_path = 'src/layout/table.tsx'
+
+with open(file_path, 'r') as f:
+    content = f.read()
+
+# 1. Update columns definition for 'labels'
+labels_replacement = r'''...labels.map((label, index) =>
+    columnHelper.accessor(label as any, {
+      header: getKeyFromTime(label),
+      meta: {
+        isRecord: true,
+        isLatest: index === labels.length - 1,
+        title: label,
+        className: (() => {
+          const dist = labels.length - 1 - index;
+          if (dist === 0) return "";
+          if (dist === 1) return "hidden sm:table-cell";
+          if (dist === 2) return "hidden md:table-cell";
+          return "hidden lg:table-cell";
+        })(),'''
+
+content = content.replace(
+    '...labels.map((label, index) =>\n    columnHelper.accessor(label as any, {\n      header: getKeyFromTime(label),\n      meta: {\n        isRecord: true,\n        isLatest: index === labels.length - 1,\n        title: label,',
+    labels_replacement
+)
+
+# 2. Update placeholder column
+content = content.replace(
+    'meta: {\n      placehoder: true,\n    },',
+    'meta: {\n      placehoder: true,\n      className: "hidden lg:table-cell",\n    },'
+)
+
+# 3. Update range column
+content = content.replace(
+    'meta: {\n      ref: true,\n      align: "center",\n    },',
+    'meta: {\n      ref: true,\n      align: "center",\n      className: "hidden md:table-cell",\n    },'
+)
+
+# 4. Update unit column
+content = content.replace(
+    'columnHelper.accessor("unit" as any, {\n    header: "Unit",\n    meta: {\n      ref: true,\n    },',
+    'columnHelper.accessor("unit" as any, {\n    header: "Unit",\n    meta: {\n      ref: true,\n      className: "hidden sm:table-cell",\n    },'
+)
+
+content = content.replace(
+    'columnHelper.accessor("origUnit" as any, {\n    header: "Orig Unit",\n    meta: {\n      ref: true,\n    },',
+    'columnHelper.accessor("origUnit" as any, {\n    header: "Orig Unit",\n    meta: {\n      ref: true,\n      className: "hidden lg:table-cell",\n    },'
+)
+
+# 5. Update thead rendering
+content = content.replace(
+    '"sticky-left bg-dark-table-header": header.id === "name",\n                      "w-1/4": (header.column.columnDef.meta as any)?.placehoder,\n                    })}',
+    '"sticky-left bg-dark-table-header": header.id === "name",\n                      "w-1/4": (header.column.columnDef.meta as any)?.placehoder,\n                    }, (header.column.columnDef.meta as any)?.className)}'
+)
+
+# 6. Update tfoot rendering
+content = content.replace(
+    '"sticky-left bg-dark-table-row": header.id === "name",\n                      "w-1/4": (header.column.columnDef.meta as any)?.placehoder,\n                    })}',
+    '"sticky-left bg-dark-table-row": header.id === "name",\n                      "w-1/4": (header.column.columnDef.meta as any)?.placehoder,\n                    }, (header.column.columnDef.meta as any)?.className)}'
+)
+
+# 7. Update tbody Data Columns
+tbody_values_replacement = '''className={cn("p-2 border border-gray-700 text-right cursor-pointer relative", {
+                                "v-bad": extra.isNotOptimal(value),
+                                "is-latest": index === array.length - 1,
+                                "hidden sm:table-cell": array.length - 1 - index === 1,
+                                "hidden md:table-cell": array.length - 1 - index === 2,
+                                "hidden lg:table-cell": array.length - 1 - index > 2,
+                              })}'''
+
+content = content.replace(
+    'className={cn("p-2 border border-gray-700 text-right cursor-pointer relative", {\n                                "v-bad": extra.isNotOptimal(value),\n                                "is-latest": index === array.length - 1,\n                              })}',
+    tbody_values_replacement
+)
+
+# 8. Update tbody Average Column
+content = content.replace(
+    '<td className="p-2 border border-gray-700">\n                        {averageCountValue',
+    '<td className="p-2 border border-gray-700 hidden lg:table-cell">\n                        {averageCountValue'
+)
+
+# 9. Update tbody Range Column
+content = content.replace(
+    '<td className="p-2 border border-gray-700 whitespace-nowrap text-center">\n                        {extra.range as any}\n                      </td>',
+    '<td className="p-2 border border-gray-700 whitespace-nowrap text-center hidden md:table-cell">\n                        {extra.range as any}\n                      </td>'
+)
+
+# 10. Update tbody Unit Column
+content = content.replace(
+    '<td className="p-2 border border-gray-700">{unit as any}</td>',
+    '<td className="p-2 border border-gray-700 hidden sm:table-cell">{unit as any}</td>'
+)
+
+# 11. Update tbody OrigUnit Column
+content = content.replace(
+    '<td className="p-2 border border-gray-700">{extra.originUnit}</td>',
+    '<td className="p-2 border border-gray-700 hidden lg:table-cell">{extra.originUnit}</td>'
+)
+
+with open(file_path, 'w') as f:
+    f.write(content)


### PR DESCRIPTION
Implemented responsive column hiding for the main data table to improve mobile usability.
- On mobile (<640px), only the "Name" and the latest data column are shown.
- On tablets and larger screens, additional historical data columns, "Unit", and "Range" columns are progressively revealed.
- Cleaned up a duplicate `aria-label` attribute in the table component.
- Verified visual layout across mobile, tablet, and desktop viewports using Playwright.

---
*PR created automatically by Jules for task [13836120103039560144](https://jules.google.com/task/13836120103039560144) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the main data table responsive so it works well on phones. On mobile, only Name and the latest value show; larger breakpoints progressively reveal older values and reference columns.

- New Features
  - Progressive reveal by breakpoint: second-latest at sm, third-latest at md, remaining history at lg; Unit at sm, Range at md, Average and Orig Unit at lg.
  - Synced visibility for headers, body cells, and footers via column meta className.

- Bug Fixes
  - Removed a duplicate aria-label on the row selection checkbox.

<sup>Written for commit 8260df86107b44fbe9f90b7c38a9111f8d8318db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

