### PR TITLE
🎨 Palette: Add missing tooltips to action buttons

### DIFF
--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -497,6 +497,7 @@ export default React.memo<NavProps>(
                             : 'border-gray-600 text-gray-300 hover:bg-gray-700 hover:text-white'
                         }`}
                         aria-label="Copy analysis to clipboard"
+                        title="Copy analysis to clipboard"
                       >
                         {isCopied ? (
                           <>
@@ -514,6 +515,7 @@ export default React.memo<NavProps>(
                         disabled={isGistLoading}
                         aria-busy={isGistLoading}
                         aria-label="Save analysis to Gist"
+                        title="Save analysis to Gist"
                         onClick={async () => {
                           setIsGistLoading(true)
                           setGistError(null)

--- a/src/layout/PValue.tsx
+++ b/src/layout/PValue.tsx
@@ -152,6 +152,7 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                           : 'border-gray-600 text-gray-300 hover:bg-gray-700 hover:text-white'
                       }`}
                       aria-label="Copy analysis to clipboard"
+                      title="Copy analysis to clipboard"
                     >
                       {isCopied ? (
                         <>


### PR DESCRIPTION
💡 **What:** Added `title` attributes to the "Copy Analysis" and "Save to Gist" icon buttons in the P-Value and Ask AI (Nav) dialogs.
🎯 **Why:** To improve UX and accessibility for mouse users by providing helpful tooltips on hover, mirroring the context already provided to screen readers via `aria-label`s.
📸 **Before/After:** The buttons previously had no native browser tooltips on hover. Now they display "Copy analysis to clipboard" and "Save analysis to Gist".
♿ **Accessibility:** Enhances discoverability of icon-button functions for sighted mouse users without cluttering the UI, bringing the buttons in line with the established pattern.

---
*PR created automatically by Jules for task [7247834532090687836](https://jules.google.com/task/7247834532090687836) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added native hover tooltips to the Copy Analysis and Save to Gist icon buttons in the P-Value and Ask AI dialogs. Mouse users now see “Copy analysis to clipboard” and “Save analysis to Gist,” matching the existing aria-labels for better discoverability and accessibility.

<sup>Written for commit 4ca98a82be40551fb524f46de8c0086a55c9bbf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

