### PR TITLE
🎨 Palette: Improve copy to clipboard visual feedback

### DIFF
--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useMemo } from "react";
 import { Dialog, Transition } from "@headlessui/react";
-import { XMarkIcon, ClipboardDocumentIcon } from "@heroicons/react/24/outline";
+import { XMarkIcon, ClipboardDocumentIcon, CheckIcon } from "@heroicons/react/24/outline";
 import { useAtomValue } from "jotai";
 import {
   notesAtom,
@@ -182,13 +182,17 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                           setIsCopied(true);
                           setTimeout(() => setIsCopied(false), 2000);
                         }}
-                        className="px-2 py-1 border border-gray-600 text-xs text-gray-300 rounded hover:bg-gray-700 hover:text-white flex items-center justify-center gap-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        className={`px-2 py-1 border text-xs rounded flex items-center justify-center gap-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 min-w-[70px] ${
+                          isCopied
+                            ? "border-green-600 text-green-400 bg-green-900/20"
+                            : "border-gray-600 text-gray-300 hover:bg-gray-700 hover:text-white"
+                        }`}
                         aria-label="Copy analysis to clipboard"
                         title="Copy analysis to clipboard"
                       >
                         {isCopied ? (
                           <>
-                            <ClipboardDocumentIcon className="h-4 w-4" /> Copied!
+                            <CheckIcon className="h-4 w-4" /> Copied!
                           </>
                         ) : (
                           <>

--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from "react";
 import { Dialog, Transition } from "@headlessui/react";
-import { XMarkIcon, ClipboardDocumentIcon } from "@heroicons/react/24/outline";
+import { XMarkIcon, ClipboardDocumentIcon, CheckIcon } from "@heroicons/react/24/outline";
 import { useAtom, useAtomValue } from "jotai";
 import { dataAtom, rankedDataMapAtom, nonInferredDataAtom } from "../atom/dataAtom";
 import { correlationAlphaAtom, correlationAlternativeAtom, correlationMethodAtom } from "../atom/correlationAtom";
@@ -163,13 +163,17 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                                 setIsCopied(true);
                                 setTimeout(() => setIsCopied(false), 2000);
                               }}
-                              className="px-2 py-1 border border-gray-600 text-xs text-gray-300 rounded hover:bg-gray-700 hover:text-white flex items-center justify-center gap-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                            className={`px-2 py-1 border text-xs rounded flex items-center justify-center gap-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 min-w-[70px] ${
+                              isCopied
+                                ? "border-green-600 text-green-400 bg-green-900/20"
+                                : "border-gray-600 text-gray-300 hover:bg-gray-700 hover:text-white"
+                            }`}
                               aria-label="Copy analysis to clipboard"
                               title="Copy analysis to clipboard"
                             >
                               {isCopied ? (
                                 <>
-                                  <ClipboardDocumentIcon className="h-4 w-4" /> Copied!
+                                <CheckIcon className="h-4 w-4" /> Copied!
                                 </>
                               ) : (
                                 <>

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -7,6 +7,7 @@ import {
   MagnifyingGlassIcon,
   TrashIcon,
   ClipboardDocumentIcon,
+  CheckIcon,
 } from "@heroicons/react/24/outline";
 import { tags } from "../processors";
 import { askBioMarkers } from "../service/askAI";
@@ -472,12 +473,16 @@ export default React.memo<NavProps>(
                           setIsCopied(true);
                           setTimeout(() => setIsCopied(false), 2000);
                         }}
-                        className="px-4 py-2 border border-gray-600 text-gray-300 rounded hover:bg-gray-700 hover:text-white flex items-center justify-center gap-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    className={`px-4 py-2 border rounded flex items-center justify-center gap-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 min-w-[160px] ${
+                      isCopied
+                        ? "border-green-600 text-green-400 bg-green-900/20"
+                        : "border-gray-600 text-gray-300 hover:bg-gray-700 hover:text-white"
+                    }`}
                         aria-label="Copy analysis to clipboard"
                       >
                         {isCopied ? (
                           <>
-                            <ClipboardDocumentIcon className="h-5 w-5" /> Copied!
+                        <CheckIcon className="h-5 w-5" /> Copied!
                           </>
                         ) : (
                           <>

--- a/src/layout/PValue.tsx
+++ b/src/layout/PValue.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from "react";
 import { Dialog, Transition } from "@headlessui/react";
-import { XMarkIcon, ClipboardDocumentIcon } from "@heroicons/react/24/outline";
+import { XMarkIcon, ClipboardDocumentIcon, CheckIcon } from "@heroicons/react/24/outline";
 import { useAtomValue } from "jotai";
 import { rankedDataMapAtom } from "../atom/dataAtom";
 import { correlationAlphaAtom, correlationAlternativeAtom, correlationMethodAtom } from "../atom/correlationAtom";
@@ -132,12 +132,16 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                         setIsCopied(true);
                         setTimeout(() => setIsCopied(false), 2000);
                       }}
-                      className="px-4 py-2 border border-gray-600 text-gray-300 rounded hover:bg-gray-700 hover:text-white flex items-center justify-center gap-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    className={`px-4 py-2 border rounded flex items-center justify-center gap-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 min-w-[160px] ${
+                      isCopied
+                        ? "border-green-600 text-green-400 bg-green-900/20"
+                        : "border-gray-600 text-gray-300 hover:bg-gray-700 hover:text-white"
+                    }`}
                       aria-label="Copy analysis to clipboard"
                     >
                       {isCopied ? (
                         <>
-                          <ClipboardDocumentIcon className="h-5 w-5" /> Copied!
+                        <CheckIcon className="h-5 w-5" /> Copied!
                         </>
                       ) : (
                         <>


### PR DESCRIPTION
**What:** Updated the "Copy Analysis" and "Copy" buttons across `PValue.tsx`, `Correlation.tsx`, `BiomarkerCorrelation.tsx`, and `Nav.tsx` to display a `CheckIcon` and apply green success classes (`border-green-600 text-green-400 bg-green-900/20`) when text is successfully copied. Added a `min-w` to prevent layout shift.
**Why:** Improves interaction feedback. Previously, the buttons only changed text from "Copy" to "Copied!". This visual enhancement gives users immediate, unambiguous confirmation that their action succeeded without causing UI jank.
**Accessibility:** Retains proper ARIA attributes and focus styles while enhancing visual cues for mouse and screen users.

---
*PR created automatically by Jules for task [2243573404935454097](https://jules.google.com/task/2243573404935454097) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve copy-to-clipboard feedback across the app. Buttons now show a checkmark and success styling on copy, and keep their width to avoid layout shift.

- **New Features**
  - On copy success, swap to `CheckIcon` and apply green success styles.
  - Add `min-w` to copy buttons (`70px` or `160px`) to prevent layout shift.
  - Preserve ARIA labels and focus rings.

<sup>Written for commit 83bf24470633ad083d7981a095c6f586a547ed4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

