### PR TITLE
🎨 Palette: Add aria-label to Save to Gist button

### DIFF
--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -509,6 +509,7 @@ export default React.memo<NavProps>(
                         className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                         disabled={isGistLoading}
                         aria-busy={isGistLoading}
+                        aria-label="Save analysis to Gist"
                         onClick={async () => {
                           setIsGistLoading(true)
                           setGistError(null)


### PR DESCRIPTION
💡 **What:** Added an `aria-label="Save analysis to Gist"` to the "Save to Gist" button in the AI correlation dialog (`src/layout/Nav.tsx`).

🎯 **Why:** The button's visible text dynamically changes between "Save to Gist" and "Saving..." with a spinner. Providing a stable, explicit `aria-label` ensures screen reader users have clear, unwavering context about what the button does regardless of its current state, improving overall accessibility.

📸 **Before/After:** No visual changes.

♿ **Accessibility:** Added `aria-label` to provide consistent and descriptive context for assistive technologies.

---
*PR created automatically by Jules for task [14981450064443164484](https://jules.google.com/task/14981450064443164484) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds aria-label "Save analysis to Gist" to the "Save to Gist" button so screen readers always announce its purpose, even when the button shows "Saving..." with a spinner. No visual changes; improves accessibility.

<sup>Written for commit 2b77cd4598db8ee6ddd9f6ac6909d492775c9e20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

