### PR TITLE
Mask API keys with visibility toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2026-10-25 - Event Delegation on Buttons with Icons
 **Learning:** When adding icons (e.g., `<XMarkIcon />`) inside a `<button>` that relies on `e.target.name` for its handler, the `e.target` often becomes the SVG icon element (which has no name), breaking the handler. Using `e.currentTarget` ensures the event listener is always attached to the button itself.
 **Action:** When refactoring text-only buttons to include icons, always audit the `onClick` handler and switch `e.target` to `e.currentTarget` or pass the value directly via closure.
+
+## 2026-11-05 - Privacy UX for Sensitive Inputs
+**Learning:** API keys displayed in plain text expose users to security risks during screen sharing. Implementing a password toggle pattern (`type="password"` with show/hide button) is a standard UX expectation that balances security with usability.
+**Action:** Identify sensitive inputs (keys, tokens) and wrap them in a password visibility toggle component by default.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,25 @@ import {
   gistTokenAtom,
   BioMarker,
 } from "./atom/dataAtom";
+import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
+
+const PasswordInput = React.memo(({ show, setShow, ...props }: any) => (
+  <div className="relative w-full">
+    <input
+      type={show ? "text" : "password"}
+      className="w-full px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500 pr-10"
+      {...props}
+    />
+    <button
+      type="button"
+      onClick={() => setShow(!show)}
+      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white focus:outline-none"
+      aria-label={show ? "Hide password" : "Show password"}
+    >
+      {show ? <EyeSlashIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
+    </button>
+  </div>
+));
 
 export default function App() {
   const data = useAtomValue(getBioMarkersAtom);
@@ -36,6 +55,8 @@ export default function App() {
   const [corrlationKey, setCorrelationKey] = React.useState<string | null>(
     null
   );
+  const [showAiKey, setShowAiKey] = React.useState(false);
+  const [showGistToken, setShowGistToken] = React.useState(false);
 
   React.useEffect(() => {
     const handler = setTimeout(() => {
@@ -217,28 +238,30 @@ export default function App() {
           <label htmlFor="gemini-key" className="text-xs text-gray-400 font-medium ml-1">
             Gemini API Key
           </label>
-          <input
-            className="px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500"
+          <PasswordInput
             name="key"
             value={aiKey || ""}
             onChange={onAiKeyChange}
             id="gemini-key"
             placeholder="Gemini key"
             autoComplete="gemini-key"
+            show={showAiKey}
+            setShow={setShowAiKey}
           />
         </div>
         <div className="flex flex-col gap-1">
           <label htmlFor="gist-token" className="text-xs text-gray-400 font-medium ml-1">
             Gist Token
           </label>
-          <input
-            className="px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500"
+          <PasswordInput
             name="gist_token"
             value={gistToken || ""}
             onChange={onGistTokenChange}
             id="gist-token"
             placeholder="Gist token"
             autoComplete="gist-token"
+            show={showGistToken}
+            setShow={setShowGistToken}
           />
         </div>
       </div>


### PR DESCRIPTION
Implemented password masking for sensitive API key inputs in `src/App.tsx`. Added a toggle button to show/hide the key using existing Heroicons. Verified frontend behavior with Playwright.

---
*PR created automatically by Jules for task [10354776541522795327](https://jules.google.com/task/10354776541522795327) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mask sensitive keys by default and add a show/hide toggle to prevent leaks during screen sharing. Introduces a reusable PasswordInput and updates the Gemini API Key and Gist Token fields.

- New Features
  - Added PasswordInput with show/hide toggle (Heroicons); masked by default.
  - Replaced Gemini API Key and Gist Token inputs with PasswordInput.
  - Added aria-label for the toggle and verified behavior with Playwright.

<sup>Written for commit ec1fbe11add28cb3ceb9107fc14948e3f31e787e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

