### PR TITLE
Fix unused variables and imports to resolve oxlint issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,6 @@ import {
   gistTokenAtom,
 } from './atom/dataAtom'
 import { BioMarker } from './types/biomarker'
-import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
 import { PasswordInput } from './layout/PasswordInput'
 
 export default function App() {

--- a/src/atom/dataAtom.ts
+++ b/src/atom/dataAtom.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai'
-import { unwrap, atomWithStorage } from 'jotai/utils'
+import { atomWithStorage } from 'jotai/utils'
 import { loadData } from '../data'
 import { processBiomarkers, processTime } from '../processors'
 import { rankData } from '../processors/stats'

--- a/src/data/archived/20230714.js
+++ b/src/data/archived/20230714.js
@@ -71,4 +71,3 @@ export default {
   ],
 }
 
-var url = ''

--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -3,7 +3,7 @@ import { Dialog, Transition } from '@headlessui/react'
 import { XMarkIcon, ClipboardDocumentIcon, CheckIcon } from '@heroicons/react/24/outline'
 import { useAtomValue } from 'jotai'
 import { notesAtom, dataMapAtom } from '../atom/dataAtom'
-import { correlationAlphaAtom, correlationAlternativeAtom } from '../atom/correlationAtom'
+import { correlationAlternativeAtom } from '../atom/correlationAtom'
 import { rankData, calculatePearson } from '../processors/stats'
 import { BiomarkerCorrelationProps, CorrelationResult } from './BiomarkerCorrelation.types'
 

