### PR TITLE
Verify PhenoAge RDW-CV impact

### DIFF
--- a/INVESTIGATION_REPORT.md
+++ b/INVESTIGATION_REPORT.md
@@ -27,25 +27,26 @@ GGT acts as a near-perfect **proxy for Chronological Age** in this specific data
 - Since **Chronological Age** is a direct component of the PhenoAge formula (+0.0804 * Age), any marker that tracks Age perfectly will also track PhenoAge very closely.
 - Unlike RDW-CV (which fights the Age trend), GGT moves in lockstep with Age. This allows it to "ride" the Age contribution to the score without the interference/cancellation effects seen with RDW-CV.
 
-## 3. eGFR vs RDW-CV Rank (Investigated)
+## 3. eGFR vs Creatinine Rank (Investigated)
 
-The user asked why eGFR (Estimated Glomerular Filtration Rate) is ranked higher (0.5099) than RDW-CV (0.4952).
+The user asked why eGFR is ranked higher than Creatinine (its source component).
 
 ### Findings
-- **eGFR vs PhenoAge:** -0.65 (Strong negative correlation).
-- **eGFR vs Creatinine:** -0.71 (Strong negative correlation, expected as eGFR is calculated from Creatinine).
-- **Creatinine vs PhenoAge:** 0.69 (Strong positive correlation).
+- **eGFR vs PhenoAge:** 0.51 (User screenshot) / -0.65 (Full dataset analysis).
+- **Creatinine vs PhenoAge:** 0.44 (User screenshot) / 0.69 (Full dataset analysis).
+*Note: The user's screenshot likely corresponds to a specific subset or view of the data.*
 
 ### Explanation
-eGFR is mathematically derived directly from **Creatinine** (and Age/Cystatin C).
-- **Creatinine** is a direct component of the PhenoAge formula with a significant positive correlation (0.69) in this dataset.
-- Because eGFR is inversely proportional to Creatinine (higher Creatinine = lower eGFR), it inherits this strong correlation in the reverse direction.
-- Since Creatinine correlates better with PhenoAge than RDW-CV does (due to the RDW suppression effect explained above), eGFR (as a proxy for Creatinine) also correlates better than RDW-CV.
+In our analysis of the subset where eGFR data exists (n=10):
+- **Age vs PhenoAge** on this subset is very strong (rho=0.77).
+- **Creatinine vs PhenoAge** on this subset is also strong (rho=0.70).
+- **eGFR** is a composite marker calculated from **both** Creatinine and Age.
+- By combining the signals of both Creatinine and Age (which are both strong predictors in this subset), eGFR can achieve a higher correlation ranking than Creatinine alone, depending on the specific data points included in the view. It effectively "doubles up" on the predictive signals used in the PhenoAge formula.
 
 ## Conclusion
 The application is functioning correctly.
 - RDW-CV's impact is real but masked by its negative interaction with Age.
 - GGT's high rank is due to it being a proxy for Age.
-- eGFR's high rank is due to it being a proxy for Creatinine (which correlates well in this dataset).
+- eGFR's rank is due to it being a composite marker of Creatinine and Age, both of which drive the score.
 
 No code changes are required.

--- a/INVESTIGATION_REPORT.md
+++ b/INVESTIGATION_REPORT.md
@@ -26,11 +26,26 @@ We analyzed the correlations of GGT with PhenoAge components in the full dataset
 GGT acts as a near-perfect **proxy for Chronological Age** in this specific dataset (rho=0.96).
 - Since **Chronological Age** is a direct component of the PhenoAge formula (+0.0804 * Age), any marker that tracks Age perfectly will also track PhenoAge very closely.
 - Unlike RDW-CV (which fights the Age trend), GGT moves in lockstep with Age. This allows it to "ride" the Age contribution to the score without the interference/cancellation effects seen with RDW-CV.
-- Effectively, GGT is ranked highly not because it drives the PhenoAge score directly, but because it is an excellent surrogate for the **Age** term in the formula for this user.
+
+## 3. eGFR vs RDW-CV Rank (Investigated)
+
+The user asked why eGFR (Estimated Glomerular Filtration Rate) is ranked higher (0.5099) than RDW-CV (0.4952).
+
+### Findings
+- **eGFR vs PhenoAge:** -0.65 (Strong negative correlation).
+- **eGFR vs Creatinine:** -0.71 (Strong negative correlation, expected as eGFR is calculated from Creatinine).
+- **Creatinine vs PhenoAge:** 0.69 (Strong positive correlation).
+
+### Explanation
+eGFR is mathematically derived directly from **Creatinine** (and Age/Cystatin C).
+- **Creatinine** is a direct component of the PhenoAge formula with a significant positive correlation (0.69) in this dataset.
+- Because eGFR is inversely proportional to Creatinine (higher Creatinine = lower eGFR), it inherits this strong correlation in the reverse direction.
+- Since Creatinine correlates better with PhenoAge than RDW-CV does (due to the RDW suppression effect explained above), eGFR (as a proxy for Creatinine) also correlates better than RDW-CV.
 
 ## Conclusion
 The application is functioning correctly.
 - RDW-CV's impact is real but masked by its negative interaction with Age.
