### PR TITLE
Fix typescript-eslint(no-non-null-asserted-optional-chain) in Table

### DIFF
--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -588,7 +588,7 @@ export default React.memo(
                     {notes[(header.column.columnDef.meta as any)?.title as string]?.supps ? (
                       <SupplementsPopover
                         supps={
-                          notes[(header.column.columnDef.meta as any)?.title as string]?.supps!
+                          notes[(header.column.columnDef.meta as any)?.title as string]?.supps ?? []
                         }
                       />
                     ) : null}


### PR DESCRIPTION
**The Issue:**
In `src/layout/Table.tsx` at line 591, a TypeScript non-null assertion operator (`!`) was being unsafely applied directly following an optional chain (`?.`). This caused a `typescript-eslint(no-non-null-asserted-optional-chain)` correctness violation.

**The Discovery Signal:**
Scan G (oxlint violations) triggered this. Specifically, running `npx oxlint src/` outputted:
`! typescript-eslint(no-non-null-asserted-optional-chain): Optional chain expressions can return undefined by design: using a non-null assertion is unsafe and wrong.` for `src/layout/Table.tsx` on line 591.

**The Fix:**
I replaced the non-null assertion operator (`!`) at the end of `notes[(header.column.columnDef.meta as any)?.title as string]?.supps!` with the nullish coalescing operator `?? []` to provide a safe empty-array fallback if the evaluated path resolves to undefined.

**The Benefit:**
This structural win removes a `suspicious/correctness` lint rule violation and prevents a potential unsafe runtime pattern if `supps` was genuinely undefined, ensuring type-safe rendering of the `SupplementsPopover` without suppressing any rules.

---
*PR created automatically by Jules for task [14105263609101700125](https://jules.google.com/task/14105263609101700125) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix unsafe non-null assertion in Table by replacing `notes[...]?.supps!` with `notes[...]?.supps ?? []`. This removes the `typescript-eslint(no-non-null-asserted-optional-chain)` violation and safely handles missing supplements.

<sup>Written for commit 9cf0c81e3bdba77b76910b00ce3d624c4fdb7da9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

