### PR TITLE
Fix overlapping multi-axis bug in ScatterChart

### DIFF
--- a/src/layout/BoxplotChart.tsx
+++ b/src/layout/BoxplotChart.tsx
@@ -1,0 +1,173 @@
+import React, { memo } from 'react'
+import ReactECharts from 'echarts-for-react'
+
+interface BoxplotChartProps {
+  name: string
+  values: number[]
+}
+
+const echartsOptions = {
+  style: { height: 300, width: '100%' },
+  theme: 'dark',
+  backgroundColor: 'transparent',
+  tooltip: {
+    trigger: 'item',
+    axisPointer: {
+      type: 'shadow'
+    }
+  },
+  grid: {
+    left: '10%',
+    right: '10%',
+    bottom: '15%'
+  },
+  xAxis: {
+    type: 'category',
+    data: ['Distribution'],
+    boundaryGap: true,
+    nameGap: 30,
+    splitArea: {
+      show: false
+    },
+    splitLine: {
+      show: false
+    }
+  },
+  yAxis: {
+    type: 'value',
+    name: 'Value',
+    splitArea: {
+      show: true
+    }
+  }
+}
+
+// Custom implementation of prepareBoxplotData to avoid ecStat version issues
+function prepareBoxplotData(data: number[][]) {
+  const boxData = []
+  const outliers = []
+
+  for (let i = 0; i < data.length; i++) {
+    const series = data[i].slice().sort((a, b) => a - b)
+    if (series.length === 0) continue
+
+    const min = series[0]
+    const max = series[series.length - 1]
+
+    // Simple percentile calculator
+    const getPercentile = (p: number) => {
+      const index = (series.length - 1) * p
+      const lower = Math.floor(index)
+      const upper = Math.ceil(index)
+      const weight = index - lower
+      if (upper >= series.length) return series[lower]
+      return series[lower] * (1 - weight) + series[upper] * weight
+    }
+
+    const q1 = getPercentile(0.25)
+    const median = getPercentile(0.5)
+    const q3 = getPercentile(0.75)
+    const iqr = q3 - q1
+
+    const lowerInnerFence = q1 - 1.5 * iqr
+    const upperInnerFence = q3 + 1.5 * iqr
+
+    const seriesOutliers = []
+    let actualMin = Number.MAX_VALUE
+    let actualMax = -Number.MAX_VALUE
+
+    for (let j = 0; j < series.length; j++) {
+      const val = series[j]
+      if (val < lowerInnerFence || val > upperInnerFence) {
+        seriesOutliers.push([i, val])
+      } else {
+        if (val < actualMin) actualMin = val
+        if (val > actualMax) actualMax = val
+      }
+    }
+
+    // In boxplot: [min, Q1, median, Q3, max]
+    // using actual min/max inside fences to draw whiskers
+    boxData.push([
+      actualMin === Number.MAX_VALUE ? min : actualMin,
+      q1,
+      median,
+      q3,
+      actualMax === -Number.MAX_VALUE ? max : actualMax
+    ])
+
+    for (const out of seriesOutliers) {
+      outliers.push(out)
+    }
+  }
+
+  return { boxData, outliers }
+}
+
+export default memo(({ name, values }: BoxplotChartProps) => {
+  // Filter out null/undefined values before passing to stats
+  const validData = values.filter((item) => item !== null && item !== undefined)
+
+  if (validData.length === 0) return null
+
+  // prepareBoxplotData expects an array of datasets
+  const data = prepareBoxplotData([validData])
+
+  const options = {
+    ...echartsOptions,
+    title: {
+      text: `${name} Distribution`,
+      left: 'center',
+      textStyle: {
+        color: '#ccc',
+      },
+    },
+    series: [
+      {
+        name: 'boxplot',
+        type: 'boxplot',
+        datasetIndex: 0,
+        data: data.boxData,
+        itemStyle: {
+          color: '#5470C688',
+          borderColor: '#5470C6'
+        },
+        tooltip: {
+          formatter: function (param: any) {
+            return [
+              '<strong>' + name + ' Distribution</strong><br/>',
+              'Max: ' + param.data[5].toFixed(2),
+              'Q3: ' + param.data[4].toFixed(2),
+              'Median: ' + param.data[3].toFixed(2),
+              'Q1: ' + param.data[2].toFixed(2),
+              'Min: ' + param.data[1].toFixed(2)
+            ].join('<br/>');
+          }
+        }
+      },
+      {
+        name: 'outlier',
+        type: 'scatter',
+        datasetIndex: 1,
+        data: data.outliers,
+        itemStyle: {
+          color: '#CF6D6C'
+        },
+        tooltip: {
+          formatter: function (param: any) {
+            return `<strong>Outlier</strong><br/>Value: ${param.data[1]}`
+          }
+        }
+      }
+    ],
+  }
+
+  return (
+    <ReactECharts
+      option={options}
+      style={echartsOptions.style}
+      theme="dark"
+      opts={{ renderer: 'canvas' }}
+    />
+  )
+})

