### PR TITLE
⚡ Bolt: Optimize `array.includes` lookups with `Set` in React component renders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,8 +130,16 @@ export default function App() {
   }, [selected])
 
   const onPValue = React.useCallback(() => {
-    let sourceTarget: (BioMarker | undefined)[] = data.filter(([name]) => selected.includes(name))
-    sourceTarget = selected.map((name) => sourceTarget.find((i) => i && i[0] === name))
+    // Optimization: Use a Set for O(1) lookups instead of O(N) array.includes inside the filter loop.
+    // This reduces complexity from O(M * N) to O(M + N).
+    const selectedSet = new Set(selected)
+    let sourceTarget: (BioMarker | undefined)[] = data.filter(([name]) => selectedSet.has(name))
+
+    // Optimization: Use a Map for O(1) lookups instead of O(N) array.find inside the map loop.
+    // This reduces complexity from O(K * N) to O(K + N).
+    const sourceTargetMap = new Map(sourceTarget.map(item => [item![0], item]))
+    sourceTarget = selected.map((name) => sourceTargetMap.get(name))
+
     if (sourceTarget.some((i) => !i)) {
       return
     }

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -96,11 +96,15 @@ export default React.memo<NavProps>(
         setIsAsking(true)
 
         try {
+          // Optimization: Use a Set for O(1) lookups instead of O(N) array.includes inside multiple filter loops.
+          // This reduces overall filtering complexity from O(M * N * 4) to O(M + N * 4).
+          const selectedSet = new Set(selected)
+
           const pairs = data
-            .filter(([key]) => selected.includes(key))
+            .filter(([key]) => selectedSet.has(key))
             .map(([key, values, unit]) => `${key} ${values[values.length - 1]} ${unit || ''}`)
           const prevPairs = data
-            .filter(([key]) => selected.includes(key))
+            .filter(([key]) => selectedSet.has(key))
             .map(([key, values, unit]) =>
               values.length > 1 ? `${key} ${values[values.length - 2]} ${unit || ''}` : undefined,
             )
@@ -108,8 +112,8 @@ export default React.memo<NavProps>(
           const relatedContext = (() => {
             if (!fullData || fullData.length === 0) return undefined
 
-            const selectedEntries = fullData.filter((d) => selected.includes(d[0]))
-            const candidates = fullData.filter((d) => !d[3].inferred && !selected.includes(d[0]))
+            const selectedEntries = fullData.filter((d) => selectedSet.has(d[0]))
+            const candidates = fullData.filter((d) => !d[3].inferred && !selectedSet.has(d[0]))
             const related = new Map<string, string>()
 
             // Optimization: Use pre-calculated ranks for all sources and candidates to avoid


### PR DESCRIPTION
💡 **What:**
Replaced O(N) array lookups (`array.includes()` and `array.find()`) inside `Array.filter()` and `Array.map()` hot loops with O(1) `Set` and `Map` lookups. 

🎯 **Why:** 
When filtering large datasets like `data` or `fullData` inside React components (`src/App.tsx` and `src/layout/Nav.tsx`), using `.includes` on an array inside a filter loop causes an O(M * N) complexity operation. By pre-allocating a `Set` for the selected items, we reduce the complexity to O(M + N), eliminating unnecessary repeated iterations and saving render cycles. The same principle applies to using a Map instead of `.find()` in `App.tsx`.

📊 **Impact:** 
Expected performance improvement: Significantly reduces CPU overhead during re-renders when a large number of biomarkers are present and multiple selections are made or AI queries are fired. 

🔬 **Measurement:**
No visual changes were introduced, but the logic maintains structural equivalence while mathematically avoiding nested loops. Validated locally passing all `playwright` functionality tests and `tsc` compilation checks.

---
*PR created automatically by Jules for task [3189372512378005492](https://jules.google.com/task/3189372512378005492) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized React render paths by replacing `array.includes` and `array.find` inside loops with `Set` and `Map` lookups to cut filtering from O(M*N) to O(M+N) and reduce CPU during re-renders on large datasets.

- **Refactors**
  - `src/App.tsx`: Use `Set` for selected lookups; use a `Map` to reorder `sourceTarget` instead of `.find`.
  - `src/layout/Nav.tsx`: Use a shared `Set` for repeated selected checks (`pairs`, `prevPairs`, `relatedContext`).
  - No UI changes; verified with `tsc` and `playwright`.

<sup>Written for commit ff4b7dcb14d7608867d75cc2685b9c1704d97053. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

