### PR TITLE
🎨 Palette: [UX improvement] Improve accessibility of async actions and correlation empty states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -51,3 +51,7 @@
 ## 2025-05-22 - Improving P-Value Modal and Row Expand Accessibility
 **Learning:** Found that the P-Value modal was dumping raw JSON text and lacked formatting, making it difficult to read. In addition, row expand/collapse buttons in the data table lacked `aria-label` and `focus-visible` styles, rendering them invisible to screen readers and keyboard users.
 **Action:** Always verify that dynamically generated statistical objects (like `pcorrtest` outputs) include a formatted `print()` method for user-facing UI, instead of relying on `JSON.stringify`. Additionally, ensure all row-level action buttons (like expand toggles) include clear `aria-label`s and `focus-visible:ring-2` styles.
+
+## 2026-10-26 - Dark Theme Contrast in Empty States
+**Learning:** Text colored `text-gray-500` or darker can fail WCAG AA contrast ratios against very dark background colors common in modals and tables in this app. Lightening these informational texts to `text-gray-400` resolves the contrast issues while preserving the intended visual hierarchy. Also found that many dynamically injected empty states were missing `role="status" aria-live="polite"`, preventing screen readers from announcing when no data is found.
+**Action:** Always verify color contrast for informational text in dark mode environments. Additionally, strictly mandate the `role="status"` and `aria-live="polite"` pattern for all empty states.

--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -234,7 +234,9 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                         <tr>
                           <td
                             colSpan={3}
-                            className="py-4 text-center text-sm text-gray-500"
+                            className="py-4 text-center text-sm text-gray-400"
+                            role="status"
+                            aria-live="polite"
                           >
                             No correlations found (p &le; 0.1, filtered &gt; 0).
                           </td>

--- a/src/layout/correlation.tsx
+++ b/src/layout/correlation.tsx
@@ -240,9 +240,9 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                             ))
                           ) : (
                             <tr>
-                              <td colSpan={3} className="py-12 text-center text-sm text-gray-500 border border-dashed border-gray-700 rounded bg-white/5">
+                              <td colSpan={3} className="py-12 text-center text-sm text-gray-400 border border-dashed border-gray-700 rounded bg-white/5" role="status" aria-live="polite">
                                 No significant correlations found.<br/>
-                                <span className="text-xs mt-2 block text-gray-600">Try increasing the Alpha threshold or changing the hypothesis.</span>
+                                <span className="text-xs mt-2 block text-gray-500">Try increasing the Alpha threshold or changing the hypothesis.</span>
                               </td>
                             </tr>
                           )}

--- a/src/layout/nav.tsx
+++ b/src/layout/nav.tsx
@@ -381,7 +381,7 @@ export default React.memo<Props>(
                         P-Value
                       </button>
                     )}
-                    <button type="button" onClick={onAskAI} disabled={isAsking} className="px-3 py-1 text-xs font-medium bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 transition-colors flex items-center justify-center gap-1 min-w-[70px]" aria-busy={isAsking}>
+                    <button type="button" onClick={onAskAI} disabled={isAsking} className="px-3 py-1 text-xs font-medium bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 transition-colors flex items-center justify-center gap-1 min-w-[70px]" aria-busy={isAsking}>
                       {isAsking ? <Spinner /> : null}
                       {isAsking ? "Asking..." : "Ask AI"}
                     </button>
@@ -512,7 +512,7 @@ export default React.memo<Props>(
                       </button>
                       <button
                         type="button"
-                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 flex items-center justify-center gap-2"
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
                         disabled={isGistLoading}
                         aria-busy={isGistLoading}
                         onClick={async () => {


### PR DESCRIPTION
💡 **What**:
- Added `disabled:cursor-not-allowed` to the "Ask AI" and "Save to Gist" buttons while they are loading.
- Added `role="status"` and `aria-live="polite"` to the empty state messages in `BiomarkerCorrelation` and `correlation` dialogs.
- Brightened the text color of the empty states from `text-gray-500` to `text-gray-400` to meet WCAG contrast requirements on dark backgrounds.

🎯 **Why**: 
- Users need immediate visual feedback when an async action is disabled and cannot be clicked.
- Screen reader users were previously unaware when correlation calculations returned no results because the new text was injected dynamically without an ARIA live region.
- The `text-gray-500` text lacked sufficient contrast against the `#222222` modal backgrounds, making it hard to read for users with visual impairments.

♿ **Accessibility**: 
- Added dynamic announcements for screen readers (`role="status"`, `aria-live="polite"`).
- Improved visual contrast ratio.
- Improved visual cursor feedback.

---
*PR created automatically by Jules for task [10668488633734605234](https://jules.google.com/task/10668488633734605234) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved UX and accessibility for async buttons and correlation dialogs with clearer disabled feedback, screen reader announcements, and better contrast on dark backgrounds.

- **Bug Fixes**
  - Show cursor-not-allowed on "Ask AI" and "Save to Gist" while loading.
  - Announce empty states with role="status" and aria-live="polite" in BiomarkerCorrelation and correlation dialogs.
  - Lighten empty-state text from gray-500 to gray-400 to meet WCAG AA on dark modals.

<sup>Written for commit 7734819203c14a4f40f7c7be4408e10ee7467171. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

