### PR TITLE
refactor: extract PValueProps to separate types file

### DIFF
--- a/src/layout/PValue.tsx
+++ b/src/layout/PValue.tsx
@@ -6,11 +6,7 @@ import { rankedDataMapAtom } from "../atom/dataAtom";
 import { correlationAlphaAtom, correlationAlternativeAtom, correlationMethodAtom } from "../atom/correlationAtom";
 import { BioMarker } from "../types/biomarker";
 import { calculateSpearmanRanked, calculatePearson } from "../processors/stats";
-
-interface PValueProps {
-  comparedSourceTarget: BioMarker[] | null;
-  onClose: () => void;
-}
+import { PValueProps } from "./PValue.types";
 
 export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
   const [isCopied, setIsCopied] = React.useState(false);

--- a/src/layout/PValue.types.ts
+++ b/src/layout/PValue.types.ts
@@ -1,0 +1,6 @@
+import { BioMarker } from "../types/biomarker";
+
+export interface PValueProps {
+  comparedSourceTarget: BioMarker[] | null;
+  onClose: () => void;
+}


### PR DESCRIPTION
The Issue: The `PValueProps` interface was defined directly inside `src/layout/PValue.tsx`.

The Fix: Created `src/layout/PValue.types.ts`, moved the interface there, and updated imports in `src/layout/PValue.tsx`.

The Benefit: Decouples TypeScript type definitions from the UI component, making the code cleaner and allowing the interface to be reused across the application if necessary.

---
*PR created automatically by Jules for task [6045699311803586528](https://jules.google.com/task/6045699311803586528) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the `PValueProps` interface out of `src/layout/PValue.tsx` into `src/layout/PValue.types.ts` and updated the component to import it. Improves code organization and enables reuse of the prop type with no behavior changes.

<sup>Written for commit 104677f249784eedd50dc6694e247e2a37a041a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

