### PR TITLE
🎨 Palette: Improve Nav Reset Button Discoverability and Accessibility

### DIFF
--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -294,11 +294,11 @@ export default React.memo<NavProps>(
 
               <button
                 type="button"
-                className={cn(
-                  'lg:ml-2 px-4 py-1 text-sm bg-yellow-500 text-black rounded hover:bg-yellow-400 w-full lg:w-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
-                  { 'invisible pointer-events-none': filterTag == null },
-                )}
+                className="lg:ml-2 px-4 py-1 text-sm bg-yellow-500 text-black rounded hover:bg-yellow-400 w-full lg:w-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 onClick={onFilterByTag}
+                disabled={filterTag == null}
+                title={filterTag == null ? 'Select a tag to filter' : 'Reset tag filter'}
+                aria-label="Reset tag filter"
               >
                 Reset
               </button>


### PR DESCRIPTION
💡 **What:** Replaced the `invisible pointer-events-none` conditional CSS classes on the Nav "Reset" tag filter button with a proper `disabled` HTML attribute, along with visual disabled styles (`disabled:opacity-50 disabled:cursor-not-allowed`).
🎯 **Why:** To improve feature discoverability. Instead of an invisible element mysteriously appearing, the button is now always visible, and uses a dynamic `title` tooltip to explain *why* it's currently disabled ("Select a tag to filter") or what it will do ("Reset tag filter").
📸 **Before/After:**
*(Before)* Button is completely invisible (`display: hidden` effectively) until a tag is clicked.
*(After)* Button is visible but grayed out with a cursor-not-allowed state. Hovering over it tells the user to select a tag first.
♿ **Accessibility:** Added an `aria-label="Reset tag filter"` for screen readers and replaced hacky pointer-event manipulation with the semantic `disabled` boolean.

---
*PR created automatically by Jules for task [11338542808101348798](https://jules.google.com/task/11338542808101348798) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Nav “Reset” tag filter button always visible and use a semantic disabled state with a helpful tooltip and ARIA label to improve discoverability and accessibility.

- **New Features**
  - Replaced `invisible pointer-events-none` with a `disabled` attribute and styles: `disabled:opacity-50 disabled:cursor-not-allowed`.
  - Added dynamic `title` (“Select a tag to filter” or “Reset tag filter”) and `aria-label="Reset tag filter"`.

<sup>Written for commit 9933270d32ca7850eca5eab1b754320312d6c3b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