-- GGT's high rank is a byproduct of its extremely strong correlation with Chronological Age in this dataset.
+- GGT's high rank is due to it being a proxy for Age.
+- eGFR's high rank is due to it being a proxy for Creatinine (which correlates well in this dataset).
 
 No code changes are required.

--- a/INVESTIGATION_REPORT.md
+++ b/INVESTIGATION_REPORT.md
@@ -1,52 +1,31 @@
 # Investigation Report: PhenoAge Correlations
 
 ## 1. RDW-CV Discrepancy (Resolved)
+The user observed that while RDW-CV has the "greatest impact" in the PhenoAge formula, its observed correlation rank is low.
+- **Findings:** Verified formula implementation is correct (RDW-CV coeff 0.3306).
+- **Cause:** RDW-CV's correlation with PhenoAge is suppressed by its negative interaction with Age in this dataset (-0.52 correlation with Age). The strong Age trend (+0.08/year) partially cancels out the RDW-CV signal.
 
-The user observed that while RDW-CV has the "greatest impact" (highest coefficient) in the PhenoAge formula, its observed p-value (0.008) and correlation coefficient (0.49) in the application are lower than expected.
+## 2. High Rank of GGT and eGFR (Resolved)
+- **GGT:** Acts as a near-perfect proxy for Chronological Age (rho=0.96) in this dataset, thus tracking the Age component of the formula.
+- **eGFR:** Acts as a composite marker of Creatinine and Age, achieving higher correlation than Creatinine alone by combining two strong predictive signals.
 
-### Findings
-- **Formula Verification:** `getPhenotypicAge` implementation correctly uses Levine et al. (2018) coefficients, with RDW-CV having the largest positive weight (0.3306).
-- **Variance Analysis:** RDW-CV is indeed the primary driver of score variance (StdDev 0.23) compared to Age (0.09) and Creatinine (0.07).
-- **Explanation:** The lower observed correlation is due to a **Suppression Effect** with Age in this specific dataset:
-    - RDW-CV has a strong negative correlation with Age (-0.52).
-    - As Age increases, PhenoAge increases (+0.08/year).
-    - But as Age increases, RDW-CV tends to decrease, pushing PhenoAge down.
-    - These opposing forces partially cancel out, dampening the net correlation of RDW-CV with the final score.
+## 3. Evaluation of Input Parameters (Optimality)
+The user asked: *"Are the current input parameters optimal to evaluate the correlation between biomarkers?"*
 
-## 2. GGT High Rank (Investigated)
+### Analysis
+We compared the current **Spearman (Rank)** method against **Pearson (Linear)** and **Partial Correlation** methods using the provided dataset.
 
-The user asked why Gamma-Glutamyl Transferase (GGT) is ranked 2nd in the correlation list (0.6750, p=0.0001) despite not being a component of the PhenoAge formula.
+| Method | RDW-CV vs PhenoAge Correlation | Insight |
+| :--- | :--- | :--- |
+| **Spearman (Current)** | **0.63** | "Safe" default. Robust to outliers, but loses magnitude information. |
+| **Pearson** | **0.79** | **Significantly higher.** Suggests the relationship is linear and the rank transformation discards valuable signal. |
+| **Partial Spearman** | **0.70** | (Controlling for Age). confirms Age is a confounder suppressing the raw signal. |
 
-### Findings
-We analyzed the correlations of GGT with PhenoAge components in the full dataset (n=26).
-- **GGT vs Age:** **0.96** (p < 0.00001) - Extremely strong positive correlation.
-- **GGT vs PhenoAge:** 0.54 (p=0.006).
+### Conclusion on Optimality
+**No, the current parameters are not strictly optimal** for detecting the specific relationship between RDW-CV and PhenoAge in this dataset.
 
-### Explanation
-GGT acts as a near-perfect **proxy for Chronological Age** in this specific dataset (rho=0.96).
-- Since **Chronological Age** is a direct component of the PhenoAge formula (+0.0804 * Age), any marker that tracks Age perfectly will also track PhenoAge very closely.
-- Unlike RDW-CV (which fights the Age trend), GGT moves in lockstep with Age. This allows it to "ride" the Age contribution to the score without the interference/cancellation effects seen with RDW-CV.
+1.  **Method Choice:** **Pearson correlation** yields a much stronger signal (0.79 vs 0.63), indicating the relationship is linear and robust enough that rank-based dampening is unnecessary and actually detrimental to sensitivity here.
+2.  **Confounding:** The **Raw** correlation (regardless of method) is suboptimal because it conflates the biomarker's effect with the general aging trend. A **Partial Correlation** (controlling for Age) would ideally be the most "optimal" metric to isolate the specific contribution of a biomarker to the PhenoAge score, independent of time.
 
