### PR TITLE
🎨 Palette: Add search icon to navigation bar

### DIFF
--- a/src/layout/nav.tsx
+++ b/src/layout/nav.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react";
 import cn from "classnames";
 import { Dialog, Transition } from "@headlessui/react";
-import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
+import { Bars3Icon, XMarkIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { tags } from "../processors";
 import { askBioMarkers } from "../service/askAI";
 import { createGist } from "../service/gist";
@@ -145,15 +145,20 @@ export default React.memo<Props>(
               <Bars3Icon className="h-6 w-6" />
             </button>
             <div className="w-full lg:w-auto lg:flex-none">
-              <input
-                type="search"
-                value={filterText}
-                onChange={onTextChange}
-                autoFocus
-                className="w-full px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500"
-                placeholder="Search"
-                aria-label="Search biomarkers"
-              />
+              <div className="relative text-gray-400 focus-within:text-gray-200">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  <MagnifyingGlassIcon className="h-5 w-5" aria-hidden="true" />
+                </div>
+                <input
+                  type="search"
+                  value={filterText}
+                  onChange={onTextChange}
+                  autoFocus
+                  className="w-full pl-10 px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500 placeholder-gray-500 focus:placeholder-gray-400"
+                  placeholder="Search"
+                  aria-label="Search biomarkers"
+                />
+              </div>
             </div>
             <div className={cn("w-full lg:flex lg:w-auto lg:items-center", { hidden: !show, block: show })}>
               <ul className="flex flex-col lg:flex-row gap-2 items-start lg:items-center list-none p-0 m-0">

--- a/tests/ux_verification.spec.ts
+++ b/tests/ux_verification.spec.ts
@@ -52,3 +52,21 @@ test('data cells show copied feedback on click', async ({ context, page }) => {
   // Expect it to disappear after 1.5s
   await expect(feedback).not.toBeVisible({ timeout: 5000 });
 });
+
+test('search input has search icon', async ({ page }) => {
+  await page.goto('http://localhost:5173');
+
+  // Verify search input is present
+  const searchInput = page.getByRole('searchbox', { name: 'Search biomarkers' });
+  await expect(searchInput).toBeVisible();
+
+  // Verify it has padding-left (class pl-10)
+  // We can check if the class name contains pl-10
+  await expect(searchInput).toHaveClass(/pl-10/);
+
+  // Verify the icon is present (by looking for the svg with correct classes)
+  // The icon is inside the same container, so we can look for it nearby
+  // Or just check page for the specific svg
+  const icon = page.locator('div.relative svg.h-5.w-5');
+  await expect(icon).toBeVisible();
+});


### PR DESCRIPTION
Added a magnifying glass icon to the search input in the navigation bar to improve visual recognition and UX. Verified with Playwright tests.

---
*PR created automatically by Jules for task [18071292540227791901](https://jules.google.com/task/18071292540227791901) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a magnifying glass icon to the navigation bar search field to make it easier to find. Playwright tests verify the icon renders and the input padding is correct.

- **New Features**
  - Imported MagnifyingGlassIcon from @heroicons/react and placed it inside the search input.
  - Wrapped the input in a relative container and added left padding (pl-10); kept accessible labels.
  - Added a Playwright test to check the searchbox and icon visibility and the padding class.

<sup>Written for commit 59ce1da03aad1701de8f384b15454d53defde976. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

