### PR TITLE
Refactor: Extract CorrelationProps into dedicated types file

### DIFF
--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -5,11 +5,7 @@ import { useAtom, useAtomValue } from "jotai";
 import { dataAtom, rankedDataMapAtom, nonInferredDataAtom } from "../atom/dataAtom";
 import { correlationAlphaAtom, correlationAlternativeAtom, correlationMethodAtom } from "../atom/correlationAtom";
 import { calculateSpearmanRanked, calculatePearson } from "../processors/stats";
-
-interface CorrelationProps {
-  target: string | null;
-  onClose: () => void;
-}
+import { CorrelationProps } from "./Correlation.types";
 
 export default React.memo(({ target, onClose }: CorrelationProps) => {
   const data = useAtomValue(nonInferredDataAtom);

--- a/src/layout/Correlation.types.ts
+++ b/src/layout/Correlation.types.ts
@@ -1,0 +1,4 @@
+export interface CorrelationProps {
+  target: string | null;
+  onClose: () => void;
+}


### PR DESCRIPTION
The Issue: The `CorrelationProps` interface was defined directly inside `src/layout/Correlation.tsx`.

The Fix: Created `src/layout/Correlation.types.ts`, moved the TypeScript interface there, and updated the import in `src/layout/Correlation.tsx`.

The Benefit: Decouples the type definition from the UI component file, adhering to the project's convention of placing bulky or dedicated type definitions in separate matching files.

---
*PR created automatically by Jules for task [13501678890759031219](https://jules.google.com/task/13501678890759031219) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `CorrelationProps` from `src/layout/Correlation.tsx` into `src/layout/Correlation.types.ts` to separate types from the component and match project conventions. Updated `Correlation` to import the interface, improving readability and reuse.

<sup>Written for commit 60fff12cd766ee72ae5d6d1ffdb35714cd1337df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