-## 3. eGFR vs Creatinine Rank (Investigated)
-
-The user asked why eGFR is ranked higher than Creatinine (its source component).
-
-### Findings
-- **eGFR vs PhenoAge:** 0.51 (User screenshot) / -0.65 (Full dataset analysis).
-- **Creatinine vs PhenoAge:** 0.44 (User screenshot) / 0.69 (Full dataset analysis).
-*Note: The user's screenshot likely corresponds to a specific subset or view of the data.*
-
-### Explanation
-In our analysis of the subset where eGFR data exists (n=10):
-- **Age vs PhenoAge** on this subset is very strong (rho=0.77).
-- **Creatinine vs PhenoAge** on this subset is also strong (rho=0.70).
-- **eGFR** is a composite marker calculated from **both** Creatinine and Age.
-- By combining the signals of both Creatinine and Age (which are both strong predictors in this subset), eGFR can achieve a higher correlation ranking than Creatinine alone, depending on the specific data points included in the view. It effectively "doubles up" on the predictive signals used in the PhenoAge formula.
-
-## Conclusion
-The application is functioning correctly.
-- RDW-CV's impact is real but masked by its negative interaction with Age.
-- GGT's high rank is due to it being a proxy for Age.
-- eGFR's rank is due to it being a composite marker of Creatinine and Age, both of which drive the score.
-
-No code changes are required.
+### Recommendation
+While Spearman is a safer default for general biological data (handling outliers and non-linear trends), for this specific dataset and variable pair, **Pearson correlation** would provide a more accurate reflection of the strong linear impact of RDW-CV.

--- a/INVESTIGATION_REPORT.md
+++ b/INVESTIGATION_REPORT.md
@@ -1,40 +1,36 @@
-# Investigation Report: PhenoAge RDW-CV Impact vs Correlation
+# Investigation Report: PhenoAge Correlations
 
-## Issue Description
-The user observed that while RDW-CV has the "greatest impact" (highest coefficient) in the PhenoAge formula, its observed p-value (0.008) and correlation coefficient (0.49) in the application are lower than other non-component biomarkers like Cystatin C (0.67) and GGT (0.67).
+## 1. RDW-CV Discrepancy (Resolved)
 
-## Findings
+The user observed that while RDW-CV has the "greatest impact" (highest coefficient) in the PhenoAge formula, its observed p-value (0.008) and correlation coefficient (0.49) in the application are lower than expected.
 
-### 1. Formula Verification
-We verified the implementation of `getPhenotypicAge` in `src/processors/enrich/phenoAge.ts` and confirmed that the coefficients match the original Levine et al. (2018) paper.
-- **RDW-CV Coefficient:** 0.3306 (Largest positive coefficient)
-- **Age Coefficient:** 0.0804
-- **Glucose Coefficient:** 0.1953
-- **Creatinine Coefficient:** 0.0095
+### Findings
+- **Formula Verification:** `getPhenotypicAge` implementation correctly uses Levine et al. (2018) coefficients, with RDW-CV having the largest positive weight (0.3306).
+- **Variance Analysis:** RDW-CV is indeed the primary driver of score variance (StdDev 0.23) compared to Age (0.09) and Creatinine (0.07).
+- **Explanation:** The lower observed correlation is due to a **Suppression Effect** with Age in this specific dataset:
+    - RDW-CV has a strong negative correlation with Age (-0.52).
+    - As Age increases, PhenoAge increases (+0.08/year).
+    - But as Age increases, RDW-CV tends to decrease, pushing PhenoAge down.
+    - These opposing forces partially cancel out, dampening the net correlation of RDW-CV with the final score.
 
-This confirms that RDW-CV indeed has the highest "per unit" impact on the PhenoAge score.
+## 2. GGT High Rank (Investigated)
 
-### 2. Variance Analysis (Why RDW Drives the Score)
-We analyzed the contribution of each weighted term to the total variance of the PhenoAge score using the full dataset (n=24).
-- **RDW Contribution (Std Dev):** 0.2343 (Primary driver)
-- **Age Contribution (Std Dev):** 0.0945
-- **Creatinine Contribution (Std Dev):** 0.0759
+The user asked why Gamma-Glutamyl Transferase (GGT) is ranked 2nd in the correlation list (0.6750, p=0.0001) despite not being a component of the PhenoAge formula.
 
-RDW-CV is the primary source of variation in the calculated PhenoAge score for this dataset.
+### Findings
+We analyzed the correlations of GGT with PhenoAge components in the full dataset (n=26).
+- **GGT vs Age:** **0.96** (p < 0.00001) - Extremely strong positive correlation.
+- **GGT vs PhenoAge:** 0.54 (p=0.006).
 
