### PR TITLE
refactor: extract TableProps and DisplayedEntry to table.types.ts

### DIFF
--- a/src/layout/table.tsx
+++ b/src/layout/table.tsx
@@ -21,27 +21,7 @@ import { ChevronRightIcon, ChevronDownIcon, ChartBarIcon, MinusIcon, CalculatorI
 import { averageCountAtom } from "../atom/averageValueAtom";
 import LineChart from "./LineChart";
 import BiomarkerCorrelation from "./BiomarkerCorrelation";
-
-interface TableProps {
-  onCorrelation: (name: string) => void;
-  showOrigColumns: boolean;
-  selected: string[];
-  onSelect: (name: string) => void;
-  showRecords: number;
-  onClearFilters?: () => void;
-}
-
-type DisplayedEntry = {
-  name: string;
-  values: number[];
-  visibleValues: number[];
-  visibleOptimality: boolean[] | null;
-  unit: string;
-  extra: BioMarker[3];
-  tag: string;
-  displayTag: string;
-  sortKey: string;
-};
+import { TableProps, DisplayedEntry } from "./table.types";
 
 const columnHelper = createColumnHelper<DisplayedEntry>();
 

--- a/src/layout/table.types.ts
+++ b/src/layout/table.types.ts
@@ -1,0 +1,22 @@
+import { BioMarker } from "../types/biomarker";
+
+export interface TableProps {
+  onCorrelation: (name: string) => void;
+  showOrigColumns: boolean;
+  selected: string[];
+  onSelect: (name: string) => void;
+  showRecords: number;
+  onClearFilters?: () => void;
+}
+
+export type DisplayedEntry = {
+  name: string;
+  values: number[];
+  visibleValues: number[];
+  visibleOptimality: boolean[] | null;
+  unit: string;
+  extra: BioMarker[3];
+  tag: string;
+  displayTag: string;
+  sortKey: string;
+};


### PR DESCRIPTION
The Issue: The `TableProps` and `DisplayedEntry` types were defined directly inside `src/layout/table.tsx`, making the file bulky and mixing component logic with type definitions.

The Fix: Created `src/layout/table.types.ts`, moved the `TableProps` and `DisplayedEntry` definitions there along with the necessary `BioMarker` import, and updated the imports in `src/layout/table.tsx`.

The Benefit: Decouples type definitions from the UI component, making the component file cleaner and the types more easily reusable across the app if needed in the future.

---
*PR created automatically by Jules for task [18128857244212196679](https://jules.google.com/task/18128857244212196679) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted TableProps and DisplayedEntry into src/layout/table.types.ts to separate types from the table component. This cleans up src/layout/table.tsx and makes the types reusable with no behavior changes.

- **Refactors**
  - Added src/layout/table.types.ts with TableProps and DisplayedEntry.
  - Updated src/layout/table.tsx to import these types.
  - Centralized BioMarker import in the new types file.

<sup>Written for commit 9a6b305efa428f36000f8113d945dc592232e83a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

