### PR TITLE
⚡ Bolt: [performance improvement] Optimize Chart rendering in Chart.tsx

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -44,22 +44,34 @@ export default memo(({ data, keys }: ChartProps) => {
     [keys],
   )
 
-  const dict = data
-    .filter(([key]) => keys.includes(key))
-    .reduce((result: Record<number, any>, [key, values]) => {
-      values.forEach((v, i) => {
-        if (!result[i]) {
-          result[i] = { d1: labels[i] }
-        }
+  const chartData = useMemo(() => {
+    // Optimization: use a local O(1) map for data lookups instead of O(N) array.find inside a map.
+    // This reduces lookup complexity from O(N*K) to O(N + K).
+    const dataMap = new Map()
+    for (let i = 0; i < data.length; i++) {
+      dataMap.set(data[i][0], data[i])
+    }
+
+    const dict = keys.reduce((result: Record<number, any>, key) => {
+      const entry = dataMap.get(key)
+      if (entry) {
+        const values = entry[1]
+        // Hoist the fieldKey resolution outside the inner loop to avoid O(K * L) overhead
         const k = valueList.find((entry) => entry.fieldName === key)
         if (k) {
-          result[i][k.fieldKey] = v
+          values.forEach((v: number | null, i: number) => {
+            if (!result[i]) {
+              result[i] = { d1: labels[i] }
+            }
+            result[i][k.fieldKey] = v
+          })
         }
-      })
+      }
       return result
     }, {})
 
-  const chartData = Object.values(dict)
+    return Object.values(dict)
+  }, [data, keys, valueList, labels])
 
   const ref = useRef<any>(null)
 


### PR DESCRIPTION
💡 What: Optimized the `Chart.tsx` rendering logic by replacing an $O(N \cdot K)$ `data.filter().includes()` call with an $O(N)$ single-pass `Map` creation and an $O(1)$ lookup. Additionally, the $O(K)$ `valueList.find` operation was hoisted outside the inner $O(L)$ `values.forEach` loop, and the entire `chartData` calculation was wrapped in a `useMemo` hook to prevent redundant computation across re-renders.

🎯 Why: The original implementation re-calculated the `dict` and `chartData` objects on every render, executing a nested loop structure where an $O(N \cdot K)$ filter was followed by an $O(K)$ lookup inside an $O(L)$ loop. This caused unnecessary processing overhead ($O(N \cdot K + K \cdot L \cdot K)$) when the underlying data (`data`, `keys`, `valueList`, `labels`) hadn't changed, potentially leading to sluggish UI responsiveness during user interactions or state updates.

📊 Impact: Reduces computational complexity of chart data preparation from $O(N \cdot K + K \cdot L \cdot K)$ to $O(N + K \cdot L)$ and eliminates redundant re-calculations on unrelated renders, significantly improving rendering performance.

🔬 Measurement: Verify the improvement by running the application, expanding a row to view the chart, and interacting with the UI. The chart should render correctly and UI responsiveness should be smooth. Run the test suite (`npx playwright test`) to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [15348040197235520402](https://jules.google.com/task/15348040197235520402) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized chart data preparation in `Chart.tsx` to reduce redundant work and speed up rendering. This replaces nested lookups with a single-pass map and memoizes the result to avoid recomputation on unrelated renders.

- **Refactors**
  - Built a `Map` from `data` for O(1) key lookups instead of `filter().includes()` and `find()`.
  - Hoisted `valueList.find` outside the inner `values.forEach`.
  - Wrapped `chartData` in `useMemo` with `[data, keys, valueList, labels]` dependencies.

<sup>Written for commit 112ea8e2ebc10bf8ea17fb524c53c37ee47f0023. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

