### PR TITLE
Enhance LineCharts with Optimal Range markArea and fix series tracking in Chart.tsx

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -83,12 +83,10 @@ export default memo(({ data, keys }: ChartProps) => {
         instance.setOption({
           yAxis,
           grid: { top: 40, bottom: 20 },
-          series: [
-            {
-              type: 'line',
-              connectNulls: true,
-            },
-          ],
+          series: keys.map(() => ({
+            type: 'line',
+            connectNulls: false,
+          })),
         }, { notMerge: true })
       }
     }

--- a/src/layout/LineChart.tsx
+++ b/src/layout/LineChart.tsx
@@ -5,6 +5,7 @@ import { labels } from '../data'
 interface LineChartProps {
   name: string
   values: number[]
+  rangeStr?: string
 }
 
 const echartsOptions = {
@@ -41,13 +42,48 @@ const formatTime = (label: string) => {
   return `20${label.slice(0, 2)}/${label.slice(2, 4)}/${label.slice(4, 6)}`
 }
 
-export default memo(({ name, values }: LineChartProps) => {
+export default memo(({ name, values, rangeStr }: LineChartProps) => {
   // Filter out null/undefined values and pair them with labels
   const data = values
     .map((value, index) => {
       return [formatTime(labels[index]), value]
     })
     .filter((item) => item[1] !== null && item[1] !== undefined)
+
+  let markArea: any = undefined
+
+  if (rangeStr) {
+    let min: number | undefined
+    let max: number | undefined
+
+    if (rangeStr.includes(' - ')) {
+      const parts = rangeStr.split(' - ')
+      min = parseFloat(parts[0])
+      max = parseFloat(parts[1])
+    } else if (rangeStr.startsWith('>=')) {
+      min = parseFloat(rangeStr.slice(2))
+    } else if (rangeStr.startsWith('<=')) {
+      max = parseFloat(rangeStr.slice(2))
+    }
+
+    if (min !== undefined || max !== undefined) {
+      markArea = {
+        itemStyle: {
+          color: 'rgba(84, 112, 198, 0.1)',
+        },
+        data: [
+          [
+            {
+              yAxis: min !== undefined && !isNaN(min) ? min : undefined,
+            },
+            {
+              yAxis: max !== undefined && !isNaN(max) ? max : undefined,
+            },
+          ],
+        ],
+      }
+    }
+  }
 
   const options = {
     ...echartsOptions,
@@ -66,6 +102,7 @@ export default memo(({ name, values }: LineChartProps) => {
         smooth: true, // Make the line smooth
         symbol: 'circle',
         symbolSize: 6,
+        markArea: markArea,
       },
     ],
   }

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -230,7 +230,7 @@ const TableRow = React.memo(
             <td colSpan={visibleLeafColumnsCount} className="border border-gray-700">
               <React.Suspense fallback={<div className="p-4 text-center text-gray-400">Loading charts...</div>}>
                 <div className="p-3 grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <LineChart name={name} values={values} />
+                  <LineChart name={name} values={values} rangeStr={typeof extra.range === 'string' ? extra.range : undefined} />
                   <BoxplotChart name={name} values={values} />
                 </div>
               </React.Suspense>


### PR DESCRIPTION
**Part 1 — Implementation Report**

**The Issue:** 
`src/layout/Chart.tsx`, lines 86-89. The multi-series line chart initialized the ECharts instance by mapping a single hardcoded line series configuration with `connectNulls: true`, completely disregarding the length of `keys`. Because of `{ notMerge: true }`, any state change to `keys` destroyed previously mapped series, leaving only the first selected biomarker with styling. Furthermore, connecting points across long gaps where the biomarker wasn't measured (years) heavily misrepresents health trends.

**Discovery Signal:** 
Scan 1 ("Does `connectNulls` behave correctly on line series, or does it connect across long null gaps in ways that misrepresent the data?") combined with Scan 5 ("stale series from previous `keys` selections bleed through on re-render").

**context7 Reference:** 
`series-line.connectNulls` (ECharts 5.6 docs) and `series` array mapping logic.

**The Fix:** 
Changed `connectNulls` to `false` and wrapped the series config in a `keys.map()` inside the `instance.setOption` call. This properly registers a configuration object for each selected biomarker series, ensuring correct rendering lengths and accurate historical tracking.

**The Benefit:** 
The application no longer silently draws dangerous, misleading connecting lines spanning unmeasured years for health tests, and properly retains line styling for multiple selected biomarkers simultaneously.

---

**Part 2 — Visualization Proposals**

**Proposal 1 of 3: Optimal Range Banding** (Implemented in this PR!)
**ECharts type:** `markArea`
**Which existing data it uses:** uses the `extra.range` formatted string (e.g., "3.9 - 6.4") already attached to every `BioMarker` via `src/processors/post/range.ts`.
**What it reveals that current charts don't:** Provides immediate visual context by shading the optimal "safe zone" horizontally behind the time-series line, allowing users to instantly spot historical values that drifted outside without mentally comparing against a static number.
**Where it would live:** extends the existing `src/layout/LineChart.tsx`.
**Trigger / entry point:** Automatically renders when a user expands a table row to view the historical `LineChart` for any biomarker that possesses a defined `extra.range`.
**Implementation complexity:** Low: The `range` string can be cleanly parsed into `min`/`max` bounds (reusing logic already proven in `RadarChart.tsx`) and passed directly into a standard ECharts `series.markArea` configuration without any new data computations or Jotai state.
**ECharts 5.6.0 API confirmed via context7:** yes (series-line.markArea)

---

**Proposal 2 of 3: Correlation Matrix Heatmap**
**ECharts type:** `heatmap`
**Which existing data it uses:** uses the computed Pearson/Spearman pairwise results stored in `correlationAtom` from `src/atom/correlationAtom.ts` and the currently visible biomarkers from `visibleDataAtom`.
**What it reveals that current charts don't:** Reveals hidden macro-relationships (like inverse correlations between Triglycerides and HDL) across all visible biomarkers simultaneously, rather than forcing the user to check pairwise text correlations one-by-one.
**Where it would live:** A new `src/layout/HeatmapChart.tsx`, rendered as an alternative matrix view within the correlation analysis workflow.
**Trigger / entry point:** A new "Matrix View" toggle button inside the existing `Correlation.tsx` dialog or above the correlation table.
**Implementation complexity:** Medium: The complex pairwise math is already pre-computed in atoms; the main effort is simply mapping the 2D correlation matrix into the `[x, y, value]` coordinate array required by ECharts `series-heatmap` and configuring the continuous `visualMap`.
**ECharts 5.6.0 API confirmed via context7:** yes (series-heatmap)

---

**Proposal 3 of 3: Tag Group Parallel Coordinates**
**ECharts type:** `parallel`
**Which existing data it uses:** uses `visibleDataAtom` filtered by the active `tagAtom` (from `src/processors/post/tag.ts`) for the most recent test date (using `aggregated.ts` labels).
**What it reveals that current charts don't:** Plots all biomarkers of a specific physiological system (e.g., all 9 "3-Liver" markers) on parallel vertical axes for a single test date, allowing the user to instantly spot which specific marker broke the pattern and drifted out of optimal range.
**Where it would live:** A new `src/layout/ParallelChart.tsx`, rendered below the main dashboard table when a specific tag filter is active.
**Trigger / entry point:** The existing tag filter buttons in `Nav.tsx` already set `tagAtom`; the parallel chart would auto-render to summarize the selected physiological system whenever exactly one tag is active.
**Implementation complexity:** Medium: Requires dynamically constructing an ECharts `parallelAxis` array from the active tag group's biomarker names, and mapping the latest values into a single line series. No new data computation is needed.
**ECharts 5.6.0 API confirmed via context7:** yes (series-parallel)

> Recommended implementation order: Proposal 1 first (highest insight, lowest effort), then 2, then 3.

---
*PR created automatically by Jules for task [3756685605366405958](https://jules.google.com/task/3756685605366405958) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optimal range band to biomarker LineCharts and fixes multi-series rendering so gaps aren’t connected and all selected series persist.

- **Bug Fixes**
  - Map `keys` to `series` in `Chart.tsx` to render all selected biomarkers and keep them on updates.
  - Set `connectNulls: false` to prevent misleading lines across unmeasured periods.

- **New Features**
  - Shade the optimal range behind each LineChart using ECharts `markArea`, parsing `extra.range` strings like "3.9 - 6.4", ">=5", and "<=7".
  - Pass `rangeStr` from the table to `LineChart` to enable the band automatically when available.

<sup>Written for commit 8303d9d4c5fdad12d05deb2bd2f1f6c33cc98885. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

