### PR TITLE
Fix stale chart renders by enforcing notMerge on setOption

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -77,7 +77,7 @@ export default memo(({ data, keys }: ChartProps) => {
               connectNulls: true,
             },
           ],
-        })
+        }, { notMerge: true })
       }
     }
     return () => {

--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -145,7 +145,7 @@ export default memo(({ data, keys }: ChartProps) => {
       .reduce((result: any[][], entry) => {
         if (entry) {
           const [key, values] = entry
-          values.forEach((v, i) => {
+          values.forEach((v: number | null, i: number) => {
             if (!result[i]) {
               result[i] = [labels[i].slice(0, -2)]
             }
@@ -217,7 +217,7 @@ export default memo(({ data, keys }: ChartProps) => {
             series: [{ symbolSize: 40 }],
             dataZoom: options.dataZoom,
           },
-          // { notMerge: true }
+          { notMerge: true }
         )
         // console.log("ch1", instance.getOption());
       }

--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -61,7 +61,7 @@ export default memo(({ data, keys }: ScatterChartProps) => {
         name: key,
         type: 'scatter',
         yAxisIndex: index,
-        data: bioMarker ? bioMarker[1].map((value, i) => [formatTime(labels[i]), value]) : [],
+        data: bioMarker ? bioMarker[1].map((value: number | null, i: number) => [formatTime(labels[i]), value]) : [],
       }
     })
   }, [data, keys])


### PR DESCRIPTION
**The Issue:**
In `src/layout/Chart.tsx` and `src/layout/Chart2.tsx`, changing the active `keys` (biomarkers) sometimes resulted in old series data remaining visible on the chart because ECharts merges new options with the previous options by default.

**Discovery Signal:**
Scan 5 — setOption Correctness. Found that `instance.setOption()` was missing `{ notMerge: true }` in `Chart.tsx` and had it commented out in `Chart2.tsx`.

**context7 Reference:**
ECharts 5.6 docs for `echartsInstance.setOption(option, notMerge, lazyUpdate)` confirms that `notMerge: true` prevents option merging.

**The Fix:**
Added `{ notMerge: true }` as the second argument to `instance.setOption` calls in `Chart.tsx` and `Chart2.tsx`. Also typed iterators inside `Chart2.tsx` and `ScatterChart.tsx` processing biomarker values as `(value: number | null, i: number)` to resolve implicit `any` TypeScript errors caused by ECharts array contents that may contain nulls.

**The Benefit:**
Stale series from previous `keys` selections no longer bleed through on re-render, ensuring the chart strictly represents only the currently selected biomarkers.

---

### Visualization Proposals

**Proposal 1 of 3: Radar Chart — Tag Group Optimal Balance**
**ECharts type:** `radar`
**Which existing data it uses:** Uses `extra.optimality[]` pre-computed in `src/processors/post/range.ts` and the `dataAtom` filtered by `tagAtom`.
**What it reveals that current charts don't:** Shows whether all biomarkers within a specific tag group (e.g., all 9 Metabolic markers) are simultaneously within their optimal ranges at a single glance, rather than requiring the user to scan each table row individually.
**Where it would live:** New `src/layout/RadarChart.tsx`, rendered conditionally when a specific tag filter is active in `App.tsx` (e.g., replacing or supplementing the ScatterChart).
**Trigger / entry point:** The existing tag filter buttons in `Nav.tsx` already set `tagAtom`; the radar chart could auto-render when a single tag group is selected.
**Implementation complexity:** Low. The `extra.optimality[]` and `extra.range` are already computed; only a new ECharts `radar` option config mapping the latest test results to normalized axes is needed.
**ECharts 5.6.0 API confirmed via context7:** Yes (radar option checked).

**Proposal 2 of 3: Heatmap — Cross-Tag Correlation Matrix**
**ECharts type:** `heatmap`
**Which existing data it uses:** Uses the pairwise correlation results stored in `correlationAtom.ts`.
**What it reveals that current charts don't:** Provides a macro-level view of how different biological systems (tag groups) influence each other (e.g., Liver vs. Lipid markers), revealing hidden systemic relationships that are hard to spot in a 1-to-1 linear table format.
**Where it would live:** A dedicated "Correlation Matrix" modal or a new section below the main table in `App.tsx`.
**Trigger / entry point:** A new "View Matrix" button next to the existing "Correlation Analysis" tools.
**Implementation complexity:** Medium. Requires mapping the 1D pairwise correlation results from `correlationAtom` into a 2D matrix structure suitable for the `heatmap` series, but no new statistical processing is required.
**ECharts 5.6.0 API confirmed via context7:** Yes (heatmap and visualMap options checked).

**Proposal 3 of 3: Boxplot — Historical Biomarker Distribution**
**ECharts type:** `boxplot`
**Which existing data it uses:** Uses the historical time-series values array (`number[]`) for each `BioMarker` from `dataAtom`.
**What it reveals that current charts don't:** Highlights the overall distribution, median drift, and historical outliers of a single biomarker across all time points, abstracting away the noise of high-frequency day-to-day fluctuations shown in the LineChart.
**Where it would live:** As a secondary tab or an expanded view inside the existing table row expansion component (`LineChart.tsx` context).
**Trigger / entry point:** A toggle button (e.g., "Line / Boxplot") within the expanded table row for a specific biomarker.
**Implementation complexity:** High. Requires using the `ecStat` or a custom processor to calculate the Q1, Median, Q3, and outliers from the raw `number[]` arrays, dealing with null values along the way.
**ECharts 5.6.0 API confirmed via context7:** Yes (boxplot series checked).

Recommended implementation order: Proposal 1 first (highest insight, lowest effort), then Proposal 2, then Proposal 3.

---
*PR created automatically by Jules for task [6292200376136779460](https://jules.google.com/task/6292200376136779460) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale chart renders by calling `echarts` setOption with `{ notMerge: true }`, so charts only show the currently selected biomarkers. Also clarifies TypeScript iterators to handle null values.

- **Bug Fixes**
  - Enforce `{ notMerge: true }` in `instance.setOption(...)` in `src/layout/Chart.tsx` and `src/layout/Chart2.tsx` to prevent old series from persisting when `keys` change.
  - Add explicit `(value: number | null, i: number)` iterator types in `src/layout/Chart2.tsx` and `src/layout/ScatterChart.tsx` to handle nulls and remove implicit `any` errors.

<sup>Written for commit 871b01a2fe555dd84cc7e695e3f29e3be5133b38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

