### PR TITLE
🎨 Palette: Add loading spinners to async actions

### DIFF
--- a/src/layout/nav.tsx
+++ b/src/layout/nav.tsx
@@ -10,6 +10,13 @@ import { visibleDataAtom, aiKeyAtom, gistTokenAtom, aiModelAtom } from "../atom/
 import { averageCountAtom } from "../atom/averageValueAtom";
 import Markdown from "react-markdown";
 
+const Spinner = () => (
+  <svg className="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+  </svg>
+);
+
 type Props = {
   selected: string[];
   onSelect: (name: string) => void;
@@ -239,11 +246,12 @@ export default React.memo<Props>(
                 {selected.length > 0 && (
                   <button
                     type="button"
-                    className="px-4 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed w-full lg:w-auto"
+                    className="px-4 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed w-full lg:w-auto flex items-center justify-center gap-2"
                     onClick={onAskAI}
                     disabled={isAsking}
+                    aria-busy={isAsking}
                   >
-                    {isAsking ? "Asking..." : "Ask AI"}
+                    {isAsking ? <><Spinner /> Asking...</> : "Ask AI"}
                   </button>
                 )}
                 {selected.map((item) => (
@@ -353,8 +361,9 @@ export default React.memo<Props>(
                     <div className="mt-4">
                       <button
                         type="button"
-                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50"
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 flex items-center justify-center gap-2"
                         disabled={isGistLoading}
+                        aria-busy={isGistLoading}
                         onClick={async () => {
                           setIsGistLoading(true);
                           setGistError(null);
@@ -378,7 +387,7 @@ export default React.memo<Props>(
                           }
                         }}
                       >
-                        {isGistLoading ? "Saving..." : "Save to Gist"}
+                        {isGistLoading ? <><Spinner /> Saving...</> : "Save to Gist"}
                       </button>
                       {gistUrl && (
                         <div className="mt-2">

--- a/tests/spinner_verification.spec.ts
+++ b/tests/spinner_verification.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+test('Ask AI button shows spinner when clicked', async ({ page }) => {
+  // Mock the API call to delay it so we can see the spinner
+  await page.route('https://generativelanguage.googleapis.com/**', async (route) => {
+    await new Promise(resolve => setTimeout(resolve, 2000)); // 2s delay
+    // Mock a successful response
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ candidates: [{ content: { parts: [{ text: "Analysis result" }] } }] })
+    });
+  });
+
+  await page.goto('http://localhost:5173');
+
+  // Wait for table to load
+  await page.waitForSelector('table');
+
+  // Set AI Key
+  const keyInput = page.locator('#gemini-key');
+  await keyInput.fill('dummy-key');
+
+  // Find a checkbox in the first data row (tbody tr)
+  const firstCheckbox = page.locator('tbody tr input[type="checkbox"]').first();
+  await expect(firstCheckbox).toBeVisible();
+  await firstCheckbox.click();
+
+  // Find the "Ask AI" button
+  const askButton = page.getByRole('button', { name: 'Ask AI' });
+  await expect(askButton).toBeVisible();
+  await expect(askButton).toBeEnabled();
+
+  // Click the button
+  await askButton.click();
+
+  // Verify the button text changes to "Asking..."
+  // The name of the button changes, so we need to find it by the new name
+  const askingButton = page.getByRole('button', { name: /Asking.../ });
+  await expect(askingButton).toBeVisible();
+
+  // Verify the spinner SVG is present inside the button
+  const spinner = askingButton.locator('svg.animate-spin');
+  await expect(spinner).toBeVisible();
+
+  // Verify aria-busy is true
+  await expect(askingButton).toHaveAttribute('aria-busy', 'true');
+});


### PR DESCRIPTION
💡 What: Added a Spinner component and integrated it into the "Ask AI" and "Save to Gist" buttons in the navigation bar.
🎯 Why: To provide visual feedback during async operations, improving the user experience and accessibility.
♿ Accessibility: Added aria-busy attribute to buttons when loading.
📸 Before/After: Buttons now show a spinner and loading text ("Asking...", "Saving...") instead of just text changes.

---
*PR created automatically by Jules for task [9443319725994859979](https://jules.google.com/task/9443319725994859979) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable Spinner and shows it on the “Ask AI” and “Save to Gist” buttons during async work to improve feedback and accessibility.

- **New Features**
  - Spinner component added and reused in nav.
  - “Ask AI” and “Save to Gist” now show a spinner and “Asking…”/“Saving…”, disable during loading, and set aria-busy.
  - Playwright test covers spinner visibility, loading text, and aria-busy on delayed “Ask AI” requests.

<sup>Written for commit 363fa54c359696f90dfe412cf1b4b4e8a3815e0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

