### PR TITLE
Refactor: Extract Table types to a dedicated file

### DIFF
--- a/src/layout/table.tsx
+++ b/src/layout/table.tsx
@@ -21,27 +21,7 @@ import { ChevronRightIcon, ChevronDownIcon, ChartBarIcon, MinusIcon, CalculatorI
 import { averageCountAtom } from "../atom/averageValueAtom";
 import LineChart from "./LineChart";
 import BiomarkerCorrelation from "./BiomarkerCorrelation";
-
-interface TableProps {
-  onCorrelation: (name: string) => void;
-  showOrigColumns: boolean;
-  selected: string[];
-  onSelect: (name: string) => void;
-  showRecords: number;
-  onClearFilters?: () => void;
-}
-
-type DisplayedEntry = {
-  name: string;
-  values: number[];
-  visibleValues: number[];
-  visibleOptimality: boolean[] | null;
-  unit: string;
-  extra: BioMarker[3];
-  tag: string;
-  displayTag: string;
-  sortKey: string;
-};
+import { TableProps, DisplayedEntry } from "./table.types";
 
 const columnHelper = createColumnHelper<DisplayedEntry>();
 

--- a/src/layout/table.types.ts
+++ b/src/layout/table.types.ts
@@ -1,0 +1,22 @@
+import { BioMarker } from "../types/biomarker";
+
+export interface TableProps {
+  onCorrelation: (name: string) => void;
+  showOrigColumns: boolean;
+  selected: string[];
+  onSelect: (name: string) => void;
+  showRecords: number;
+  onClearFilters?: () => void;
+}
+
+export type DisplayedEntry = {
+  name: string;
+  values: number[];
+  visibleValues: number[];
+  visibleOptimality: boolean[] | null;
+  unit: string;
+  extra: BioMarker[3];
+  tag: string;
+  displayTag: string;
+  sortKey: string;
+};


### PR DESCRIPTION
The Issue: The `TableProps` interface and `DisplayedEntry` type were defined directly inside `src/layout/table.tsx`, bloating the component file and making the types harder to reuse.

The Fix: Created `src/layout/table.types.ts`, moved the TypeScript type/interface definitions there, and updated the imports in `table.tsx`.

The Benefit: Decouples TypeScript type definitions from the UI component, making the code more organized, the component file leaner, and the types cleanly reusable across the app.

---
*PR created automatically by Jules for task [4202911012931176852](https://jules.google.com/task/4202911012931176852) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved TableProps and DisplayedEntry from src/layout/table.tsx into src/layout/table.types.ts, and updated imports. This cleans up the component and makes the types reusable across the app.

<sup>Written for commit fc95a9d734e4b91871a016e3e0a4222ced8d3fd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

