### PR TITLE
🎨 Palette: Extract Spinner Component

### DIFF
--- a/src/layout/Spinner.tsx
+++ b/src/layout/Spinner.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+export const Spinner = () => (
+  <svg
+    className="animate-spin h-4 w-4 text-white"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <circle
+      className="opacity-25"
+      cx="12"
+      cy="12"
+      r="10"
+      stroke="currentColor"
+      strokeWidth="4"
+    ></circle>
+    <path
+      className="opacity-75"
+      fill="currentColor"
+      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+    ></path>
+  </svg>
+);

--- a/src/layout/nav.tsx
+++ b/src/layout/nav.tsx
@@ -23,29 +23,7 @@ import {
 import { calculateSpearman, calculateSpearmanRanked } from "../processors/stats";
 import { averageCountAtom } from "../atom/averageValueAtom";
 import Markdown from "react-markdown";
-
-const Spinner = () => (
-  <svg
-    className="animate-spin h-4 w-4 text-white"
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-  >
-    <circle
-      className="opacity-25"
-      cx="12"
-      cy="12"
-      r="10"
-      stroke="currentColor"
-      strokeWidth="4"
-    ></circle>
-    <path
-      className="opacity-75"
-      fill="currentColor"
-      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-    ></path>
-  </svg>
-);
+import { Spinner } from "./Spinner";
 
 type Props = {
   selected: string[];


### PR DESCRIPTION
The Issue: The `<Spinner>` component (an inline SVG) was defined directly inside `src/layout/nav.tsx`.

The Fix: Created `src/layout/Spinner.tsx`, moved the Spinner definition there, and updated the imports in `nav.tsx`.

The Benefit: Decouples the generic loading indicator from the Nav component, making the `Spinner` reusable across the app and improving file organization.

---
*PR created automatically by Jules for task [8142394928436691720](https://jules.google.com/task/8142394928436691720) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the inline Spinner from src/layout/nav.tsx into src/layout/Spinner.tsx and updated nav to import it, making the loading indicator reusable and improving layout organization.

<sup>Written for commit 7c155df5c7568c92845873715c799ce00f16d487. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

