### PR TITLE
Refactor: Extract PasswordInput Component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,25 +16,7 @@ import {
   gistTokenAtom,
   BioMarker,
 } from "./atom/dataAtom";
-import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
-
-const PasswordInput = React.memo(({ show, setShow, ...props }: any) => (
-  <div className="relative w-full">
-    <input
-      type={show ? "text" : "password"}
-      className="w-full px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500 pr-10"
-      {...props}
-    />
-    <button
-      type="button"
-      onClick={() => setShow(!show)}
-      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
-      aria-label={show ? "Hide password" : "Show password"}
-    >
-      {show ? <EyeSlashIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
-    </button>
-  </div>
-));
+import { PasswordInput } from "./layout/PasswordInput";
 
 export default function App() {
   const data = useAtomValue(getBioMarkersAtom);

--- a/src/layout/PasswordInput.tsx
+++ b/src/layout/PasswordInput.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
+
+export const PasswordInput = React.memo(({ show, setShow, ...props }: any) => (
+  <div className="relative w-full">
+    <input
+      type={show ? "text" : "password"}
+      className="w-full px-3 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500 pr-10"
+      {...props}
+    />
+    <button
+      type="button"
+      onClick={() => setShow(!show)}
+      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
+      aria-label={show ? "Hide password" : "Show password"}
+    >
+      {show ? <EyeSlashIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
+    </button>
+  </div>
+));


### PR DESCRIPTION
The Issue: The `PasswordInput` component was defined directly inside `src/App.tsx`.

The Fix: Created `src/layout/PasswordInput.tsx`, moved the React component there, and updated imports in `src/App.tsx`.

The Benefit: Decouples the component from the main application view file, improving code organization and making the `PasswordInput` component reusable across the app.

---
*PR created automatically by Jules for task [4511315690389928869](https://jules.google.com/task/4511315690389928869) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted PasswordInput from App.tsx into src/layout/PasswordInput.tsx and updated App.tsx to import it. Improves organization and makes the component reusable across the app.

<sup>Written for commit 598a883f8f05ca29640a9d2cec8049a1e83f4ae8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

