### PR TITLE
Fix Chart.tsx tooltip missing values and unformatted dates

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -1,3 +1,22 @@
+**Part 1 — Implementation Report**
+
+**The Issue:**
+In `src/layout/Chart.tsx`, the multi-axis line chart lacked a custom tooltip formatter and was passing raw 6-digit `labels[i]` (e.g., "YYMMDD") directly into the X-axis dimension (`d1`). This caused the ECharts default tooltip to show unformatted dates and render `"SeriesName: -"` for any missing data points (nulls mapped to `'-'`), violating the null-suppression UX pattern.
+
+**Discovery Signal:**
+Scan 1 (Null Value Handling) & Scan 2 (Tooltip Quality). Found that the tooltip showed unformatted dates and raw `'-'` for null biomarker values.
+
+**context7 Reference:**
+Confirmed `option.tooltip.formatter` callback parameters for `trigger: 'axis'` and the `dataset` format structure for ECharts 5.6.0.
+
+**The Fix:**
+- Added a `formatTime(label)` helper to `src/layout/Chart.tsx`.
+- Updated the `chartData` generation to pass formatted dates `formatTime(labels[i])` into `d1`.
+- Added a custom `tooltip.formatter` to `echartsOptions.option` that intercepts `axis` triggers, unpacks the dataset rows via `p.dimensionNames[p.encode.y[0]]`, and only appends series to the tooltip string if their value `!== '-' && !== null && !== undefined`.
+
+**The Benefit:**
+The X-axis and tooltip now display correctly formatted readable dates (20YY/MM/DD). Tooltips are now completely clean of missing values, ensuring users only see data that was actually measured at a specific time point without distracting empty/null placeholders.
+
 ---
 
 **Proposal 1 of 3: Tag Group vs Optimal Range Radar**

--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -22,7 +22,39 @@ const echartsOptions: any = {
   option: {
     grid: { top: 40, bottom: 20 },
     backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'axis',
+      backgroundColor: '#111111',
+      borderColor: '#3a3a3a80',
+      textStyle: {
+        color: '#f0f0f0',
+      },
+      formatter: (params: any) => {
+        const pArray = Array.isArray(params) ? params : [params]
+        if (pArray.length === 0) return ''
+
+        let tooltipStr = `${pArray[0].value.d1}`
+        let hasValidValues = false
+
+        pArray.forEach((p) => {
+          const dimName = p.dimensionNames[p.encode.y[0]]
+          const val = p.value[dimName]
+
+          if (val !== '-' && val !== null && val !== undefined) {
+            tooltipStr += `<br/>${p.marker} ${p.seriesName}: <strong>${val}</strong>`
+            hasValidValues = true
+          }
+        })
+
+        return hasValidValues ? tooltipStr : ''
+      },
+    },
   },
+}
+
+const formatTime = (label: string) => {
+  if (!label || label.length < 6) return label
+  return `20${label.slice(0, 2)}/${label.slice(2, 4)}/${label.slice(4, 6)}`
 }
 
 export default memo(({ data, keys }: ChartProps) => {
@@ -61,7 +93,7 @@ export default memo(({ data, keys }: ChartProps) => {
         if (k) {
           values.forEach((v: number | null, i: number) => {
             if (!result[i]) {
-              result[i] = { d1: labels[i] }
+              result[i] = { d1: formatTime(labels[i]) }
             }
             result[i][k.fieldKey] = v !== null && v !== undefined ? v : '-'
           })


### PR DESCRIPTION
Fixes missing custom tooltip and date formatting in `src/layout/Chart.tsx`.

- **Discovery Signal**: Scan 1 (Null Value Handling) & Scan 2 (Tooltip Quality). The `Chart.tsx` multi-axis line chart pushes missing null values as `'-'` into the dataset but does not define a custom tooltip formatter. As a result, when users hover over the chart, the default ECharts `axis` tooltip triggers and displays `"SeriesName: -"` for missing biomarker points, violating the null-suppression UX pattern. Additionally, it passes raw `labels[i]` (`"YYMMDD"`) directly into the `d1` dimension without formatting it to `20YY/MM/DD`, rendering raw digits on the X-axis and tooltip.
- **Fix**: Updated `src/layout/Chart.tsx` to:
  1. Add a `formatTime` helper.
  2. Use `formatTime(labels[i])` when populating the `d1` dimension in `chartData`.
  3. Implement a custom `tooltip.formatter` in `echartsOptions.option` that intercepts `axis` trigger events, gracefully unpacks the ECharts `dataset` values using `p.encode` and `p.dimensionNames`, and completely suppresses any series entry that is `'-'`, `null`, or `undefined`.
- **Proposals**: Added three proposals (Radar, Heatmap, Boxplot) grounded in existing data structures, verified against ECharts 5.6 APIs to `PROPOSALS.md`.

---
*PR created automatically by Jules for task [11190650059537022567](https://jules.google.com/task/11190650059537022567) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the multi‑axis line chart to show readable dates and hide missing values in tooltips. Also adds an implementation note and three visualization proposals to `PROPOSALS.md`.

- **Bug Fixes**
  - Format x‑axis labels as `20YY/MM/DD` via a new `formatTime` helper when setting `d1`.
  - Add a custom axis `tooltip.formatter` that filters out `'-'`, `null`, and `undefined` values, showing only valid series entries.

<sup>Written for commit 19e70f4c059adb6aa16f1859236cdab9809f3992. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

