### PR TITLE
Improve tooltip formatting in ScatterChart

### DIFF
--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -52,6 +52,22 @@ const echartsOptions: any = {
   ],
   tooltip: {
     triggerOn: 'mousemove',
+    backgroundColor: '#111111',
+    borderColor: '#3a3a3a80',
+    textStyle: {
+      color: '#f0f0f0',
+    },
+    formatter: (params: any) => {
+      // Return custom formatted string for scatter data points
+      if (params.seriesType === 'scatter' && params.value && params.value.length >= 3) {
+        // value[0] is X, value[1] is Y, value[2] is Date string, value[3] is Unit 1, value[4] is Unit 2
+        const [x, y, date, unitX, unitY] = params.value;
+        const dispX = unitX ? `${x} ${unitX}` : x;
+        const dispY = unitY ? `${y} ${unitY}` : y;
+        return `${date}<br/><strong>${params.dimensionNames[0]}:</strong> ${dispX}<br/><strong>${params.dimensionNames[1]}:</strong> ${dispY}`;
+      }
+      return params.name || params.seriesName || '';
+    }
   },
   grid: {
     top: 40,
@@ -130,7 +146,12 @@ export default memo(({ data, keys }: ChartProps) => {
     },
   ]
 
-  const [scatterData, scatterData2] = useMemo(() => {
+  const formatTime = (label: string) => {
+    if (!label || label.length < 6) return label
+    return `20${label.slice(0, 2)}/${label.slice(2, 4)}/${label.slice(4, 6)}`
+  }
+
+  const [scatterData, mappedScatterData] = useMemo(() => {
     // Optimization: use a local O(1) map for data lookups instead of O(N) array.find inside a map.
     // This reduces lookup complexity from O(N*K) to O(N + K).
     const dataMap = new Map()
@@ -147,7 +168,7 @@ export default memo(({ data, keys }: ChartProps) => {
           const [key, values] = entry
           values.forEach((v: number | null, i: number) => {
             if (!result[i]) {
-              result[i] = [labels[i].slice(0, -2)]
+              result[i] = [labels[i]]
             }
             result[i].push(v)
           })
@@ -156,15 +177,18 @@ export default memo(({ data, keys }: ChartProps) => {
       }, [])
       .filter((v) => v[1] !== null && v[1] !== undefined && v[2] !== null && v[2] !== undefined)
 
-    const excludedDate: number[][] = matchedData.map((v) => [+v[2], +v[1]])
+    const unitX = dataMap.get(keys[0])?.[2] || '';
+    const unitY = dataMap.get(keys[1])?.[2] || '';
+
+    const mappedScatterData: any[][] = matchedData.map((v) => [v[1], v[2], formatTime(v[0]), unitX, unitY])
 
     const scatterData: Record<string, any>[] = matchedData.map((v) => ({
       [keys[0]]: v[1],
       [keys[1]]: v[2],
-      date: v[0],
+      date: formatTime(v[0]),
     }))
 
-    return [scatterData, excludedDate]
+    return [scatterData, mappedScatterData]
   }, [keys, data])
 
   const scatterRef = useRef<any>(null)
@@ -174,12 +198,15 @@ export default memo(({ data, keys }: ChartProps) => {
     ;(xAxis as any[])[0].name = keys[0]
     ;(yAxis as any[])[0].name = keys[1]
 
-    const scatterData = scatterData2.map((v) => [v[1], v[0]])
-
-    const dataset: any[] = [{ source: scatterData }]
+    const dataset: any[] = [
+      {
+        dimensions: [keys[0], keys[1], 'Date'],
+        source: mappedScatterData,
+      },
+    ]
 
     // Guard against regression transform crash on <2 points
-    if (scatterData.length >= 2) {
+    if (mappedScatterData.length >= 2) {
       dataset.push({
         transform: {
           type: 'ecStat:regression',
@@ -190,7 +217,7 @@ export default memo(({ data, keys }: ChartProps) => {
     const nextSeries = [
       series[0],
       // Only include the regression series if dataset contains it
-      ...(scatterData.length >= 2 ? [{
+      ...(mappedScatterData.length >= 2 ? [{
         ...series[1],
         datasetIndex: 1,
         tooltip: {
@@ -208,17 +235,17 @@ export default memo(({ data, keys }: ChartProps) => {
       dataZoom: [
         {
           ...(echartsOptions.dataZoom as any[])[0],
-          startValue: scatterData.length > 0 ? Math.min(...scatterData.map((item) => item[0])) : 0,
-          endValue: scatterData.length > 0 ? Math.max(...scatterData.map((item) => item[0])) : 100,
+          startValue: mappedScatterData.length > 0 ? Math.min(...mappedScatterData.map((item) => item[0])) : 0,
+          endValue: mappedScatterData.length > 0 ? Math.max(...mappedScatterData.map((item) => item[0])) : 100,
         },
         {
           ...(echartsOptions.dataZoom as any[])[1],
-          startValue: scatterData.length > 0 ? Math.min(...scatterData.map((item) => item[1])) : 0,
-          endValue: scatterData.length > 0 ? Math.max(...scatterData.map((item) => item[1])) : 100,
+          startValue: mappedScatterData.length > 0 ? Math.min(...mappedScatterData.map((item) => item[1])) : 0,
+          endValue: mappedScatterData.length > 0 ? Math.max(...mappedScatterData.map((item) => item[1])) : 100,
         },
       ],
     }
-  }, [scatterData2, keys])
+  }, [mappedScatterData, keys])
 
   useEffect(() => {
     if (scatterRef.current) {


### PR DESCRIPTION
Improved tooltip formatting and date display in the main `Chart2.tsx` scatter plot chart. Added proper dark theme constants and data point units to the tooltip `formatter`.

Detailed documentation provided in commit message with the required Implementation Report and 3 new chart proposals.

---
*PR created automatically by Jules for task [14441291495430132457](https://jules.google.com/task/14441291495430132457) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved ScatterChart tooltip to show formatted dates and units, with dark theme styling. Addresses task 14441291495430132457 by fixing date truncation and making tooltip content clearer.

- **Bug Fixes**
  - Preserve full date label and format via `formatTime` (remove prior truncation).
  - Apply dark theme tooltip styles (background, border, text) and add a custom `formatter` for scatter points.
  - Extend dataset to include `[x, y, date, unitX, unitY]`; update series/regression usage and guard when <2 points.
  - Recompute dataZoom bounds from the mapped data and optimize lookups with a local map.

<sup>Written for commit 7ab4b7dcd3251b50fdee11e030aaa507bf1224f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

