### PR TITLE
Refactor: Extract Correlation Atoms

### DIFF
--- a/src/atom/correlationAtom.ts
+++ b/src/atom/correlationAtom.ts
@@ -1,0 +1,5 @@
+import { atomWithStorage } from "jotai/utils";
+
+export const correlationAlphaAtom = atomWithStorage<number>("correlationAlpha", 0.01);
+export const correlationAlternativeAtom = atomWithStorage<"two-sided" | "less" | "greater">("correlationAlternative", "two-sided");
+export const correlationMethodAtom = atomWithStorage<"spearman" | "pearson">("correlationMethod", "spearman");

--- a/src/atom/dataAtom.ts
+++ b/src/atom/dataAtom.ts
@@ -76,10 +76,6 @@ export const aiKeyAtom = atomWithStorage<string | null>("key", null);
 export const aiModelAtom = atomWithStorage<string>("model", "gemini-3-flash-preview");
 export const gistTokenAtom = atomWithStorage<string | null>("gistToken", null);
 
-export const correlationAlphaAtom = atomWithStorage<number>("correlationAlpha", 0.01);
-export const correlationAlternativeAtom = atomWithStorage<"two-sided" | "less" | "greater">("correlationAlternative", "two-sided");
-export const correlationMethodAtom = atomWithStorage<"spearman" | "pearson">("correlationMethod", "spearman");
-
 export const nonInferredDataAtom = atom((get) => {
   const data = get(dataAtom);
   return data.filter((item) => !item[3]?.inferred);

--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -5,9 +5,11 @@ import { useAtomValue } from "jotai";
 import {
   notesAtom,
   dataAtom,
+} from "../atom/dataAtom";
+import {
   correlationAlphaAtom,
   correlationAlternativeAtom,
-} from "../atom/dataAtom";
+} from "../atom/correlationAtom";
 import { calculateSpearmanRanked, rankData } from "../processors/stats";
 
 interface BiomarkerCorrelationProps {

--- a/src/layout/correlation.tsx
+++ b/src/layout/correlation.tsx
@@ -2,7 +2,8 @@ import React, { Fragment } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { useAtom, useAtomValue } from "jotai";
-import { dataAtom, correlationAlphaAtom, correlationAlternativeAtom, rankedDataMapAtom, correlationMethodAtom, nonInferredDataAtom } from "../atom/dataAtom";
+import { dataAtom, rankedDataMapAtom, nonInferredDataAtom } from "../atom/dataAtom";
+import { correlationAlphaAtom, correlationAlternativeAtom, correlationMethodAtom } from "../atom/correlationAtom";
 import { calculateSpearmanRanked, calculatePearson } from "../processors/stats";
 
 interface CorrelationProps {

--- a/src/layout/pValue.tsx
+++ b/src/layout/pValue.tsx
@@ -2,7 +2,8 @@ import React, { Fragment } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { useAtomValue } from "jotai";
-import { correlationAlphaAtom, correlationAlternativeAtom, rankedDataMapAtom, correlationMethodAtom } from "../atom/dataAtom";
+import { rankedDataMapAtom } from "../atom/dataAtom";
+import { correlationAlphaAtom, correlationAlternativeAtom, correlationMethodAtom } from "../atom/correlationAtom";
 import { BioMarker } from "../types/biomarker";
 import { calculateSpearmanRanked, calculatePearson } from "../processors/stats";
 


### PR DESCRIPTION
The Issue: The correlation-related Jotai atoms (`correlationAlphaAtom`, `correlationAlternativeAtom`, `correlationMethodAtom`) were loosely defined inside `src/atom/dataAtom.ts` along with unrelated application state, violating separation of concerns and reducing file maintainability.

The Fix: Created a new dedicated file, `src/atom/correlationAtom.ts`, moved these specific atoms into it, and updated all corresponding imports in `src/atom/dataAtom.ts`, `src/layout/correlation.tsx`, `src/layout/pValue.tsx`, and `src/layout/BiomarkerCorrelation.tsx`. Also fixed a bug that crept in from a bad diff. 

The Benefit: Decouples the correlation settings state from the core data and AI state, organizing the state store structurally and making the atoms easily reusable and isolated across the application.

---
*PR created automatically by Jules for task [181372549260781268](https://jules.google.com/task/181372549260781268) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted correlation Jotai atoms into src/atom/correlationAtom.ts to separate correlation settings from core data state and improve maintainability. Updated imports in dataAtom and correlation-related layouts; no behavior changes.

<sup>Written for commit 059f7155ac955bd5b5abbcb14d8c5f22725ffdca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