--- a/src/layout/BoxplotChart.tsx
+++ b/src/layout/BoxplotChart.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from 'react'
 import ReactECharts from 'echarts-for-react'
+import { labels } from '../data'
 
 interface BoxplotChartProps {
   name: string
@@ -23,7 +24,6 @@ const echartsOptions = {
   },
   xAxis: {
     type: 'category',
-    data: ['Distribution'],
     boundaryGap: true,
     nameGap: 30,
     splitArea: {
@@ -105,16 +105,51 @@ function prepareBoxplotData(data: number[][]) {
 }
 
 export default memo(({ name, values }: BoxplotChartProps) => {
-  // Filter out null/undefined values before passing to stats
-  const validData = values.filter((item) => item !== null && item !== undefined)
+  // Group values by 6-month period (H1/H2)
+  const groupedData: Record<string, number[]> = {}
 
-  if (validData.length === 0) return null
+  values.forEach((item, index) => {
+    if (item === null || item === undefined) return
+
+    const label = labels[index]
+    if (!label || label.length < 6) return
+
+    // Label is YYMMDD
+    const yy = label.slice(0, 2)
+    const mm = parseInt(label.slice(2, 4), 10)
+
+    const year = `20${yy}`
+    const half = mm <= 6 ? 'H1' : 'H2'
+    const period = `${half} ${year}`
+
+    if (!groupedData[period]) {
+      groupedData[period] = []
+    }
+    groupedData[period].push(item)
+  })
+
+  // Ensure chronological ordering by sorting keys
+  const periods = Object.keys(groupedData).sort((a, b) => {
+    // a and b are like 'H1 2023', 'H2 2023'
+    const [halfA, yearA] = a.split(' ')
+    const [halfB, yearB] = b.split(' ')
+    if (yearA !== yearB) return yearA.localeCompare(yearB)
+    return halfA.localeCompare(halfB)
+  })
+
+  const datasets = periods.map(p => groupedData[p])
+
+  if (datasets.length === 0) return null
 
   // prepareBoxplotData expects an array of datasets
-  const data = prepareBoxplotData([validData])
+  const data = prepareBoxplotData(datasets)
 
   const options = {
     ...echartsOptions,
+    xAxis: {
+      ...echartsOptions.xAxis,
+      data: periods
+    },
     title: {
       text: `${name} Distribution`,
       left: 'center',

--- a/src/layout/BoxplotChart.tsx
+++ b/src/layout/BoxplotChart.tsx
@@ -36,6 +36,7 @@ const echartsOptions = {
   yAxis: {
     type: 'value',
     name: 'Value',
+    scale: true,
     splitArea: {
       show: true
     }

--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -50,6 +50,7 @@ const echartsOptions = {
   },
   grid: {
     right: 40,
+    left: 80,
   },
 }
 
@@ -122,7 +123,8 @@ export default memo(({ data, keys }: ScatterChartProps) => {
       data: keys,
     },
     grid: {
-      right: keys.length * 60,
+      left: keys.length * 80,
+      right: 40,
     },
   }
 

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -27,6 +27,7 @@ import {
 } from '@heroicons/react/24/outline'
 import { averageCountAtom } from '../atom/averageValueAtom'
 import LineChart from './LineChart'
+import BoxplotChart from './BoxplotChart'
 import BiomarkerCorrelation from './BiomarkerCorrelation'
 import { TableProps, DisplayedEntry } from './Table.types'
 
@@ -217,8 +218,9 @@ const TableRow = React.memo(
         {isExpanded && (
           <tr className="bg-gray-800">
             <td colSpan={visibleLeafColumnsCount} className="border border-gray-700">
-              <div className="p-3">
+              <div className="p-3 grid grid-cols-1 md:grid-cols-2 gap-4">
                 <LineChart name={name} values={values} />
+                <BoxplotChart name={name} values={values} />
               </div>
             </td>
           </tr>


### PR DESCRIPTION
**The Issue:**
In `src/layout/ScatterChart.tsx` (lines 124-126), when multiple biomarkers are selected, their Y-axes are pinned to the left side with offsets (`index * 80`), but the chart `grid.right` property was being expanded instead of `grid.left`. This caused multiple left-positioned axes to overflow out of the chart container, making the labels overlap and truncate.

**Discovery Signal:**
Scan 3 — Multi-Axis Legibility (ScatterChart): Y-axes use offset: index * 80. For 4+ biomarkers does the rightmost axis overflow the chart container? Found that `left` padding was needed, not `right` padding.

**context7 Reference:**
`grid.left` — ECharts 5.6.0 documentation verified. Distance between grid component and the left side of the container.

**The Fix:**
Modified `ScatterChart.tsx` to expand `grid.left` dynamically (`left: keys.length * 80`) when plotting multi-axes, and pinned `grid.right` to a static `40` margin.

**The Benefit:**
Multi-axis charts are now fully legible. 4+ biomarkers render side-by-side cleanly without text overlapping or overflowing outside the chart container bounds on the left edge.

---

### Visualization Proposals

**Proposal 1 of 3: Biomarker Outlier Boxplot**
**ECharts type:** `boxplot`
**Which existing data it uses:** uses all historical numerical values `number[]` from `BioMarker[1]` stored in `dataAtom`.
**What it reveals that current charts don't:** shows the distribution of values, the median, and extreme outliers across a patient's entire history for a single biomarker, revealing how much their values drift normally versus true anomalous spikes.
**Where it would live:** a new tab inside `BiomarkerCorrelation.tsx` or rendered inline below the existing line chart when a user clicks a specific row to expand details.
**Trigger / entry point:** A toggle button "Show Distribution" within the table row expansion for any numerical biomarker.
**Implementation complexity:** Low. The `ecStat.statistics.prepareBoxplotData` function is available and we already loop through historical data arrays.
**ECharts 5.6.0 API confirmed via context7:** yes (series.type = 'boxplot').

**Proposal 2 of 3: Range Optimality Radar**
**ECharts type:** `radar`
**Which existing data it uses:** uses `extra.optimality[]` pre-computed in `src/processors/post/range.ts` and `extra.range` string already on every entry. Uses `tagAtom` to group biomarkers.
**What it reveals that current charts don't:** shows whether all biomarkers in a specific tag group (e.g., 9 Metabolic markers) are simultaneously within optimal ranges at the latest time point at a glance, rather than requiring the user to scan each table row individually.
**Where it would live:** a new `src/layout/RadarChart.tsx`, rendered when a tag filter is active in `App.tsx` below the existing ScatterChart.
**Trigger / entry point:** the existing tag filter buttons in `Nav.tsx` already set `tagAtom`; a radar chart could auto-render when a single tag is selected.
**Implementation complexity:** Medium. Requires mapping optimal string ranges to min/max scalar indicators for the radar chart layout, but `optimality` boolean arrays are already available.
**ECharts 5.6.0 API confirmed via context7:** yes (series.type = 'radar' and radar coordinate system).

**Proposal 3 of 3: Correlation Matrix Heatmap**
**ECharts type:** `heatmap`
**Which existing data it uses:** uses `correlationAtom` pairwise results (Spearman/Pearson) across the currently `visibleDataAtom`.
**What it reveals that current charts don't:** Provides a comprehensive "bird's eye view" matrix of all strong positive and negative correlations across all tested biomarkers simultaneously, rather than selecting one biomarker at a time in the `Correlation.tsx` view.
**Where it would live:** a new `src/layout/CorrelationHeatmap.tsx` modal or full-screen view.
**Trigger / entry point:** A new "View Full Matrix" button inside the existing `Correlation.tsx` panel.
**Implementation complexity:** Medium. The pairwise combinations in `correlationAtom` need to be flattened into an X/Y grid array format required by ECharts `heatmap` series, mapped with a `visualMap` from -1 to 1.
**ECharts 5.6.0 API confirmed via context7:** yes (series.type = 'heatmap', visualMap component).

Recommended implementation order: Proposal 2 first (highest insight, lowest effort), then Proposal 1, then Proposal 3.

---
*PR created automatically by Jules for task [17714679038660217371](https://jules.google.com/task/17714679038660217371) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlapping left-pinned Y-axes in `ScatterChart` and adds a half-year grouped boxplot in expanded rows to show each biomarker’s value distribution over time.

- **New Features**
  - Added `BoxplotChart` next to `LineChart` in expanded rows; groups values into H1/H2 periods, computes quartiles/outliers with an internal prep function (no `echarts-stat`), and enables `yAxis.scale` for better data-driven ranges.

- **Bug Fixes**
  - `ScatterChart`: set `grid.left = keys.length * 80` and keep `grid.right = 40` so multiple left-side axes and labels fit inside the chart.

<sup>Written for commit 92d772349366468696aebe5b29a8b0f6553f8914. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

