### PR TITLE
🎨 Palette: Standardize Copy to Clipboard Interactions for Correlation Tables

### DIFF
--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useMemo } from "react";
 import { Dialog, Transition } from "@headlessui/react";
-import { XMarkIcon } from "@heroicons/react/24/outline";
+import { XMarkIcon, ClipboardDocumentIcon } from "@heroicons/react/24/outline";
 import { useAtomValue } from "jotai";
 import {
   notesAtom,
@@ -24,6 +24,7 @@ interface CorrelationResult {
 }
 
 const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorrelationProps) => {
+  const [isCopied, setIsCopied] = React.useState(false);
   const notes = useAtomValue(notesAtom);
   const data = useAtomValue(dataAtom); // Access raw data
   const alpha = 0.05;
@@ -182,14 +183,41 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                   <Dialog.Title className="text-lg font-medium leading-6 truncate pr-2">
                     Correlations: {biomarkerId}
                   </Dialog.Title>
-                  <button
-                    onClick={onClose}
-                    className="text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded shrink-0"
-                    aria-label="Close dialog"
-                    title="Close dialog"
-                  >
-                    <XMarkIcon className="h-6 w-6" />
-                  </button>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {correlations && correlations.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const header = "Supplement\tP-Value\tRho\n";
+                          const rows = correlations.map(item => `${item.name}\t${item.pValue.toFixed(4)}\t${item.rho.toFixed(3)}`).join("\n");
+                          navigator.clipboard.writeText(header + rows);
+                          setIsCopied(true);
+                          setTimeout(() => setIsCopied(false), 2000);
+                        }}
+                        className="px-2 py-1 border border-gray-600 text-xs text-gray-300 rounded hover:bg-gray-700 hover:text-white flex items-center justify-center gap-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        aria-label="Copy analysis to clipboard"
+                        title="Copy analysis to clipboard"
+                      >
+                        {isCopied ? (
+                          <>
+                            <ClipboardDocumentIcon className="h-4 w-4" /> Copied!
+                          </>
+                        ) : (
+                          <>
+                            <ClipboardDocumentIcon className="h-4 w-4" /> Copy
+                          </>
+                        )}
+                      </button>
+                    )}
+                    <button
+                      onClick={onClose}
+                      className="text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded shrink-0"
+                      aria-label="Close dialog"
+                      title="Close dialog"
+                    >
+                      <XMarkIcon className="h-6 w-6" />
+                    </button>
+                  </div>
                 </div>
 
                 <div className="overflow-y-auto flex-grow p-6 pt-0">

--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from "react";
 import { Dialog, Transition } from "@headlessui/react";
-import { XMarkIcon } from "@heroicons/react/24/outline";
+import { XMarkIcon, ClipboardDocumentIcon } from "@heroicons/react/24/outline";
 import { useAtom, useAtomValue } from "jotai";
 import { dataAtom, rankedDataMapAtom, nonInferredDataAtom } from "../atom/dataAtom";
 import { correlationAlphaAtom, correlationAlternativeAtom, correlationMethodAtom } from "../atom/correlationAtom";
@@ -18,6 +18,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
   const [alpha, setAlpha] = useAtom(correlationAlphaAtom);
   const [alternative, setAlternative] = useAtom(correlationAlternativeAtom);
   const [method, setMethod] = useAtom(correlationMethodAtom);
+  const [isCopied, setIsCopied] = React.useState(false);
 
   const entries = React.useMemo(() => {
     if (!Array.isArray(data) || !target) {
@@ -148,10 +149,35 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                   <div className="flex h-full flex-col overflow-y-scroll bg-[#222222] border-l border-gray-700 shadow-xl">
                     <div className="px-4 py-6 sm:px-6">
                       <div className="flex items-start justify-between">
-                        <Dialog.Title className="text-base font-semibold leading-6 text-white">
+                        <Dialog.Title className="text-base font-semibold leading-6 text-white truncate pr-2">
                           Correlation Analysis: <span className="text-blue-400">{target}</span>
                         </Dialog.Title>
-                        <div className="ml-3 flex h-7 items-center">
+                        <div className="ml-3 flex items-center gap-2 shrink-0">
+                          {entries && entries.length > 0 && (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                const header = "Biomarker\tP-Value\tCoeff\n";
+                                const rows = entries.map(entry => `${entry[0]}\t${entry[2].toFixed(6)}\t${entry[3].toFixed(4)}`).join("\n");
+                                navigator.clipboard.writeText(header + rows);
+                                setIsCopied(true);
+                                setTimeout(() => setIsCopied(false), 2000);
+                              }}
+                              className="px-2 py-1 border border-gray-600 text-xs text-gray-300 rounded hover:bg-gray-700 hover:text-white flex items-center justify-center gap-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                              aria-label="Copy analysis to clipboard"
+                              title="Copy analysis to clipboard"
+                            >
+                              {isCopied ? (
+                                <>
+                                  <ClipboardDocumentIcon className="h-4 w-4" /> Copied!
+                                </>
+                              ) : (
+                                <>
+                                  <ClipboardDocumentIcon className="h-4 w-4" /> Copy
+                                </>
+                              )}
+                            </button>
+                          )}
                           <button
                             type="button"
                             className="relative rounded-md text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"


### PR DESCRIPTION
💡 What: Added a dedicated "Copy Analysis" button to the Correlation and Biomarker Correlation dialog tables.
🎯 Why: Raw analytical text forces users to manually highlight and copy. This feature enables one-click copying of tabulated correlation results (TSV formatted) to easily paste into spreadsheets or notes, accompanied by a temporal "Copied!" success state for immediate feedback.
📸 Before/After: Visual improvements captured in pre-commit frontend verification screenshots. 
♿ Accessibility: The new buttons are implemented as standard `<button>` elements with `aria-label`s, sync'd `title` tooltips, semantic icons, and consistent `focus-visible:ring-2` keyboard focus styles.

---
*PR created automatically by Jules for task [13098035708745834263](https://jules.google.com/task/13098035708745834263) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Copy Analysis” button to the Correlation and Biomarker Correlation dialogs to copy TSV-formatted results for easy pasting into spreadsheets, with a brief “Copied!” confirmation. Improves speed of exporting analysis while keeping interactions accessible and consistent.

- **New Features**
  - Added a Copy button to both dialogs; rendered only when results exist.
  - Copies TSV with headers (Biomarker/Supplement, P-Value, Coeff/Rho) and formatted values.
  - Shows a 2s “Copied!” state for feedback.
  - Uses standard `<button>` with `aria-label`, `title`, consistent focus styles, and `ClipboardDocumentIcon` from `@heroicons/react`.

<sup>Written for commit ededf0b62f51865c5f54af16691571b85ec35f6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

