### PR TITLE
🎨 Palette: Add Escape key handler to search input

### DIFF
--- a/src/layout/nav.tsx
+++ b/src/layout/nav.tsx
@@ -281,6 +281,14 @@ export default React.memo<Props>(
                   onChange={onTextChange}
                   onFocus={() => setIsFocused(true)}
                   onBlur={() => setIsFocused(false)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") {
+                      onTextChange({
+                        target: { value: "" },
+                      } as React.ChangeEvent<HTMLInputElement>);
+                      e.currentTarget.blur();
+                    }
+                  }}
                   autoFocus
                   className="w-full pl-10 pr-10 py-2 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus:border-blue-500 placeholder-gray-500 focus:placeholder-gray-400"
                   placeholder="Search"


### PR DESCRIPTION
💡 **What**: Added an `onKeyDown` handler to the search input that listens for the `Escape` key. When pressed, it instantly clears the search text and removes focus (blurs) from the input field.

🎯 **Why**: This implements a standard, expected keyboard interaction pattern for search bars. It allows users who navigate primarily via keyboard (or who prefer keyboard shortcuts) to quickly exit and clear a search without needing to reach for the mouse to click the "X" button or click outside the field. It also complements the existing `/` shortcut to focus the search bar.

♿ **Accessibility**: Significant improvement for keyboard users. Provides an immediate escape hatch from the focused search context.

📸 **Before/After**: Not visually apparent, but functional. Before, pressing Escape while typing did nothing. Now, pressing Escape clears the text and drops focus from the text box.

---
*PR created automatically by Jules for task [8453361501392873629](https://jules.google.com/task/8453361501392873629) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Escape key handling to the search input. Pressing Escape now always clears the query and blurs the field, giving keyboard users a quick way to exit search and complementing the '/' focus shortcut.

<sup>Written for commit 592ced0441a002ce1c155bb1116efd905efe1063. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

