### PR TITLE
⚡ Bolt: Memoize App props to prevent Table re-renders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -192,7 +192,9 @@ export default function App() {
     });
   }, [setFilterTag, setFilterText]);
 
-  const navProps = {
+  // Optimization: Memoize props passed to components to prevent unnecessary re-renders.
+  // navProps changes on every keystroke (due to searchText), so Nav will re-render, which is correct.
+  const navProps = React.useMemo(() => ({
     selected,
     onSelect,
     chartType,
@@ -208,16 +210,46 @@ export default function App() {
     onOriginValueToggle,
     onVisualize,
     onPValue,
-  };
+  }), [
+    selected,
+    onSelect,
+    chartType,
+    onChartTypeChange,
+    onClearSelection,
+    searchText,
+    filterTag,
+    showOrigColumns,
+    showRecords,
+    onShowRecordsChange,
+    onTextChange,
+    onFilterByTag,
+    onOriginValueToggle,
+    onVisualize,
+    onPValue
+  ]);
 
-  const tableProps = {
+  // Optimization: tableProps does NOT include searchText. It only includes state relevant to the table.
+  // This prevents the heavy Table component from re-rendering on every keystroke in the search input,
+  // since Table relies on the debounced filterTextAtom, not the immediate searchText.
+  const tableProps = React.useMemo(() => ({
     showOrigColumns,
     selected,
     onSelect,
     showRecords,
     onClearFilters,
     onCorrelation,
-  };
+  }), [
+    showOrigColumns,
+    selected,
+    onSelect,
+    showRecords,
+    onClearFilters,
+    onCorrelation
+  ]);
+
+  // Optimization: Memoize onClose handlers to ensure referential stability for React.memo components
+  const onPValueClose = React.useCallback(() => setSourceTarget(null), []);
+  const onCorrelationClose = React.useCallback(() => setCorrelationKey(null), []);
 
   return (
     <>
@@ -227,11 +259,11 @@ export default function App() {
       <Nav {...navProps} />
       <PValue
         comparedSourceTarget={comparedSourceTarget}
-        onClose={() => setSourceTarget(null)}
+        onClose={onPValueClose}
       />
       <Correlation
         target={corrlationKey}
-        onClose={() => setCorrelationKey(null)}
+        onClose={onCorrelationClose}
       />
       {chartKeys && chartKeys.length > 0 && chartType === 'scatter' && <ScatterChart data={data} keys={chartKeys} />}
       <Table {...tableProps} />

--- a/vite_screenshot.log
+++ b/vite_screenshot.log
@@ -1,0 +1,7 @@
+Port 5173 is in use, trying another one...
+Port 5174 is in use, trying another one...
+
+  VITE v7.1.12  ready in 418 ms
+
+  ➜  Local:   http://localhost:5175/
+  ➜  Network: use --host to expose


### PR DESCRIPTION
Memoize App props to prevent Table re-renders

---
*PR created automatically by Jules for task [15982236808210069362](https://jules.google.com/task/15982236808210069362) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized App props to stop the heavy Table from re-rendering on every keystroke, making search input typing smoother and reducing render overhead. Also memoized close handlers for modal components to keep memoized children stable.

- **Refactors**
  - Memoized navProps with useMemo; Nav still re-renders with searchText as expected.
  - Memoized tableProps with useMemo and excluded searchText; Table now updates only on relevant state (uses debounced filterTextAtom).
  - Replaced inline onClose lambdas with useCallback for PValue and Correlation.

<sup>Written for commit c76cccef2c1cd9b94f047329baf14147e2f1cb55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

