### PR TITLE
🎨 Palette: Improve keyboard focus visibility and text contrast in Modals

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -66,3 +66,7 @@
 ## 2026-11-25 - Standardize Copy to Clipboard Interactions
 **Learning:** Raw analytical output (like ASCII correlation tables in modals) forces users to manually highlight and copy text. Additionally, clickable data cells lack explicit mouse discoverability without a `title` tooltip.
 **Action:** Always provide a dedicated "Copy Analysis" or "Copy to Clipboard" button with a temporal success state ("Copied!") when presenting raw analytical text to users. Furthermore, ensure any interactive element intended for copying (like `td` data cells) explicitly uses `title="Copy to clipboard"` to complement its `aria-label`.
+
+## 2026-12-10 - Keyboard Navigation in Custom Selects and Modals
+**Learning:** Found that `<select>` elements and secondary action buttons (like "Copy Analysis" or "Save to Gist") in modals often lose their default browser focus rings when styled with Tailwind (e.g., using `outline-none` or custom borders). This renders them completely inaccessible to keyboard users navigating via Tab.
+**Action:** Always ensure that custom-styled form inputs and interactive elements explicitly include `focus-visible:ring-2 focus-visible:ring-blue-500` to restore clear keyboard focus indicators without adding unintended visual outlines for mouse clicks.

--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -177,7 +177,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                               id="corr-method"
                               value={method}
                               onChange={(e) => setMethod(e.target.value as any)}
-                              className="w-24 px-2 py-1 bg-dark-bg border border-gray-600 rounded text-xs focus:border-blue-500 outline-none transition-colors text-white"
+                              className="w-24 px-2 py-1 bg-dark-bg border border-gray-600 rounded text-xs focus:border-blue-500 outline-none transition-colors text-white focus-visible:ring-2 focus-visible:ring-blue-500"
                             >
                               <option value="spearman">Spearman</option>
                               <option value="pearson">Pearson</option>
@@ -189,7 +189,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                               id="corr-alpha"
                               value={alpha}
                               onChange={(e) => setAlpha(Number(e.target.value))}
-                              className="w-24 px-2 py-1 bg-dark-bg border border-gray-600 rounded text-xs focus:border-blue-500 outline-none transition-colors text-white"
+                              className="w-24 px-2 py-1 bg-dark-bg border border-gray-600 rounded text-xs focus:border-blue-500 outline-none transition-colors text-white focus-visible:ring-2 focus-visible:ring-blue-500"
                             >
                               <option value={0.05}>0.05</option>
                               <option value={0.01}>0.01</option>
@@ -203,7 +203,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                               id="corr-alt"
                               value={alternative}
                               onChange={(e) => setAlternative(e.target.value as any)}
-                              className="w-24 px-2 py-1 bg-dark-bg border border-gray-600 rounded text-xs focus:border-blue-500 outline-none transition-colors text-white"
+                              className="w-24 px-2 py-1 bg-dark-bg border border-gray-600 rounded text-xs focus:border-blue-500 outline-none transition-colors text-white focus-visible:ring-2 focus-visible:ring-blue-500"
                             >
                               <option value="two-sided">Two-sided</option>
                               <option value="less">Less</option>
@@ -216,9 +216,9 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                       <table className="min-w-full mb-8">
                         <thead>
                           <tr className="border-b border-gray-800">
-                            <th scope="col" className="text-left text-xs text-gray-500 uppercase tracking-wider font-semibold py-2 px-1">Biomarker</th>
-                            <th scope="col" className="text-right text-xs text-gray-500 uppercase tracking-wider font-semibold py-2 px-1 w-24">P-Value</th>
-                            <th scope="col" className="text-right text-xs text-gray-500 uppercase tracking-wider font-semibold py-2 px-1 w-20">Coeff</th>
+                            <th scope="col" className="text-left text-xs text-gray-400 uppercase tracking-wider font-semibold py-2 px-1">Biomarker</th>
+                            <th scope="col" className="text-right text-xs text-gray-400 uppercase tracking-wider font-semibold py-2 px-1 w-24">P-Value</th>
+                            <th scope="col" className="text-right text-xs text-gray-400 uppercase tracking-wider font-semibold py-2 px-1 w-20">Coeff</th>
                           </tr>
                         </thead>
                         <tbody className="divide-y divide-gray-800">
