### PR TITLE
⚡ Bolt: prevent DataCell re-renders

### DIFF
--- a/src/layout/table.tsx
+++ b/src/layout/table.tsx
@@ -45,7 +45,10 @@ function getKeyFromTime(label: string) {
   return label.slice(0, 2) + "/" + label.slice(2, 4);
 }
 
-const DataCell = React.memo(({ className, rawValue, onCopy, children }: any) => {
+// Optimization: DataCell accepts stable props (unit, displayValue) instead of children
+// to ensure React.memo works effectively. Passing JSX as children (e.g. <a...>)
+// creates new object references on every render, defeating memoization.
+const DataCell = React.memo(({ className, rawValue, onCopy, unit, displayValue }: any) => {
   const [copied, setCopied] = React.useState(false);
 
   const handleInteraction = React.useCallback(async () => {
@@ -53,6 +56,19 @@ const DataCell = React.memo(({ className, rawValue, onCopy, children }: any) => 
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
   }, [onCopy, rawValue]);
+
+  const content = (unit as any)?.url ? (
+    <a
+      href={(unit as any).url}
+      target="_blank"
+      rel="noreferrer"
+      className="text-blue-400 hover:underline"
+    >
+      {displayValue}
+    </a>
+  ) : (
+    displayValue
+  );
 
   return (
       <td
@@ -66,9 +82,9 @@ const DataCell = React.memo(({ className, rawValue, onCopy, children }: any) => 
             }
           }}
           role="button"
-          aria-label={typeof children === 'string' || typeof children === 'number' ? `Copy ${children}` : 'Copy value'}
+          aria-label={typeof displayValue === 'string' || typeof displayValue === 'number' ? `Copy ${displayValue}` : 'Copy value'}
       >
-           {children}
+           {content}
           {copied && (
                <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-1 px-2 py-1 text-xs text-white bg-blue-600 rounded shadow-lg z-50 animate-fade-in-out pointer-events-none whitespace-nowrap" aria-live="polite">
                   Copied!
@@ -368,21 +384,10 @@ export default React.memo(
                               })}
                               key={index}
                               rawValue={value != null ? value.toString() : ""}
+                              displayValue={value}
+                              unit={unit}
                               onCopy={onCellClick}
-                            >
-                              {(unit as any)?.url ? (
-                                <a
-                                  href={(unit as any).url}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="text-blue-400 hover:underline"
-                                >
-                                  {value}
-                                </a>
-                              ) : (
-                                value
-                              )}
-                            </DataCell>
+                            />
                           );
                         })}
                       <td className="p-2 border border-gray-700 hidden lg:table-cell">


### PR DESCRIPTION
This PR optimizes the `DataCell` component in `src/layout/table.tsx` to reduce unnecessary re-renders.

**The Problem:**
Previously, `DataCell` received its content via the `children` prop. For cells containing a link (when `unit.url` exists), the parent component created a new `<a>` JSX element on every render. Since JSX elements are new object references each time, `React.memo` on `DataCell` always saw different props and triggered a re-render, even if the data hadn't changed.

**The Solution:**
I refactored `DataCell` to accept `unit` (stable object reference or string) and `displayValue` (stable primitive) as props. The component now handles the conditional rendering of the link or text internally. This ensures that the props passed to `DataCell` are referentially stable across renders (as long as the underlying data is stable), allowing `React.memo` to work as intended.

**Verification:**
- `pnpm exec tsc --noEmit` passed.
- `pnpm build` passed.
- `pnpm exec playwright test tests/table_verification.spec.ts` passed.
- `pnpm exec playwright test tests/ux_verification.spec.ts` passed.


---
*PR created automatically by Jules for task [3748254969670861110](https://jules.google.com/task/3748254969670861110) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unnecessary DataCell re-renders by passing stable props instead of JSX children, improving table performance during state changes. React.memo now correctly skips unchanged cells, including those with links.

- **Refactors**
  - DataCell now accepts unit and displayValue and renders link/text internally.
  - Props are referentially stable, enabling effective React.memo.
  - Updated table.tsx usage to pass unit/displayValue instead of children.

<sup>Written for commit 11b875579080d6c06d746343367da874cf41b543. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

