### PR TITLE
Include related biomarkers in Ask AI request

### DIFF
--- a/src/layout/nav.tsx
+++ b/src/layout/nav.tsx
@@ -183,7 +183,7 @@ export default React.memo<Props>(
           setIsAsking(false);
         }
       },
-      [selected, data, filterTag, key]
+      [selected, data, filterTag, key, model, fullData]
     );
 
     const [canvasText, setCanvasText] = React.useState<string | null>(null);

--- a/src/service/askAI.ts
+++ b/src/service/askAI.ts
@@ -5,7 +5,8 @@ export const askBioMarkers = async (
   key: string | null,
   model: string,
   tag: string | null,
-  prevPairs: string[]
+  prevPairs: string[],
+  relatedContext?: string
 ) => {
   if (!key) {
     throw new Error("Missing Gemini key");
@@ -28,6 +29,11 @@ The current biomarkers are: ${pairs.join(",")}`;
   if (prevPairs.length) {
     content = `${content}
 In month ago, the values were: ${prevPairs.join(",")}`;
+  }
+
+  if (relatedContext) {
+    content = `${content}
+${relatedContext}`;
   }
   console.log(content);
 


### PR DESCRIPTION
Updated `askBioMarkers` in `src/service/askAI.ts` to accept a `relatedContext` argument and append it to the prompt.
Modified `src/layout/nav.tsx` to calculate Spearman correlations between selected biomarkers and all other available data.
Filtered related biomarkers based on `p-value <= 0.05` and `|coefficient| >= 0.4`.
Formatted the related biomarkers string and passed it to the AI service.

---
*PR created automatically by Jules for task [4718517285339214484](https://jules.google.com/task/4718517285339214484) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds related biomarkers to the Ask AI request using significant Spearman correlations to provide context from selected biomarkers and recent values.

- **New Features**
  - Compute Spearman correlations between selected biomarkers and all non-inferred, non-selected biomarkers.
  - Keep only results with p-value <= 0.05 and |coefficient| >= 0.4 (two-sided).
  - Append a “Related Biomarkers” section with latest value, unit, correlation, and p-value.
  - Extend askBioMarkers to accept an optional relatedContext parameter and include it in the prompt.

<sup>Written for commit 80c41f3fea7d9ff38fbaff49757df46d45faf968. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

