### PR TITLE
🎨 Palette: Add "Copied!" feedback to data cells

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -11,3 +11,7 @@
 ## 2025-05-21 - Form Accessibility Patterns
 **Learning:** Critical configuration inputs relied solely on placeholders, causing context loss when filled. Found duplicate `name` attributes in these ad-hoc forms, likely from copy-paste coding.
 **Action:** Enforce visible labels for all inputs using a vertical flex container pattern (`flex-col gap-1`) to maintain layout while improving usability. Always audit `name` and `id` attributes when cloning form fields.
+
+## 2026-02-15 - Data Integrity in DOM-based Actions
+**Learning:** Extracting data from `textContent` for actions like "Copy to Clipboard" is risky when the UI state changes (e.g., injecting a "Copied!" tooltip). This can lead to copying the tooltip text along with the data on rapid interactions.
+**Action:** Pass the raw data value to the event handler instead of relying on the DOM content, especially for interactive elements with dynamic children.

--- a/src/layout/table.tsx
+++ b/src/layout/table.tsx
@@ -41,6 +41,39 @@ function getKeyFromTime(label: string) {
   return label.slice(0, 2) + "/" + label.slice(2, 4);
 }
 
+const DataCell = React.memo(({ className, onCellClick, children }: any) => {
+  const [copied, setCopied] = React.useState(false);
+
+  const handleInteraction = React.useCallback(async () => {
+      if (onCellClick) await onCellClick();
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+  }, [onCellClick]);
+
+  return (
+      <td
+          className={cn(className, "relative group focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-sm")}
+          onClick={handleInteraction}
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              handleInteraction();
+            }
+          }}
+          role="button"
+          aria-label={typeof children === 'string' || typeof children === 'number' ? `Copy ${children}` : 'Copy value'}
+      >
+           {children}
+          {copied && (
+               <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-1 px-2 py-1 text-xs text-white bg-blue-600 rounded shadow-lg z-50 animate-fade-in-out pointer-events-none whitespace-nowrap" aria-live="polite">
+                  Copied!
+               </span>
+          )}
+      </td>
+  )
+});
+
 const columns: ColumnDef<DisplayedEntry, any>[] = [
   columnHelper.accessor("selection" as any, {
     header: "",
@@ -112,8 +145,8 @@ export default React.memo(
     const notes = useAtomValue(notesAtom);
     const [expandedRowId, setExpandedRowId] = React.useState<string | null>(null);
 
-    const onCellClick = React.useCallback(async (e: React.MouseEvent<HTMLElement>) => {
-      await navigator.clipboard.writeText((e.target as HTMLElement).textContent || "");
+    const onCellClick = React.useCallback(async (text: string) => {
+      await navigator.clipboard.writeText(text);
     }, []);
 
     const toggleExpand = React.useCallback((id: string) => {
@@ -291,8 +324,8 @@ export default React.memo(
                               !showRecords || index >= labels.length - showRecords
                           )
                           .map((value, index, array) => (
-                            <td
-                              className={cn("p-2 border border-gray-700 text-right cursor-pointer relative", {
+                            <DataCell
+                              className={cn("p-2 border border-gray-700 text-right cursor-pointer", {
                                 "v-bad": extra.isNotOptimal(value),
                                 "is-latest": index === array.length - 1,
                                 "hidden sm:table-cell": array.length - 1 - index === 1,
@@ -300,7 +333,7 @@ export default React.memo(
                                 "hidden lg:table-cell": array.length - 1 - index > 2,
                               })}
                               key={index}
-                              onClick={onCellClick}
+                              onCellClick={() => onCellClick(value != null ? value.toString() : "")}
                             >
                               {(unit as any)?.url ? (
                                 <a
@@ -314,7 +347,7 @@ export default React.memo(
                               ) : (
                                 value
                               )}
-                            </td>
+                            </DataCell>
                           ))}
                       <td className="p-2 border border-gray-700 hidden lg:table-cell">
                         {averageCountValue

--- a/tests/ux_verification.spec.ts
+++ b/tests/ux_verification.spec.ts
@@ -7,21 +7,48 @@ test('table has accessible chart toggle buttons', async ({ page }) => {
   await page.waitForSelector('table');
   await page.waitForTimeout(2000);
 
-  // Look for ANY chart toggle button.
-  // Since rows might be grouped, the first row might be a group header.
-  // We want to find the specific button we refactored.
-  // We added aria-label="Toggle chart for ..."
-
-  const toggleButton = page.locator('button[aria-label^="Toggle chart for"]').first();
+  // Look for ANY chart toggle button using title which is stable
+  const toggleButton = page.locator('button[title="Toggle Chart"]').first();
 
   // Check if it's visible
   await expect(toggleButton).toBeVisible();
 
-  // Check ARIA attributes
-  await expect(toggleButton).toHaveAttribute('aria-label', /^Toggle chart for/);
+  // Check ARIA attributes (initial state)
+  // It should be expanded false initially
   await expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+  await expect(toggleButton).toHaveAttribute('aria-label', "Expand chart");
 
   // Test interaction
   await toggleButton.click();
+
+  // After click, it should be expanded true and label should change
   await expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+  await expect(toggleButton).toHaveAttribute('aria-label', "Collapse chart");
+});
+
+test('data cells show copied feedback on click', async ({ context, page }) => {
+  // Grant clipboard permissions
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+  await page.goto('http://localhost:5173');
+
+  // Wait for table to load
+  await page.waitForSelector('table');
+  await page.waitForTimeout(2000);
+
+  // Find a data cell.
+  const dataCell = page.locator('td.cursor-pointer').first();
+  await expect(dataCell).toBeVisible();
+
+  // Click it
+  await dataCell.click();
+
+  // Expect "Copied!" span to appear
+  // We use .locator to find inside the cell, or page.locator with text
+  // The span is absolute positioned inside the td
+  const feedback = dataCell.locator('text=Copied!');
+  await expect(feedback).toBeVisible();
+
+  // Expect it to disappear after 1.5s
+  await expect(feedback).not.toBeVisible({ timeout: 5000 });
 });


### PR DESCRIPTION
💡 What: Added a temporary "Copied!" tooltip when users click on a data cell in the main table.
🎯 Why: Users were receiving no feedback after clicking to copy, leading to uncertainty.
📸 Before/After: Before: silent copy. After: "Copied!" appears for 1.5s.
♿ Accessibility: Made data cells keyboard accessible (tabIndex, Enter/Space support) and added aria-labels.
Fixed regression where rapid clicks copied "Copied!" text.

---
*PR created automatically by Jules for task [15699349678565017056](https://jules.google.com/task/15699349678565017056) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a transient “Copied!” tooltip to table data cells and makes cells keyboard-accessible to give clear copy feedback and improve accessibility. Also prevents copying the tooltip text and updates tests to cover the new behavior.

- **New Features**
  - Show “Copied!” tooltip for 1.5s on cell click or Enter/Space.
  - Extracted DataCell component with button semantics, focus ring, and aria-labels.

- **Bug Fixes**
  - Prevent copying tooltip text by writing the raw cell value to the clipboard.
  - Fixed chart toggle UX test and added a test for the copied feedback.

<sup>Written for commit ab1d02b64363dc0d3925dc3df3dc88833361adb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

