### PR TITLE
fix(charts): prevent ecStat regression crash and fix tooltip on Chart2

### DIFF
--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -154,7 +154,7 @@ export default memo(({ data, keys }: ChartProps) => {
         }
         return result
       }, [])
-      .filter((v) => v[1] && v[2])
+      .filter((v) => v[1] !== null && v[1] !== undefined && v[2] !== null && v[2] !== undefined)
 
     const excludedDate: number[][] = matchedData.map((v) => [+v[2], +v[1]])
 
@@ -175,33 +175,46 @@ export default memo(({ data, keys }: ChartProps) => {
     ;(yAxis as any[])[0].name = keys[1]
 
     const scatterData = scatterData2.map((v) => [v[1], v[0]])
-    ;(series as any[])[1].datasetIndex = 1
 
-    const dataset = [
-      { source: scatterData },
-      {
+    const dataset: any[] = [{ source: scatterData }]
+
+    // Guard against regression transform crash on <2 points
+    if (scatterData.length >= 2) {
+      dataset.push({
         transform: {
           type: 'ecStat:regression',
-          // 'linear' by default.
-          // config: { method: 'linear', formulaOn: 'end'}
         },
-      },
+      })
+    }
+
+    const nextSeries = [
+      series[0],
+      // Only include the regression series if dataset contains it
+      ...(scatterData.length >= 2 ? [{
+        ...series[1],
+        datasetIndex: 1,
+        tooltip: {
+          formatter: (params: any) => {
+            return `<strong>Regression Trend</strong>`
+          }
+        }
+      }] : [])
     ]
 
     return {
       ...echartsOptions,
       dataset,
-      series,
+      series: nextSeries,
       dataZoom: [
         {
           ...(echartsOptions.dataZoom as any[])[0],
-          startValue: Math.min(...scatterData.map((item) => item[0])),
-          endValue: Math.max(...scatterData.map((item) => item[0])),
+          startValue: scatterData.length > 0 ? Math.min(...scatterData.map((item) => item[0])) : 0,
+          endValue: scatterData.length > 0 ? Math.max(...scatterData.map((item) => item[0])) : 100,
         },
         {
           ...(echartsOptions.dataZoom as any[])[1],
-          startValue: Math.min(...scatterData.map((item) => item[1])),
-          endValue: Math.max(...scatterData.map((item) => item[1])),
+          startValue: scatterData.length > 0 ? Math.min(...scatterData.map((item) => item[1])) : 0,
+          endValue: scatterData.length > 0 ? Math.max(...scatterData.map((item) => item[1])) : 100,
         },
       ],
     }


### PR DESCRIPTION
This commit fixes several edge cases in Chart2.tsx related to how ECharts handles empty, sparse, or null-filled arrays.
It prevents the ecStat:regression transform from crashing ECharts initialization when fewer than 2 data points exist. It uses strict null checks instead of truthy evaluations to prevent valid 0 values from being filtered out while correctly ignoring nulls. It bounds the dataZoom dynamically and adds a custom formatter to display "Regression Trend" instead of raw points in the tooltip.

---
*PR created automatically by Jules for task [3325972860348275834](https://jules.google.com/task/3325972860348275834) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `ecStat:regression` from crashing Chart2 with sparse datasets and fixes null/zero handling. Also updates the regression tooltip and sets safe `dataZoom` bounds.

- **Bug Fixes**
  - Use strict null checks so 0 values are kept and nulls are ignored.
  - Add regression dataset/series only when there are at least 2 points to avoid `echarts` init crashes with `ecStat:regression`.
  - Set safe `dataZoom` bounds for empty data and show "Regression Trend" in the regression tooltip.

<sup>Written for commit ebd2779e9379c8d30cd07801f83b7666a1a37078. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

