### PR TITLE
⚡ Bolt: Replace O(N) array search with O(1) Map lookup in data merge

### DIFF
--- a/src/processors/merge.ts
+++ b/src/processors/merge.ts
@@ -1,14 +1,27 @@
-export default (inputs: Array<RawEntry>): Entry[] =>
-  inputs.reduce((result: Entry[], info, index) => {
-    info.entries.forEach(([name, value, unit, extra]) => {
-      const matchedEntry = result.find((entry) => entry[0] === name)
+export default (inputs: Array<RawEntry>): Entry[] => {
+  // Optimization: Pre-compute a lookup Map of entries to avoid O(N) Array.find()
+  // calls inside the nested entries loop. This reduces complexity from O(T*U) to O(T),
+  // where T is Total Entries and U is Unique Entries.
+  const map = new Map<string, Entry>()
+  const len = inputs.length
+
+  for (let index = 0; index < len; index++) {
+    const info = inputs[index]
+    const entries = info.entries
+    for (let i = 0; i < entries.length; i++) {
+      const [name, value, unit, extra] = entries[i]
+      let matchedEntry = map.get(name)
+
       if (matchedEntry) {
         matchedEntry[1][index] = value
       } else {
-        const values = Array.from<string>({ length: inputs.length })
+        const values = Array.from<string>({ length: len })
         values[index] = value
-        result.push([name, values, unit as string, extra])
+        matchedEntry = [name, values, unit as string, extra]
+        map.set(name, matchedEntry)
       }
-    })
-    return result
-  }, [])
+    }
+  }
+
+  return Array.from(map.values())
+}


### PR DESCRIPTION
💡 What: Replaced the O(N) `result.find()` lookup inside `src/processors/merge.ts` with an O(1) `Map` lookup during the data parsing pipeline.
🎯 Why: In nested loops iterating over raw historical data items, repeatedly searching an ever-growing results array using `find()` causes a performance degradation O(T * U) (where T is Total Entries and U is Unique Entries). Using a Map brings this down to O(T).
📊 Impact: Considerably faster overall initial rendering time when processing dense legacy data snapshots into visual atoms.
🔬 Measurement: Verify using `pnpm exec tsc --noEmit`, `pnpm lint`, and the Playwright suite. Review the performance notes directly embedded into the `merge.ts` processor code.

---
*PR created automatically by Jules for task [15751949774756400152](https://jules.google.com/task/15751949774756400152) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the O(N) array lookup in `src/processors/merge.ts` with an O(1) `Map` to speed up merging across historical entries. This reduces the merge step from O(T*U) to O(T) and improves initial render time for dense datasets.

<sup>Written for commit a9db1eeb742fdcd5305cf91486ced48bb3989e9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