@@ -243,7 +243,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                             <tr>
                               <td colSpan={3} className="py-12 text-center text-sm text-gray-400 border border-dashed border-gray-700 rounded bg-white/5" role="status" aria-live="polite">
                                 No significant correlations found.<br/>
-                                <span className="text-xs mt-2 block text-gray-500">Try increasing the Alpha threshold or changing the hypothesis.</span>
+                                <span className="text-xs mt-2 block text-gray-400">Try increasing the Alpha threshold or changing the hypothesis.</span>
                               </td>
                             </tr>
                           )}

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -472,7 +472,7 @@ export default React.memo<NavProps>(
                           setIsCopied(true);
                           setTimeout(() => setIsCopied(false), 2000);
                         }}
-                        className="px-4 py-2 border border-gray-600 text-gray-300 rounded hover:bg-gray-700 hover:text-white flex items-center justify-center gap-2 transition-colors"
+                        className="px-4 py-2 border border-gray-600 text-gray-300 rounded hover:bg-gray-700 hover:text-white flex items-center justify-center gap-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                         aria-label="Copy analysis to clipboard"
                       >
                         {isCopied ? (
@@ -487,7 +487,7 @@ export default React.memo<NavProps>(
                       </button>
                       <button
                         type="button"
-                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                         disabled={isGistLoading}
                         aria-busy={isGistLoading}
                         onClick={async () => {

--- a/src/layout/PValue.tsx
+++ b/src/layout/PValue.tsx
@@ -132,7 +132,7 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                         setIsCopied(true);
                         setTimeout(() => setIsCopied(false), 2000);
                       }}
-                      className="px-4 py-2 border border-gray-600 text-gray-300 rounded hover:bg-gray-700 hover:text-white flex items-center justify-center gap-2 transition-colors"
+                      className="px-4 py-2 border border-gray-600 text-gray-300 rounded hover:bg-gray-700 hover:text-white flex items-center justify-center gap-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                       aria-label="Copy analysis to clipboard"
                     >
                       {isCopied ? (


### PR DESCRIPTION
## What
- Upgraded correlation modal table headers and empty state subtext from `text-gray-500` to `text-gray-400` for better visibility in the dark theme.
- Added `focus-visible:ring-2 focus-visible:ring-blue-500` and `focus:outline-none` classes to interactive `<select>` inputs in `Correlation.tsx` and secondary action buttons (`Copy Analysis`, `Save to Gist`) across `Nav.tsx` and `PValue.tsx`.
- Recorded a new critical learning in `.Jules/palette.md` noting the importance of restoring browser focus rings on custom-styled elements.

## Why
Custom Tailwind styles (like `outline-none`) often strip away default browser focus indicators, making the application inaccessible to users navigating via keyboard (Tab). The contrast ratios for `text-gray-500` were also failing WCAG guidelines against the very dark modal backgrounds.

## Accessibility
- Restores robust keyboard navigation support for complex modal interactions.
- Meets WCAG AA text contrast standards for secondary information and table headers.

## Before/After
*(Verified via Playwright screenshot automation - inputs now show clear blue rings when focused.)*

---
*PR created automatically by Jules for task [17826645701151380264](https://jules.google.com/task/17826645701151380264) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves keyboard focus visibility and dark-theme text contrast in modals to restore accessible navigation and meet WCAG AA. Users can now tab through selects and secondary actions with clear focus rings.

- **Bug Fixes**
  - Added visible focus styles to modal `<select>` inputs and secondary buttons (“Copy Analysis”, “Save to Gist”) in `Correlation.tsx`, `Nav.tsx`, and `PValue.tsx`.
  - Increased contrast in correlation modal: table headers and empty-state subtext from `text-gray-500` to `text-gray-400`.
  - Documented the guideline in `.Jules/palette.md` to always restore focus indicators on custom-styled controls.

<sup>Written for commit ab7ea6ec0620f1b26ac4472a1c6e4764a0ea070a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

