### PR TITLE
⚡ Bolt: [performance improvement] Optimize Array Allocation in BiomarkerCorrelation

### DIFF
--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -47,22 +47,39 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
 
     // Optimization: Hoist invariant calculations outside the loop
     // 1. Identify valid indices: where biomarker value > 0 AND note exists
-    const validIndices: number[] = [];
-    const filteredBiomarkerValues: number[] = [];
+    // Pre-allocate typed arrays to avoid Array.push() overhead in the hot loop
+    const maxLen = rawValues.length;
+    const validIndicesArray = new Int32Array(maxLen);
+    const filteredBiomarkerValuesArray = new Float64Array(maxLen);
+    let count = 0;
 
-    rawValues.forEach((val: any, index) => {
-      const numVal = Number(val);
-      if (!isNaN(numVal) && numVal > 0 && index < noteValues.length) {
-          validIndices.push(index);
-          filteredBiomarkerValues.push(numVal);
+    for (let index = 0; index < maxLen; index++) {
+      const val = rawValues[index];
+      if (val !== null && val !== undefined) {
+        const numVal = Number(val);
+        if (!isNaN(numVal) && numVal > 0 && index < noteValues.length) {
+          validIndicesArray[count] = index;
+          filteredBiomarkerValuesArray[count] = numVal;
+          count++;
+        }
       }
-    });
+    }
+
+    const validIndices = validIndicesArray.subarray(0, count);
+    const filteredBiomarkerValues = filteredBiomarkerValuesArray.subarray(0, count);
 
     // If we don't have enough data points, we can't correlate
-    if (validIndices.length < 3) return [];
+    if (count < 3) return [];
 
     // Check variation in biomarker values once
-    const hasBiomarkerVariation = filteredBiomarkerValues.some(v => v !== filteredBiomarkerValues[0]);
+    let hasBiomarkerVariation = false;
+    const firstBioVal = filteredBiomarkerValues[0];
+    for (let i = 1; i < count; i++) {
+      if (filteredBiomarkerValues[i] !== firstBioVal) {
+        hasBiomarkerVariation = true;
+        break;
+      }
+    }
     if (!hasBiomarkerVariation) return [];
 
     // Rank the filtered biomarker values once
@@ -76,11 +93,10 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
     const suppVectors = new Map<string, Int8Array>();
 
     uniqueSupplements.forEach(supp => {
-      suppVectors.set(supp, new Int8Array(validIndices.length));
+      suppVectors.set(supp, new Int8Array(count));
     });
 
-    const numValid = validIndices.length;
-    for (let k = 0; k < numValid; k++) {
+    for (let k = 0; k < count; k++) {
       const i = validIndices[k];
       const note = noteValues[i];
       if (note && note.supps) {
@@ -100,7 +116,7 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
       // Check if there is variation in the supplement vector
       const firstVal = filteredSuppVector[0];
       let hasSuppVariation = false;
-      for (let k = 1; k < numValid; k++) {
+      for (let k = 1; k < count; k++) {
         if (filteredSuppVector[k] !== firstVal) {
           hasSuppVariation = true;
           break;

--- a/src/processors/stats.ts
+++ b/src/processors/stats.ts
@@ -221,7 +221,7 @@ export function rankBinaryData(arr: number[] | Int8Array): Float64Array {
  * Calculates the ranks of the input array.
  * Ties are assigned the average rank.
  */
-export function rankData(arr: number[]): Float64Array {
+export function rankData(arr: number[] | Float64Array): Float64Array {
   const n = arr.length;
   // Optimization: use a typed array of indices to avoid allocating `{v, i}` objects
   const indices = new Int32Array(n);


### PR DESCRIPTION
💡 What: Replaced standard `Array.push()` usage inside the `useMemo` computation loop of `BiomarkerCorrelation.tsx` with pre-allocated `Float64Array` and `Int32Array` arrays. The downstream logic was also updated to slice the active `subarray()` based on a counter instead of using generic Array properties. `rankData` in `stats.ts` was updated to support `Float64Array` natively without copying.

🎯 Why: During loop accumulation, dynamically resizing arrays creates intermediate arrays and closure overhead which causes expensive memory allocations and garbage collection. Pre-allocating typed arrays forces memory contiguity and avoids this penalty inside nested hot loops.

📊 Impact: Reduces intermediate memory allocation drastically and speeds up rendering paths that invoke correlation updates with many valid entries.

🔬 Measurement: Verify the change by running `npx playwright test`. Benchmark comparisons typically show large latency reductions when allocating flat Float64Arrays compared to `Array.push()` chains for identical numeric data sizes.

---
*PR created automatically by Jules for task [14671520380978203794](https://jules.google.com/task/14671520380978203794) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized biomarker correlation by replacing push-based arrays with pre-allocated typed arrays to reduce allocations and speed up renders. Updated `rankData` to accept `Float64Array` to avoid copying.

- **Refactors**
  - Use `Int32Array` and `Float64Array` with a `count` and `subarray()` instead of `Array.push()` inside the hot loop.
  - Replace `some()` with a simple loop for variation checks on typed arrays.
  - Build supplement vectors with `count`-based sizing.
  - Allow `rankData` to accept `Float64Array`.

<sup>Written for commit 135d3b0cba7bc4586d5cee0eb217e69e11e43683. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

