### PR TITLE
🎨 Palette: Add accessibility label to supplements button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,3 +23,7 @@
 ## 2026-11-05 - Privacy UX for Sensitive Inputs
 **Learning:** API keys displayed in plain text expose users to security risks during screen sharing. Implementing a password toggle pattern (`type="password"` with show/hide button) is a standard UX expectation that balances security with usability.
 **Action:** Identify sensitive inputs (keys, tokens) and wrap them in a password visibility toggle component by default.
+
+## 2026-02-14 - Icon-only Button Accessibility
+**Learning:** Icon-only buttons (like `?`) are easily missed during manual accessibility audits because they look interactive. Automated tests asserting `aria-label` presence on specific selectors (like `button:has-text("?")`) reliably catch these omissions.
+**Action:** When creating icon-only buttons, always include an `aria-label` and verify it with a specific test case targeting that button.

--- a/src/layout/SupplementsPopover.tsx
+++ b/src/layout/SupplementsPopover.tsx
@@ -10,7 +10,10 @@ export default function SupplementsPopover({ supps }: Props) {
 
   return (
     <Popover className="w-full h-full flex justify-center items-center">
-      <PopoverButton className="w-full h-full cursor-pointer hover:bg-gray-800 hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded font-bold transition-colors flex justify-center items-center">
+      <PopoverButton
+        aria-label="View supplements"
+        className="w-full h-full cursor-pointer hover:bg-gray-800 hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded font-bold transition-colors flex justify-center items-center"
+      >
         ?
       </PopoverButton>
       <PopoverPanel

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -132,3 +132,20 @@ test('selected item chips in nav are accessible and removable', async ({ page })
   // Verify checkbox is unchecked
   await expect(firstCheckbox).not.toBeChecked();
 });
+
+test('supplements popover button has accessible label', async ({ page }) => {
+  await page.goto('http://localhost:5173');
+
+  // Wait for table to load
+  await page.waitForSelector('table');
+
+  // Find the button with visible text "?"
+  // We use filter hasText to find the button element containing "?"
+  const popoverButton = page.locator('button').filter({ hasText: '?' }).first();
+
+  // Verify it's visible
+  await expect(popoverButton).toBeVisible();
+
+  // Verify it has the expected aria-label
+  await expect(popoverButton).toHaveAttribute('aria-label', 'View supplements');
+});


### PR DESCRIPTION
💡 What: Added `aria-label="View supplements"` to the supplements popover button.
🎯 Why: The button was icon-only ("?") and lacked an accessible name, making it confusing for screen reader users (announced as just "button" or "question mark").
♿ Accessibility: Ensures the button is properly announced as "View supplements" to assistive technologies.

---
*PR created automatically by Jules for task [15856552328347394522](https://jules.google.com/task/15856552328347394522) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an accessible label to the icon-only supplements button so screen readers announce “View supplements” instead of “?”. Includes a regression test to keep this behavior.

- **Bug Fixes**
  - Added aria-label="View supplements" to the supplements popover button.
  - Added an accessibility test to assert the label on the “?” button.

<sup>Written for commit b242032df0ef8fd037fa519f8fb69a307e0ee744. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

