### PR TITLE
⚡ Bolt: O(1) Set lookup for Table row selection

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -52,3 +52,8 @@
 
 **Learning:** In data enrichment pipelines like `src/processors/enrich/inferData.ts`, deeply nested `Array.find()` calls inside `map` loops across multiple periods and recipes create an O(Recipes * Periods * Fields * Entries) complexity that needlessly searches the same array repeatedly.
 **Action:** Always pre-compute a lookup `Map` (e.g., `Map<string, number[]>`) for dataset entries before executing nested iterations over time-series data. Looking up required field vectors once per recipe avoids O(N) searches inside hot loops and reduces overall complexity to O(Entries + Recipes * Periods * Fields).
+
+## 2025-07-20 - Array.includes in React Loops
+
+**Learning:** Calling `array.includes()` inside mapping operations (like rendering list items via `table.getRowModel().rows.map`) scales poorly (O(N*M)) as the number of elements increases.
+**Action:** Always construct an O(1) local hash map or object via `Object.fromEntries` inside a `useMemo` specifically for selection and filtering lookups, rather than relying on linear searches inside the render path.

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -441,6 +441,11 @@ export default React.memo(
       return 'No records found'
     }, [filterText, tag])
 
+    // Optimization: Replace O(N) Array.includes with O(1) Set.has lookup
+    // inside the TableRow render loop.
+    // Impact: Reduces complexity of row selection from O(Rows * SelectedItems) to O(Rows + SelectedItems).
+    const selectedSet = React.useMemo(() => new Set(selected), [selected])
+
     return (
       <React.Suspense fallback="Loading...">
         <table className="w-full text-sm text-left border-collapse bg-dark-table-row text-dark-text">
@@ -531,7 +536,7 @@ export default React.memo(
                   <TableRow
                     key={row.id}
                     entry={row.original}
-                    isSelected={selected.includes(row.original.name)}
+                    isSelected={selectedSet.has(row.original.name)}
                     isExpanded={isExpanded}
                     rowId={row.id}
                     toggleExpand={toggleExpand}


### PR DESCRIPTION
💡 What: Replaced the O(N) `Array.includes()` check inside the `Table.tsx` render loop with an O(1) `Set.has()` lookup by pre-computing a `Set` from the `selected` array using `useMemo`. Added explicit inline comments explaining the performance gain and added a learning to `.jules/bolt.md`.
🎯 Why: The original implementation executed an O(N) array search for every row (`N` selected items $\times$ `M` rows). Converting the selection array to a `Set` once per selection change bounds the complexity to O(N + M), improving React render times when handling large datasets.
📊 Impact: Reduces rendering complexity of the row selection mapping from O(Rows $\times$ SelectedItems) to O(Rows + SelectedItems), saving processor cycles on each input keypress or filter action.
🔬 Measurement: Verified functionality and observed no regressions via standard E2E test suite.

---
*PR created automatically by Jules for task [16262817098543916298](https://jules.google.com/task/16262817098543916298) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized table row selection by switching from `Array.includes()` to `Set.has()` with a memoized `selectedSet`. This reduces render work and improves responsiveness on large tables.

- **Refactors**
  - Precompute `selectedSet` with `useMemo` and use `Set.has()` in `Table.tsx` row rendering.
  - Added a note in `.jules/bolt.md` on avoiding linear searches inside React render loops.

<sup>Written for commit e4707b028b91c32f2d80dc899a12e63c3f25ab1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

