### PR TITLE
Fix ECharts missing data interpolation and tooltips

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -63,7 +63,7 @@ export default memo(({ data, keys }: ChartProps) => {
             if (!result[i]) {
               result[i] = { d1: labels[i] }
             }
-            result[i][k.fieldKey] = v
+            result[i][k.fieldKey] = v !== null && v !== undefined ? v : '-'
           })
         }
       }

--- a/src/layout/LineChart.tsx
+++ b/src/layout/LineChart.tsx
@@ -20,6 +20,14 @@ const echartsOptions = {
     textStyle: {
       color: '#f0f0f0',
     },
+    formatter: (params: any) => {
+      // ECharts axis trigger passes an array of series data for that axis index
+      const p = Array.isArray(params) ? params[0] : params
+      if (!p || p.value[1] === '-' || p.value[1] === null || p.value[1] === undefined) {
+        return ''
+      }
+      return `${p.seriesName}<br/>${p.value[0]}<br/><strong>${p.value[1]}</strong>`
+    },
   },
   grid: {
     left: '3%',
@@ -43,12 +51,12 @@ const formatTime = (label: string) => {
 }
 
 export default memo(({ name, values, rangeStr }: LineChartProps) => {
-  // Filter out null/undefined values and pair them with labels
+  // Map null/undefined values to '-' and pair them with labels
+  // Preserving missing points prevents misrepresenting data gaps (connectNulls: false by default)
   const data = values
     .map((value, index) => {
-      return [formatTime(labels[index]), value]
+      return [formatTime(labels[index]), value !== null && value !== undefined ? value : '-']
     })
-    .filter((item) => item[1] !== null && item[1] !== undefined)
 
   let markArea: any = undefined
 


### PR DESCRIPTION
**The Issue:**
In `src/layout/LineChart.tsx`, missing (null/undefined) data points were being stripped entirely via `.filter()`. Because the data array omitted these points, ECharts (even with `connectNulls: false` default) incorrectly interpolated lines across large gaps in time where a biomarker was not tested, misrepresenting the patient's health timeline. 

**Discovery Signal:**
Scan 1 — Null Value Handling triggered this fix.

**context7 Reference:**
The specific options checked and used are:
- `series[].data` (mapping `'-'` natively to missing points in ECharts 5.x)
- `tooltip.formatter` callback correctly handling `'-'` in ECharts 5.6.0.

**The Fix:**
- Edited `src/layout/LineChart.tsx` to stop `.filter()`ing nulls and map them to `'-'`.
- Edited `src/layout/LineChart.tsx` to provide a strict custom `tooltip.formatter` that gracefully suppresses the tooltip (`return ''`) when a missing point (`'-'`) is hovered.
- Edited `src/layout/Chart.tsx` to also map `null` to `'-'` in its dataset dimension arrays for parity.

**The Benefit:**
Line charts correctly "break" across unmeasured timeframes, and users no longer see misleading tooltips or lines.

---

## Proposals

**Proposal 1 of 3: Radar Chart for Tag Group Optimality**

**ECharts type:** `radar`

**Which existing data it uses:**
It uses the pre-computed `extra.optimality[]` booleans and `extra.range` string from `BioMarker` entries stored in `visibleDataAtom` or `dataAtom`, aggregated by their corresponding `extra.tag` group (from `src/processors/post/tag.ts`).

**What it reveals that current charts don't:**
Shows whether an entire group of biomarkers (e.g. all 9 Metabolic markers) are simultaneously within optimal range at a glance. Currently, a user has to scan multiple individual table rows to get a holistic view of a single bodily system.

**Where it would live:**
A new `src/layout/RadarChart.tsx`, rendered within the main dashboard when a user clicks one of the tag filter buttons (e.g., '2-Metabolic').

**Trigger / entry point:**
The existing tag filter buttons in the top `Nav.tsx` already populate a `tagAtom` or filter the `visibleDataAtom`. When the filtered view is active, this RadarChart could conditionally appear at the top of the table.

**Implementation complexity:** Low
The optimal/non-optimal binary state is already calculated in `extra.optimality[]`; only mapping this state onto a single ECharts `radar` config is required.

**ECharts 5.6.0 API confirmed via context7:** yes (`series-radar`, `radar.indicator`)

---

**Proposal 2 of 3: Range Deviation Bar Chart**

**ECharts type:** `bar` + `markLine`

**Which existing data it uses:**
Uses the latest non-null numeric value from the `values[]` array in `BioMarker`, alongside the `extra.range` min/max boundaries, pulling from `dataAtom`.

**What it reveals that current charts don't:**
It ranks how far *out of range* various biomarkers are. A user could instantly see which of their test results was furthest from the optimal bound, allowing them to prioritize health interventions.

**Where it would live:**
A new `src/layout/DeviationChart.tsx` component, potentially accessible via a new "Outliers" tab on the dashboard.

**Trigger / entry point:**
A toggle button in the navigation or table header to switch from "Chronological" view to "Deviation/Outliers" view.

**Implementation complexity:** Medium
Requires computing a normalized "deviation score" (percentage off from the `extra.range` boundary) for the most recent test date across all biomarkers before feeding it to the chart.

**ECharts 5.6.0 API confirmed via context7:** yes (`series-bar`, `series-bar.markLine`)

---

**Proposal 3 of 3: Time-Series Heatmap for Test Density**

**ECharts type:** `heatmap`

**Which existing data it uses:**
Uses the timestamps from `labels[]` (mapped to months/years) and the presence/absence of non-null values in the `values[]` array for each `BioMarker` in `dataAtom`.

**What it reveals that current charts don't:**
Provides a macro-level overview of a user's testing history since 2008. Users can quickly see which years/months had dense testing and for which specific biomarker groups, revealing gaps in their personal health monitoring protocol.

**Where it would live:**
A new `src/layout/DensityHeatmap.tsx`, rendered in a "History" or "Overview" section.

**Trigger / entry point:**
A dedicated "Testing History Overview" button on the dashboard that expands a full-width heatmap.

**Implementation complexity:** Medium
Requires grouping the `labels[]` into months/years and counting the number of valid test results per bucket to construct the X/Y coordinates and color value for the heatmap dataset.

**ECharts 5.6.0 API confirmed via context7:** yes (`series-heatmap`, `visualMap`)

---

> Recommended implementation order: Proposal 1 first (highest insight, lowest effort), then Proposal 2, then Proposal 3.

---
*PR created automatically by Jules for task [12240964645062062157](https://jules.google.com/task/12240964645062062157) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misrepresented gaps in line charts by preserving missing points and suppressing tooltips for them. Lines now break over unmeasured periods and tooltips only show for real values.

- **Bug Fixes**
  - `src/layout/LineChart.tsx`: Map `null`/`undefined` to `'-'` instead of filtering; add a tooltip formatter that returns empty for missing values.
  - `src/layout/Chart.tsx`: Map `null`/`undefined` to `'-'` in dataset dimensions.
  - Result: No interpolation across gaps; no misleading tooltips on missing data.

<sup>Written for commit 151715d1dec032fa67622965adbaca96250a4362. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

