### PR TITLE
🎨 Palette: Improve keyboard accessibility for checkboxes

### DIFF
--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -416,7 +416,7 @@ export default React.memo<NavProps>(
                 </div>
                 <div className="hidden xl:flex items-center gap-2 w-full xl:w-auto">
                   <input
-                    className="h-4 w-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:ring-blue-500"
+                    className="h-4 w-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     type="checkbox"
                     checked={showOrigColumns}
                     onChange={onOriginValueToggle}

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -129,7 +129,7 @@ const TableRow = React.memo(
           <td className="p-2 border border-gray-700 text-center">
             <input
               type="checkbox"
-              className="w-4 h-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:ring-blue-500"
+              className="w-4 h-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
               name={name}
               aria-label={`Select ${name}`}
               title={`Select ${name}`}


### PR DESCRIPTION
💡 **What**: Replaced `focus:ring-blue-500` with `focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` on the "Origin values" checkbox in `Nav.tsx` and the row selection checkboxes in `Table.tsx`.
🎯 **Why**: Checkboxes were losing their default browser focus rings when styled with Tailwind due to the base `focus:ring-blue-500` without `outline-none`. This rendered them completely inaccessible or confusing to keyboard users navigating via Tab.
♿ **Accessibility**: Restores clear keyboard focus indicators for standard form inputs without adding unintended visual outlines for mouse clicks.

---
*PR created automatically by Jules for task [15825399917255106927](https://jules.google.com/task/15825399917255106927) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored clear keyboard focus indicators for checkboxes in the nav and table. Keyboard users now see a visible focus ring when tabbing, without unwanted outlines on mouse click.

- **Bug Fixes**
  - Updated checkbox styles in `src/layout/Nav.tsx` and `src/layout/Table.tsx` to use `focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` instead of `focus:ring-blue-500`.

<sup>Written for commit f1443b1895f5b6cc0e69e1ff1d2118b820128fbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

