### PR TITLE
Fix ScatterChart null handling & Dark theme tooltip polishing

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -1,0 +1,72 @@
+---
+
+**Proposal 1 of 3: Tag Group vs Optimal Range Radar**
+
+**ECharts type:** `radar`
+
+**Which existing data it uses:**
+It uses `extra.optimality[]` pre-computed in `src/processors/post/range.ts`, the `extra.tag` field for filtering by a specific group (e.g., `2-Metabolic`), and `extra.range` to format tooltip bounds.
+
+**What it reveals that current charts don't:**
+It shows whether all biomarkers in a specific tag group (like all 9 Metabolic markers) are simultaneously within their optimal ranges at a glance. Instead of requiring the user to scan each table row individually and track them over time, this provides a single "shape of health" for a specific subsystem at the latest time point.
+
+**Where it would live:**
+A new `src/layout/RadarChart.tsx` component, rendered dynamically below the main ScatterChart when a specific tag filter is active (via `tagAtom` in `App.tsx` or `Nav.tsx`).
+
+**Trigger / entry point:**
+The existing tag filter buttons in `Nav.tsx` already set `tagAtom`; the radar chart could auto-render when a single valid tag group is selected.
+
+**Implementation complexity:** Low
+`extra.optimality[]` and `extra.range` are already computed; only a new ECharts `radar` option config mapped from the filtered `visibleDataAtom` is needed.
+
+**ECharts 5.6.0 API confirmed via context7:** yes - `radar` and `series-radar` options verified.
+
+---
+
+**Proposal 2 of 3: Biomarker Correlation Matrix Heatmap**
+
+**ECharts type:** `heatmap`
+
+**Which existing data it uses:**
+It uses the pre-computed correlations available in the `correlationAtom` (which uses `correlationMethodAtom` for Spearman vs Pearson) and the `rankedDataMapAtom` cache for fast data fetching.
+
+**What it reveals that current charts don't:**
+It instantly visualizes the strength and direction of relationships across all tracked biomarkers simultaneously. Currently, users must manually select pairs or read the raw text output in the `BiomarkerCorrelation` table to find strong relationships. A heatmap provides a global view of how all markers influence each other (e.g., how metabolic markers cluster).
+
+**Where it would live:**
+A new `src/layout/CorrelationHeatmap.tsx` component, replacing or living alongside the existing `BiomarkerCorrelation.tsx` table when viewing the correlation analysis page.
+
+**Trigger / entry point:**
+A toggle button in the correlation analysis view to switch between the "Table View" (current) and "Matrix View" (new heatmap).
+
+**Implementation complexity:** Medium
+The math is already done and cached via `correlationAtom`. The challenge is formatting the NxN matrix data correctly for the ECharts `heatmap` series and ensuring the visual map scaling correctly handles [-1, 1] correlation bounds.
+
+**ECharts 5.6.0 API confirmed via context7:** yes - `series-heatmap` and `visualMap` options verified.
+
+---
+
+**Proposal 3 of 3: Single Biomarker Drift Boxplot**
+
+**ECharts type:** `boxplot`
+
+**Which existing data it uses:**
+It uses the raw values array (`bioMarker[1]`) for a single biomarker across all time points, ignoring nulls.
+
+**What it reveals that current charts don't:**
+It shows the distribution (min, max, median, quartiles) and outliers of a single biomarker over time. While the LineChart shows the exact path, a boxplot clearly identifies if a marker has high variance (widely spread boxes) or is tightly controlled, and instantly flags historical outlier readings that might represent acute events rather than chronic drift.
+
+**Where it would live:**
+A new `src/layout/BoxplotChart.tsx`, optionally rendered as a secondary tab inside the expanded row view of `Table.tsx` (next to the current `LineChart.tsx`).
+
+**Trigger / entry point:**
+A small toggle inside the expanded table row: "Line Chart" vs "Distribution (Boxplot)".
+
+**Implementation complexity:** Low
+We only need to map the non-null values of the selected biomarker into the standard ECharts boxplot format. We can use the `@echarts-readymade/core` or `echarts-for-react` wrapper.
+
+**ECharts 5.6.0 API confirmed via context7:** yes - `series-boxplot` option verified.
+
+---
+
+Recommended implementation order: Proposal 2 first (highest insight, medium effort), then Proposal 1, then Proposal 3.

--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -19,6 +19,24 @@ const echartsOptions = {
   series: [] as any[],
   tooltip: {
     trigger: 'item',
+    backgroundColor: '#111111',
+    borderColor: '#3a3a3a80',
+    textStyle: {
+      color: '#f0f0f0'
+    },
+    formatter: (params: any) => {
+      const { seriesName, value } = params
+      const date = value[0]
+      const val = value[1]
+      const unit = value[2] ? ` ${value[2]}` : ''
+      return `
+        <div style="max-width: 250px; white-space: normal; line-height: 1.4;">
+          <div style="font-size: 12px; color: #999;">${date}</div>
+          <div style="font-weight: bold; margin-top: 4px;">${seriesName}</div>
+          <div style="margin-top: 4px;">${val}${unit}</div>
+        </div>
+      `
+    }
   },
   legend: {
     data: [] as string[],
@@ -57,11 +75,30 @@ export default memo(({ data, keys }: ScatterChartProps) => {
 
     return keys.map((key, index) => {
       const bioMarker = dataMap.get(key)
+      if (!bioMarker) {
+        return {
+          name: key,
+          type: 'scatter',
+          yAxisIndex: index,
+          data: [],
+        }
+      }
+
+      const values = bioMarker[1]
+      const unit = bioMarker[2]
+
+      const validData = []
+      for (let i = 0; i < values.length; i++) {
+        if (values[i] !== null && values[i] !== undefined) {
+          validData.push([formatTime(labels[i]), values[i], unit])
+        }
+      }
+
       return {
         name: key,
         type: 'scatter',
         yAxisIndex: index,
-        data: bioMarker ? bioMarker[1].map((value: number | null, i: number) => [formatTime(labels[i]), value]) : [],
+        data: validData,
       }
     })
   }, [data, keys])


### PR DESCRIPTION
Fixes an issue where `ScatterChart` would incorrectly pass null or undefined data values directly to ECharts, resulting in "0" or "NaN" artifacts in the UI and tooltip.

Additionally, this adds much-needed polish to the scatter tooltip to conform to the required dark theme. It now properly formats the numerical values alongside their specific measurement unit (`extra.unit`), removing ambiguity.

Also included is `PROPOSALS.md` answering the second part of the objective: 3 visualization ideas (Radar tag-groups, Correlation heatmap, Biomarker drift boxplot) validated against `ECharts 5.6.0` API documentation.

---
*PR created automatically by Jules for task [9661657814202896294](https://jules.google.com/task/9661657814202896294) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes null/undefined handling in `ScatterChart` to prevent 0/NaN points and updates the tooltip to a dark theme with unit-aware formatting. Also adds `PROPOSALS.md` with three `ECharts`-based visualization ideas.

- **Bug Fixes**
  - Filters out `null`/`undefined` values and safely handles missing series so only valid points are passed to `ECharts`.
  - Extends scatter data to include units for accurate tooltip output.

- **New Features**
  - Adds a dark-mode tooltip (custom HTML formatter) showing date, biomarker name, numeric value, and unit.
  - Introduces `PROPOSALS.md` with 3 validated ideas against `ECharts 5.6.0`: tag-group radar, correlation heatmap, and single-biomarker boxplot.

<sup>Written for commit e7bb24e59159a55a8515385a233269625a0dc97c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