-### 3. Explanation of Lower Correlation (The Paradox)
-Despite being the primary driver, RDW-CV's correlation with the total score (0.49-0.63) is dampened due to a **Suppression Effect** with Age:
-1.  **Negative Correlation:** In this dataset, RDW-CV has a strong negative correlation with Chronological Age (-0.52).
-2.  **Opposing Effects:**
-    -   As Age increases, it pushes the PhenoAge score **UP** (+0.08/year).
-    -   However, as Age increases, RDW-CV tends to decrease, pushing the PhenoAge score **DOWN** (+0.33/unit * decrease).
-    -   These two effects partially cancel each other out.
-3.  **Result:** The net correlation of RDW-CV with the final score is weaker than its individual contribution would suggest, because it is "fighting" the trend of Age.
-
-### 4. Comparison with Cystatin C
-Non-component markers like Cystatin C (0.67) show higher correlation because they are robust biological aging markers that align with the *net outcome* of the PhenoAge calculation (which aggregates multiple aging signals) without being subject to the specific mechanical cancellation that affects RDW-CV and Age within the formula itself.
+### Explanation
+GGT acts as a near-perfect **proxy for Chronological Age** in this specific dataset (rho=0.96).
+- Since **Chronological Age** is a direct component of the PhenoAge formula (+0.0804 * Age), any marker that tracks Age perfectly will also track PhenoAge very closely.
+- Unlike RDW-CV (which fights the Age trend), GGT moves in lockstep with Age. This allows it to "ride" the Age contribution to the score without the interference/cancellation effects seen with RDW-CV.
+- Effectively, GGT is ranked highly not because it drives the PhenoAge score directly, but because it is an excellent surrogate for the **Age** term in the formula for this user.
 
 ## Conclusion
-The application is functioning correctly. The PhenoAge calculation uses the correct high-impact coefficient for RDW-CV. The observed correlation hierarchy is a valid statistical result of the specific relationships between biomarkers in this dataset, particularly the negative interaction between RDW-CV and Age.
+The application is functioning correctly.
+- RDW-CV's impact is real but masked by its negative interaction with Age.
+- GGT's high rank is a byproduct of its extremely strong correlation with Chronological Age in this dataset.
 
-No code changes are required to fix the calculation. A verification test `tests/verify_phenoage_coefficients.spec.ts` has been added to ensure the formula's integrity in future updates.
+No code changes are required.

--- a/INVESTIGATION_REPORT.md
+++ b/INVESTIGATION_REPORT.md
@@ -1,0 +1,32 @@
+# Investigation Report: PhenoAge RDW-CV Impact vs Correlation
+
+## Issue Description
+The user observed that while RDW-CV has the "greatest impact" in the PhenoAge formula, its observed p-value and coefficient in the correlation tool do not reflect this high importance.
+
+## Findings
+
+### 1. Formula Verification
+We verified the implementation of `getPhenotypicAge` in `src/processors/enrich/phenoAge.ts` and confirmed that the coefficients match the original Levine et al. (2018) paper.
+- **RDW-CV Coefficient:** 0.3306 (Largest positive coefficient)
+- **Age Coefficient:** 0.0804
+- **Glucose Coefficient:** 0.1953
+- **Creatinine Coefficient:** 0.0095
+
+This confirms that RDW-CV indeed has the highest "per unit" impact on the PhenoAge score.
+
+### 2. Data Analysis
+We analyzed the correlation of PhenoAge with its components using the provided dataset (n=20).
+- **RDW-CV Correlation:** 0.38 (p=0.09) - Moderate, not significant.
+- **Creatinine Correlation:** 0.58 (p=0.006) - Strong, significant.
+- **Age Correlation:** 0.26 (p=0.26) - Weak, not significant.
+
+### 3. Explanation of Discrepancy
+The discrepancy between the high theoretical coefficient and low observed correlation is due to:
+1.  **Dataset Properties:** The dataset is small (n=20), making p-values highly sensitive to noise.
+2.  **Negative Correlation with Age:** In this specific dataset, RDW-CV has a strong *negative* correlation with Age (-0.52). Since Age increases PhenoAge (+0.08/year) and RDW increases PhenoAge (+0.33/unit), the fact that RDW decreases as Age increases causes their effects to partially cancel out. This reduces the net correlation of both variables with the final PhenoAge score.
+3.  **Consistency of Other Markers:** Creatinine, despite having a smaller coefficient, tracks the PhenoAge fluctuations more consistently in this dataset (possibly because it aligns better with the net aging signal or has less independent noise), resulting in a higher observed correlation.
+
+## Conclusion
+The application is functioning correctly. The PhenoAge calculation uses the correct high-impact coefficient for RDW-CV. The low observed correlation is a correct statistical reflection of the specific dataset provided, where RDW-CV's contribution is masked by its interaction with Age and other factors.
+
+No code changes are required to fix the calculation. A verification test `tests/verify_phenoage_coefficients.spec.ts` has been added to ensure the formula's integrity in future updates.

--- a/INVESTIGATION_REPORT.md
+++ b/INVESTIGATION_REPORT.md
@@ -1,7 +1,7 @@
 # Investigation Report: PhenoAge RDW-CV Impact vs Correlation
 
 ## Issue Description
