### PR TITLE
🎨 Palette: Make biomarker names clickable to toggle selection

### DIFF
--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -131,7 +131,8 @@ const TableRow = React.memo(
           <td className="p-2 border border-gray-700 text-center">
             <input
               type="checkbox"
-              className="w-4 h-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              id={`select-${String(rowId).replace(/[^a-zA-Z0-9-_]/g, '-')}`}
+              className="w-4 h-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
               name={name}
               aria-label={`Select ${name}`}
               title={`Select ${name}`}
@@ -180,7 +181,12 @@ const TableRow = React.memo(
             className="p-2 border border-gray-700 whitespace-nowrap sticky-left bg-dark-table-row"
             title={extra.description}
           >
-            {name}
+            <label
+              htmlFor={`select-${String(rowId).replace(/[^a-zA-Z0-9-_]/g, '-')}`}
+              className="cursor-pointer hover:text-blue-400 transition-colors"
+            >
+              {name}
+            </label>
           </th>
           {(!showOrigColumns || !extra.hasOrigin) ? (
             visibleValues.map((value: any, index: number) => {


### PR DESCRIPTION
💡 **What**: Wrapped the biomarker name in a `<label>` linked to the row's selection `<input type="checkbox">` via `htmlFor`. Added `cursor-pointer` and a hover color transition to indicate interactivity.
🎯 **Why**: Previously, users had to click exactly on the small 16x16px checkbox to select a biomarker for comparison or AI analysis. Clicking the biomarker name is a much larger target and a common expectation in data tables, reducing friction and making selection effortless.
📸 **Before/After**: (Visual validation complete via Playwright frontend screenshot)
♿ **Accessibility**: Improves accessibility by associating the text label with the checkbox input semantically (`htmlFor`/`id`), increasing the click target size for users with motor difficulties.

---
*PR created automatically by Jules for task [15084889519456259130](https://jules.google.com/task/15084889519456259130) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make biomarker names clickable labels that toggle the row’s selection checkbox. This expands the click target and improves accessibility, matching common table behavior.

<sup>Written for commit 0e1744381d581e9c12d6134c6bdd17a6e6667acf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

