### PR TITLE
🎨 Palette: Enhance supplements button with icon and tooltip

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -39,3 +39,7 @@
 ## 2026-10-25 - Scoping Checkbox Locators in Tests
 **Learning:** Generic locators like `input[type="checkbox"]` often match unexpected elements (like navigation toggles) in this layout.
 **Action:** Always scope checkbox locators to their container (e.g., `table input[type="checkbox"]`) to avoid false positives in tests.
+
+## 2026-03-05 - Refactoring Text to Icons
+**Learning:** Playwright tests often rely on text content (e.g., `hasText: "?"`) which breaks immediately when refactoring to icons.
+**Action:** When replacing text with icons, always proactively update associated tests to use robust locators like `aria-label` or `role`, and verify the new locator works before committing.

--- a/src/layout/SupplementsPopover.tsx
+++ b/src/layout/SupplementsPopover.tsx
@@ -1,4 +1,5 @@
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
+import { BeakerIcon } from '@heroicons/react/24/outline'
 import cn from 'classnames'
 
 interface Props {
@@ -12,9 +13,10 @@ export default function SupplementsPopover({ supps }: Props) {
     <Popover className="w-full h-full flex justify-center items-center">
       <PopoverButton
         aria-label="View supplements"
-        className="w-full h-full cursor-pointer hover:bg-gray-800 hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded font-bold transition-colors flex justify-center items-center"
+        title="View supplements taken on this date"
+        className="w-full h-full cursor-pointer hover:bg-gray-800 hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded font-bold transition-colors flex justify-center items-center p-1"
       >
-        ?
+        <BeakerIcon className="h-5 w-5" />
       </PopoverButton>
       <PopoverPanel
         anchor="top"

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -141,11 +141,14 @@ test('supplements popover button has accessible label', async ({ page }) => {
 
   // Find the button with visible text "?"
   // We use filter hasText to find the button element containing "?"
-  const popoverButton = page.locator('button').filter({ hasText: '?' }).first();
+  const popoverButton = page.locator('button[aria-label="View supplements"]').first();
 
   // Verify it's visible
   await expect(popoverButton).toBeVisible();
 
   // Verify it has the expected aria-label
   await expect(popoverButton).toHaveAttribute('aria-label', 'View supplements');
+
+  // Verify it has the expected title
+  await expect(popoverButton).toHaveAttribute('title', 'View supplements taken on this date');
 });

--- a/tests/popover_verification.spec.ts
+++ b/tests/popover_verification.spec.ts
@@ -13,7 +13,7 @@ test('supplements popover functionality', async ({ page }) => {
 
   // Locate the "?" button in the footer
   // Use a specific locator to avoid confusion with other "?"
-  const popoverButton = page.locator('tfoot button:has-text("?")').first();
+  const popoverButton = page.locator('tfoot button[aria-label="View supplements"]').first();
 
   // Ensure it exists
   const count = await popoverButton.count();


### PR DESCRIPTION
💡 What: Replaced the text-based "?" button for supplements with a `BeakerIcon` and added a tooltip.
🎯 Why: To improve visual consistency and provide better affordance for users.
📸 Before/After: The "?" text is now a flask icon.
♿ Accessibility: Added `title` attribute for mouse users and preserved `aria-label` for screen readers.

---
*PR created automatically by Jules for task [17520932775058375270](https://jules.google.com/task/17520932775058375270) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the text “?” supplements button with a beaker icon and added a native tooltip to improve clarity and visual consistency. Preserves accessibility and makes tests more robust.

- **New Features**
  - Swapped “?” for BeakerIcon in SupplementsPopover.
  - Added title tooltip: “View supplements taken on this date”.
  - Kept aria-label: “View supplements”.

- **Refactors**
  - Updated Playwright tests to target aria-label instead of text.
  - Accessibility test now also verifies the title attribute.
  - Added a note in .Jules/palette.md about using robust locators when replacing text with icons.

<sup>Written for commit d218ac9daddfc6d3c2aca72402f8498492e906b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