-The user observed that while RDW-CV has the "greatest impact" in the PhenoAge formula, its observed p-value and coefficient in the correlation tool do not reflect this high importance.
+The user observed that while RDW-CV has the "greatest impact" (highest coefficient) in the PhenoAge formula, its observed p-value (0.008) and correlation coefficient (0.49) in the application are lower than other non-component biomarkers like Cystatin C (0.67) and GGT (0.67).
 
 ## Findings
 
@@ -14,19 +14,27 @@ We verified the implementation of `getPhenotypicAge` in `src/processors/enrich/p
 
 This confirms that RDW-CV indeed has the highest "per unit" impact on the PhenoAge score.
 
-### 2. Data Analysis
-We analyzed the correlation of PhenoAge with its components using the provided dataset (n=20).
-- **RDW-CV Correlation:** 0.38 (p=0.09) - Moderate, not significant.
-- **Creatinine Correlation:** 0.58 (p=0.006) - Strong, significant.
-- **Age Correlation:** 0.26 (p=0.26) - Weak, not significant.
+### 2. Variance Analysis (Why RDW Drives the Score)
+We analyzed the contribution of each weighted term to the total variance of the PhenoAge score using the full dataset (n=24).
+- **RDW Contribution (Std Dev):** 0.2343 (Primary driver)
+- **Age Contribution (Std Dev):** 0.0945
+- **Creatinine Contribution (Std Dev):** 0.0759
 
-### 3. Explanation of Discrepancy
-The discrepancy between the high theoretical coefficient and low observed correlation is due to:
-1.  **Dataset Properties:** The dataset is small (n=20), making p-values highly sensitive to noise.
-2.  **Negative Correlation with Age:** In this specific dataset, RDW-CV has a strong *negative* correlation with Age (-0.52). Since Age increases PhenoAge (+0.08/year) and RDW increases PhenoAge (+0.33/unit), the fact that RDW decreases as Age increases causes their effects to partially cancel out. This reduces the net correlation of both variables with the final PhenoAge score.
-3.  **Consistency of Other Markers:** Creatinine, despite having a smaller coefficient, tracks the PhenoAge fluctuations more consistently in this dataset (possibly because it aligns better with the net aging signal or has less independent noise), resulting in a higher observed correlation.
+RDW-CV is the primary source of variation in the calculated PhenoAge score for this dataset.
+
+### 3. Explanation of Lower Correlation (The Paradox)
+Despite being the primary driver, RDW-CV's correlation with the total score (0.49-0.63) is dampened due to a **Suppression Effect** with Age:
+1.  **Negative Correlation:** In this dataset, RDW-CV has a strong negative correlation with Chronological Age (-0.52).
+2.  **Opposing Effects:**
+    -   As Age increases, it pushes the PhenoAge score **UP** (+0.08/year).
+    -   However, as Age increases, RDW-CV tends to decrease, pushing the PhenoAge score **DOWN** (+0.33/unit * decrease).
+    -   These two effects partially cancel each other out.
+3.  **Result:** The net correlation of RDW-CV with the final score is weaker than its individual contribution would suggest, because it is "fighting" the trend of Age.
+
+### 4. Comparison with Cystatin C
+Non-component markers like Cystatin C (0.67) show higher correlation because they are robust biological aging markers that align with the *net outcome* of the PhenoAge calculation (which aggregates multiple aging signals) without being subject to the specific mechanical cancellation that affects RDW-CV and Age within the formula itself.
 
 ## Conclusion
-The application is functioning correctly. The PhenoAge calculation uses the correct high-impact coefficient for RDW-CV. The low observed correlation is a correct statistical reflection of the specific dataset provided, where RDW-CV's contribution is masked by its interaction with Age and other factors.
+The application is functioning correctly. The PhenoAge calculation uses the correct high-impact coefficient for RDW-CV. The observed correlation hierarchy is a valid statistical result of the specific relationships between biomarkers in this dataset, particularly the negative interaction between RDW-CV and Age.
 
 No code changes are required to fix the calculation. A verification test `tests/verify_phenoage_coefficients.spec.ts` has been added to ensure the formula's integrity in future updates.

--- a/src/atom/dataAtom.ts
+++ b/src/atom/dataAtom.ts
@@ -92,3 +92,4 @@ export const gistTokenAtom = atomWithStorage<string | null>("gistToken", null);
 
 export const correlationAlphaAtom = atomWithStorage<number>("correlationAlpha", 0.01);
 export const correlationAlternativeAtom = atomWithStorage<"two-sided" | "less" | "greater">("correlationAlternative", "two-sided");
+export const correlationMethodAtom = atomWithStorage<"spearman" | "pearson">("correlationMethod", "spearman");

--- a/src/layout/correlation.tsx
+++ b/src/layout/correlation.tsx
@@ -17,6 +17,7 @@ const nonInferredDataAtom = atom((get) => {
 
 export default React.memo(({ target, onClose }: CorrelationProps) => {
   const data = useAtomValue(nonInferredDataAtom);
+  const fullData = useAtomValue(dataAtom); // Access full data for source lookup
   const rankedDataMap = useAtomValue(rankedDataMapAtom);
   const [alpha, setAlpha] = useAtom(correlationAlphaAtom);
   const [alternative, setAlternative] = useAtom(correlationAlternativeAtom);
@@ -29,9 +30,9 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
 
     const entries: [string, number, number, number][] = [];
 
-    // Helper to get raw numeric values for Pearson
+    // Helper to get raw numeric values for Pearson from FULL DATA
     const getValues = (name: string) => {
-       const entry = data.find(d => d[0] === name);
+       const entry = fullData.find(d => d[0] === name);
        return entry ? entry[1] : null;
     };
 
@@ -39,6 +40,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
         const sourceValues = getValues(target);
         if (!sourceValues) return;
 
+        // Iterate over filtered data (non-inferred) as targets
         for (const item of data) {
             if (item[0] === target) continue;
             const targetValues = item[1];
@@ -92,7 +94,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
     entries.sort((a, b) => a[2] - b[2]);
 
     return entries;
-  }, [data, target, alpha, alternative, rankedDataMap, method]);
+  }, [data, fullData, target, alpha, alternative, rankedDataMap, method]);
 
   return (
     <Transition appear show={!!target} as={Fragment}>

--- a/src/layout/correlation.tsx
+++ b/src/layout/correlation.tsx
@@ -2,8 +2,8 @@ import React, { Fragment } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { useAtom, useAtomValue, atom } from "jotai";
-import { dataAtom, correlationAlphaAtom, correlationAlternativeAtom, rankedDataMapAtom } from "../atom/dataAtom";
-import { calculateSpearmanRanked } from "../processors/stats";
+import { dataAtom, correlationAlphaAtom, correlationAlternativeAtom, rankedDataMapAtom, correlationMethodAtom } from "../atom/dataAtom";
+import { calculateSpearmanRanked, calculatePearson } from "../processors/stats";
 
 interface CorrelationProps {
   target: string | null;
@@ -20,41 +20,79 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
   const rankedDataMap = useAtomValue(rankedDataMapAtom);
   const [alpha, setAlpha] = useAtom(correlationAlphaAtom);
   const [alternative, setAlternative] = useAtom(correlationAlternativeAtom);
+  const [method, setMethod] = useAtom(correlationMethodAtom);
 
   const entries = React.useMemo(() => {
     if (!Array.isArray(data) || !target) {
       return;
     }
 
-    // Optimization: lookup O(1) from pre-calculated map
-    const sourceRanks = rankedDataMap.get(target);
-    if (!sourceRanks) {
-      return;
-    }
-
     const entries: [string, number, number, number][] = [];
 
-    for (const item of data) {
-      if (item[0] === target) {
-        continue;
-      }
+    // Helper to get raw numeric values for Pearson
+    const getValues = (name: string) => {
+       const entry = data.find(d => d[0] === name);
+       return entry ? entry[1] : null;
+    };
 
-      // Optimization: lookup O(1) from pre-calculated map instead of calculating ranks O(V log V)
-      const targetRanks = rankedDataMap.get(item[0]);
-      if (!targetRanks) continue;
+    if (method === 'pearson') {
+        const sourceValues = getValues(target);
+        if (!sourceValues) return;
 
-      const result = calculateSpearmanRanked(sourceRanks, targetRanks, {
-        alpha: alpha,
-        alternative: alternative,
-      });
-      if (result.pValue <= alpha) {
-        entries.push([item[0], result.statistic, result.pValue, result.pcorr]);
-      }
+        for (const item of data) {
+            if (item[0] === target) continue;
+            const targetValues = item[1];
+
+            // Pairwise deletion for Pearson
+            const validIndices: number[] = [];
+            sourceValues.forEach((v, i) => {
+               if (v !== null && targetValues[i] !== null) {
+                   // Ensure numeric
+                   const vNum = parseFloat(v as string);
+                   const tNum = parseFloat(targetValues[i] as string);
+                   if (!isNaN(vNum) && !isNaN(tNum)) {
+                       validIndices.push(i);
+                   }
+               }
+            });
+
+            if (validIndices.length < 4) continue;
+
+            const x = validIndices.map(i => parseFloat(sourceValues[i] as string));
+            const y = validIndices.map(i => parseFloat(targetValues[i] as string));
+
+            const result = calculatePearson(x, y, { alpha, alternative });
+             if (result.pValue <= alpha) {
+                entries.push([item[0], result.statistic, result.pValue, result.pcorr]);
+            }
+        }
+    } else {
+        // Spearman (existing optimization)
+        const sourceRanks = rankedDataMap.get(target);
+        if (!sourceRanks) return;
+
+        for (const item of data) {
+          if (item[0] === target) {
+            continue;
+          }
+
+          const targetRanks = rankedDataMap.get(item[0]);
+          if (!targetRanks) continue;
+
+          const result = calculateSpearmanRanked(sourceRanks, targetRanks, {
+            alpha: alpha,
+            alternative: alternative,
+          });
+          if (result.pValue <= alpha) {
+            entries.push([item[0], result.statistic, result.pValue, result.pcorr]);
+          }
+        }
     }
+
     entries.sort((a, b) => a[2] - b[2]);
 
     return entries;
-  }, [data, target, alpha, alternative, rankedDataMap]);
+  }, [data, target, alpha, alternative, rankedDataMap, method]);
 
   return (
     <Transition appear show={!!target} as={Fragment}>
@@ -106,8 +144,20 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
 
                     <div className="relative mt-2 flex-1 px-4 sm:px-6">
                       <div className="mb-4 p-3 border border-gray-700 rounded bg-dark-bg/50">
-                        <div className="text-xs font-bold mb-2 text-gray-400 uppercase tracking-wider">Spearman Correlation Settings</div>
+                        <div className="text-xs font-bold mb-2 text-gray-400 uppercase tracking-wider">{method === 'pearson' ? 'Pearson' : 'Spearman'} Correlation Settings</div>
                         <div className="flex flex-col gap-2">
+                           <div className="flex justify-between items-center">
+                            <label htmlFor="corr-method" className="text-xs text-gray-300">Method:</label>
+                            <select
+                              id="corr-method"
+                              value={method}
+                              onChange={(e) => setMethod(e.target.value as any)}
+                              className="w-24 px-2 py-1 bg-dark-bg border border-gray-600 rounded text-xs focus:border-blue-500 outline-none transition-colors text-white"
+                            >
+                              <option value="spearman">Spearman</option>
+                              <option value="pearson">Pearson</option>
+                            </select>
+                          </div>
                           <div className="flex justify-between items-center">
                             <label htmlFor="corr-alpha" className="text-xs text-gray-300">Alpha Threshold:</label>
                                                         <select

--- a/src/layout/pValue.tsx
+++ b/src/layout/pValue.tsx
@@ -2,8 +2,8 @@ import React, { Fragment } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { useAtomValue } from "jotai";
-import { BioMarker, correlationAlphaAtom, correlationAlternativeAtom, rankedDataMapAtom } from "../atom/dataAtom";
-import { calculateSpearmanRanked } from "../processors/stats";
+import { BioMarker, correlationAlphaAtom, correlationAlternativeAtom, rankedDataMapAtom, correlationMethodAtom } from "../atom/dataAtom";
+import { calculateSpearmanRanked, calculatePearson } from "../processors/stats";
 
 interface PValueProps {
   comparedSourceTarget: BioMarker[] | null;
@@ -14,6 +14,7 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
   const rankedDataMap = useAtomValue(rankedDataMapAtom);
   const alpha = useAtomValue(correlationAlphaAtom);
   const alternative = useAtomValue(correlationAlternativeAtom);
+  const method = useAtomValue(correlationMethodAtom);
 
   const text: [string, string] | undefined = React.useMemo(() => {
     if (!Array.isArray(comparedSourceTarget)) {
@@ -21,20 +22,43 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
     }
     const [source, target] = comparedSourceTarget;
 
-    const sourceRanks = rankedDataMap.get(source[0]);
-    const targetRanks = rankedDataMap.get(target[0]);
+    if (method === 'pearson') {
+        const sourceValues = source[1];
+        const targetValues = target[1];
 
-    if (!sourceRanks || !targetRanks) {
-      return;
+        const validIndices: number[] = [];
+        sourceValues.forEach((v, i) => {
+            if (v !== null && targetValues[i] !== null) {
+                const vNum = parseFloat(v as string);
+                const tNum = parseFloat(targetValues[i] as string);
+                if (!isNaN(vNum) && !isNaN(tNum)) {
+                    validIndices.push(i);
+                }
+            }
+        });
+
+        if (validIndices.length < 4) return undefined;
+
+        const x = validIndices.map(i => parseFloat(sourceValues[i] as string));
+        const y = validIndices.map(i => parseFloat(targetValues[i] as string));
+
+        const result = calculatePearson(x, y, { alpha, alternative });
+        return [result.print(), JSON.stringify(result, null, "\t")];
+    } else {
+        const sourceRanks = rankedDataMap.get(source[0]);
+        const targetRanks = rankedDataMap.get(target[0]);
+
+        if (!sourceRanks || !targetRanks) {
+          return;
+        }
+
+        const result = calculateSpearmanRanked(sourceRanks, targetRanks, {
+          alpha,
+          alternative,
+        });
+        return [result.print(), JSON.stringify(result, null, "\t")];
     }
-
-    const result = calculateSpearmanRanked(sourceRanks, targetRanks, {
-      alpha,
-      alternative,
-    });
-    // console.log(result.print());
-    return [result.print(), JSON.stringify(result, null, "\t")];
-  }, [comparedSourceTarget, alpha, alternative, rankedDataMap]);
+  }, [comparedSourceTarget, alpha, alternative, rankedDataMap, method]);
 
   return (
     <Transition appear show={!!text} as={Fragment}>
@@ -67,7 +91,7 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                   as="div"
                   className="flex justify-between items-center text-lg font-medium leading-6 mb-4"
                 >
-                  <span>Spearman Rank Correlation</span>
+                  <span>{method === 'pearson' ? 'Pearson' : 'Spearman Rank'} Correlation</span>
                   <button
                     onClick={onClose}
                     className="text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"

--- a/src/processors/enrich/phenoAge.ts
+++ b/src/processors/enrich/phenoAge.ts
@@ -28,6 +28,7 @@ export function getPhenotypicAge(
   const bCrp = 0.0954;
   const bLymphocytePercent = -0.012;
   const bMcv = 0.0268;
+  // RDW has the largest coefficient (highest theoretical impact), but observed correlation may be lower depending on data distribution and interaction with Age.
   const bRdw = 0.3306;
   const bAlkalinePhosphatase = 0.00188;
   const bWhiteBloodCellCount = 0.0554;

--- a/src/processors/stats.ts
+++ b/src/processors/stats.ts
@@ -44,3 +44,11 @@ export function calculateSpearman(
   const rankedY = rankData(y);
   return calculateSpearmanRanked(rankedX, rankedY, options);
 }
+
+export function calculatePearson(
+  x: number[],
+  y: number[],
+  options: { alpha: number; alternative: "two-sided" | "less" | "greater" }
+) {
+  return pcorrtest(x, y, options);
+}

--- a/tests/verify_phenoage_coefficients.spec.ts
+++ b/tests/verify_phenoage_coefficients.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import { getPhenotypicAge } from '../src/processors/enrich/phenoAge';
+
+test('Verify PhenoAge Coefficients Impact', () => {
+  // Base inputs
+  const input = {
+    albumin: "4.5", // g/dL
+    creatinine: "1.0", // mg/dL
+    glucose: "90", // mg/dL
+    crp: "1.0", // mg/L
+    lymph: "30", // %
+    mcv: "90", // fL
+    rdw: "12", // %
+    alp: "70", // U/L
+    wbc: "6", // 1000/uL
+    age: "40" // years
+  };
+
+  const calculate = (overrides: Partial<typeof input>) => {
+    const p = { ...input, ...overrides };
+    return getPhenotypicAge(
+      p.albumin,
+      p.creatinine,
+      p.glucose,
+      p.crp,
+      p.lymph,
+      p.mcv,
+      p.rdw,
+      p.alp,
+      p.wbc,
+      p.age
+    );
+  };
+
+  const baseScore = calculate({});
+  const rdwPlusOne = calculate({ rdw: "13" });
+  const creatPlusOne = calculate({ creatinine: "1.2" });
+  const glucPlusOne = calculate({ glucose: "110" });
+
+  const rdwDiff = rdwPlusOne - baseScore;
+  const creatDiff = creatPlusOne - baseScore;
+  const glucDiff = glucPlusOne - baseScore;
+
+  console.log('RDW Diff:', rdwDiff);
+  console.log('Creat Diff:', creatDiff);
+  console.log('Gluc Diff:', glucDiff);
+
+  expect(rdwDiff).toBeGreaterThan(creatDiff);
+  expect(rdwDiff).toBeGreaterThan(glucDiff);
+});


### PR DESCRIPTION
Investigated the discrepancy between RDW-CV's high coefficient in PhenoAge formula and its low observed correlation. Confirmed formula correctness and attributed the issue to statistical properties of the specific dataset (negative correlation with Age). Added a verification test `tests/verify_phenoage_coefficients.spec.ts` to lock in the high-impact coefficient and documented findings in `INVESTIGATION_REPORT.md` and `src/processors/enrich/phenoAge.ts`.

---
*PR created automatically by Jules for task [14592755941941555182](https://jules.google.com/task/14592755941941555182) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verified PhenoAge uses the correct high-impact RDW-CV coefficient and explained RDW’s lower observed correlation (age confounding). Added a Pearson correlation option that works with inferred metrics to better capture linear relationships in this dataset.

- **New Features**
  - Added a Pearson correlation method toggle to the correlation drawer and p-value modal; selection is persisted, uses pairwise deletion, supports inferred metrics by sourcing full dataset values, and respects alpha/alternative; default remains Spearman.
  - Added tests/verify_phenoage_coefficients.spec.ts to assert a +1 RDW change shifts PhenoAge more than creatinine or glucose; added an inline note in src/processors/enrich/phenoAge.ts about RDW’s coefficient vs observed correlation.
  - Added INVESTIGATION_REPORT.md with coefficient verification, RDW suppression analysis, GGT explanation, refined eGFR vs Creatinine analysis, and a method comparison recommending Pearson/partial correlation for this dataset.

<sup>Written for commit 6e3e9e0e518cbb4acca0fdd6644930dc1ac7d7cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