--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -144,7 +144,7 @@ export default memo(({ data, keys }: ChartProps) => {
       })
       .reduce((result: any[][], entry) => {
         if (entry) {
-          const [key, values] = entry
+          const [, values] = entry
           values.forEach((v: number | null, i: number) => {
             if (!result[i]) {
               result[i] = [labels[i].slice(0, -2)]
@@ -194,7 +194,7 @@ export default memo(({ data, keys }: ChartProps) => {
         ...series[1],
         datasetIndex: 1,
         tooltip: {
-          formatter: (params: any) => {
+          formatter: (_params: any) => {
             return `<strong>Regression Trend</strong>`
           }
         }

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -21,7 +21,7 @@ import {
   aiModelAtom,
   rankedDataMapAtom,
 } from '../atom/dataAtom'
-import { calculateSpearman, calculateSpearmanRanked } from '../processors/stats'
+import { calculateSpearmanRanked } from '../processors/stats'
 import { averageCountAtom } from '../atom/averageValueAtom'
 import Markdown from 'react-markdown'
 import { Spinner } from './Spinner'
@@ -89,7 +89,7 @@ export default React.memo<NavProps>(
     const onToggle = () => setShow((v) => !v)
 
     const onAskAI = React.useCallback(
-      async (e: React.MouseEvent<HTMLButtonElement>) => {
+      async () => {
         if (selected.length === 0) {
           return
         }
@@ -187,14 +187,6 @@ export default React.memo<NavProps>(
       (e: React.ChangeEvent<HTMLSelectElement>) => setAverageCount(e.target.value),
       [],
     )
-
-    const onButtonClick = React.useCallback(
-      (e: React.MouseEvent<HTMLButtonElement>) => {
-        onSelect(e.currentTarget.name)
-      },
-      [onSelect],
-    )
-
     return (
       <>
         <nav

--- a/src/layout/PValue.tsx
+++ b/src/layout/PValue.tsx
@@ -8,7 +8,6 @@ import {
   correlationAlternativeAtom,
   correlationMethodAtom,
 } from '../atom/correlationAtom'
-import { BioMarker } from '../types/biomarker'
 import { calculateSpearmanRanked, calculatePearson } from '../processors/stats'
 import { PValueProps } from './PValue.types'
 

--- a/src/layout/SupplementsPopover.tsx
+++ b/src/layout/SupplementsPopover.tsx
@@ -1,6 +1,5 @@
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
 import { BeakerIcon } from '@heroicons/react/24/outline'
-import cn from 'classnames'
 
 interface Props {
   supps: string[]

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import cn from 'classnames'
 import { labels } from '../data'
 import { visibleDataAtom, notesAtom, filterTextAtom, tagAtom } from '../atom/dataAtom'
-import { BioMarker } from '../types/biomarker'
 import { useAtomValue } from 'jotai'
 import {
   useReactTable,

--- a/src/processors/post/range.ts
+++ b/src/processors/post/range.ts
@@ -144,7 +144,7 @@ export default (entry: Entry, strict?: boolean): Entry => {
     // Optimization: pre-calculate optimality to avoid repeated calculations in render loops
     extra.optimality = values.map((val) => extra.isNotOptimal?.(val) ?? false)
   } else if (extra) {
-    extra.isNotOptimal = (value: any) => false
+    extra.isNotOptimal = () => false
     extra.optimality = values.map(() => false)
   }
   return entry

--- a/src/processors/stats.ts
+++ b/src/processors/stats.ts
@@ -1,5 +1,3 @@
-import pcorrtest from '@stdlib/stats-pcorrtest'
-
 // Beta function approximation or exact implementation
 function betacf(a: number, b: number, x: number) {
   const MAXIT = 100

--- a/tests/benchmark.spec.ts
+++ b/tests/benchmark.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { calculateSpearmanRanked, calculatePearson } from '../src/processors/stats'
+import { calculatePearson } from '../src/processors/stats'
 
 test('compare logic edge cases', async () => {
   let x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/tests/benchmark.ts
+++ b/tests/benchmark.ts
@@ -1,46 +1,13 @@
 import pcorrtest from '@stdlib/stats-pcorrtest'
 
-const calculatePearsonValue = (x: number[], y: number[]) => {
-  const n = x.length
-  let sumX = 0
-  let sumY = 0
-  let sumXY = 0
-  let sumX2 = 0
-  let sumY2 = 0
-
-  for (let i = 0; i < n; i++) {
-    const xi = x[i]
-    const yi = y[i]
-    sumX += xi
-    sumY += yi
-    sumXY += xi * yi
-    sumX2 += xi * xi
-    sumY2 += yi * yi
-  }
-
-  const numerator = n * sumXY - sumX * sumY
-  const denominator = Math.sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY))
-
-  if (denominator === 0) return 0
-
-  // Clamp r to [-1, 1] to avoid NaN due to floating point inaccuracies
-  let r = numerator / denominator
-  if (r > 1) return 1
-  if (r < -1) return -1
-  return r
-}
 
 // ... existing code ...
 
-function pcorrtest_manual(
+export function pcorrtest_manual(
   x: number[],
   y: number[],
   options?: { alpha?: number; alternative?: 'two-sided' | 'less' | 'greater' },
 ) {
-  const alpha = options?.alpha ?? 0.05
-  const alternative = options?.alternative ?? 'two-sided'
-  const n = x.length
-  const r = calculatePearsonValue(x, y)
 
   // We can calculate the t-statistic threshold corresponding to alpha.
   // Instead of evaluating the CDF to get the exact p-value for every calculation,

--- a/tests/benchmark_biomarker_correlation.spec.ts
+++ b/tests/benchmark_biomarker_correlation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test } from '@playwright/test'
 import { calculateSpearmanRanked, rankData } from '../src/processors/stats'
 
 test('benchmark biomarker correlation optimized v4', async () => {

--- a/tests/benchmark_inferData.spec.ts
+++ b/tests/benchmark_inferData.spec.ts
@@ -53,9 +53,8 @@ test('benchmark inferData optimization', async () => {
 
   // Baseline
   const start1 = performance.now()
-  let result1;
-  for (let iter = 0; iter < 100; iter++) {
-    result1 = recipes.map(([name, fields, func, extra = {}]) => {
+    for (let iter = 0; iter < 100; iter++) {
+    recipes.map(([name, fields, func, extra = {}]) => {
       const values = Array.from({ length: periods }).map((_v, i) => {
         const fieldValues = fields.map((field) => entries.find(([n]) => n === field)?.[1][i])
 
@@ -76,15 +75,14 @@ test('benchmark inferData optimization', async () => {
 
   // Optimized
   const start2 = performance.now()
-  let result2;
-  for (let iter = 0; iter < 100; iter++) {
+    for (let iter = 0; iter < 100; iter++) {
     // Build a map of entry vectors ONCE per iter instead of calling find O(M * N) times
     const entryMap = new Map<string, number[]>()
     for (let i = 0; i < entries.length; i++) {
       entryMap.set(entries[i][0], entries[i][1])
     }
 
-    result2 = recipes.map(([name, fields, func, extra = {}]) => {
+    recipes.map(([name, fields, func, extra = {}]) => {
       // Look up vectors once per field
       const fieldArrays = fields.map(field => entryMap.get(field))
 

--- a/tests/benchmark_spearman_rank_Int8.spec.ts
+++ b/tests/benchmark_spearman_rank_Int8.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test } from '@playwright/test'
 import { rankData, calculateSpearmanRanked } from '../src/processors/stats'
 
 function rankBinaryDataArray(arr: number[]): Float64Array {

--- a/tests/verify_correlation_ui.spec.ts
+++ b/tests/verify_correlation_ui.spec.ts
@@ -21,7 +21,6 @@ test('Verify correlation dialog functionality', async ({ page }) => {
   await correlationButton.click()
 
   // Check if Correlation view appears
-  const dialogPanel = page.locator('div[role="dialog"]').first()
 
   // Take a screenshot of the correlation settings dialog
   await page.screenshot({ path: 'correlation_dialog.png' })


### PR DESCRIPTION
This PR resolves `eslint(no-unused-vars)` issues reported by `oxlint` in the `src` directory. Unused imports and unused variables/parameters have been safely removed to reduce confusion and keep the codebase clean.

Changes made:
- Removed unused imports like `unwrap`, `EyeIcon`, `EyeSlashIcon`, `BioMarker`, `cn`, `calculateSpearman`, `pcorrtest`, `correlationAlphaAtom`.
- Removed unused local variables like `url` in an old snapshot and unused function parameters/closures.
- The `no-loss-of-precision` and `unicorn/no-new-array` issues remain untouched as they were determined to potentially change processor/performance logic contrary to requirements.

All tests and TypeScript compilation pass after these changes.

---
*PR created automatically by Jules for task [956640382985133614](https://jules.google.com/task/956640382985133614) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unused imports, variables, and parameters across src and tests to resolve `oxlint` `eslint(no-unused-vars)` warnings. This is a cleanup only; no behavior changes.

- **Bug Fixes**
  - Deleted unused imports and types (e.g., from `@heroicons/react`, `jotai/utils`, `@stdlib/stats-pcorrtest`) and dropped unused locals/params.
  - Tweaked a few functions to ignore unused args and avoid unnecessary destructuring.
  - Left `no-loss-of-precision` and `unicorn/no-new-array` rules unchanged due to performance constraints; all tests and TypeScript build pass.

<sup>Written for commit cf72cad7b3210670b795e6dd0a56ab91bb31a05a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

