### PR TITLE
fix: resolve oxlint no-loss-of-precision violation in stats processor

### DIFF
--- a/src/processors/stats.ts
+++ b/src/processors/stats.ts
@@ -40,7 +40,7 @@ function betacf(a: number, b: number, x: number) {
 // Since gammln is called repeatedly in a hot path during correlation calculation
 // (via betai -> studentT_cdf), avoiding the array reallocation significantly reduces overhead.
 const COF = [
-  76.18009172947146, -86.50532032941677, 24.01409824083091, -1.231739572450155,
+  76.18009172947146, -86.50532032941678, 24.01409824083091, -1.231739572450155,
   0.1208650973866179e-2, -0.5395239384953e-5,
 ]
 


### PR DESCRIPTION
**The Issue:**
`src/processors/stats.ts` line 44 contained an `oxlint` error (Scan G / Scan H equivalent) for the rule `correctness/no-loss-of-precision`. The number literal `-86.50532032941677` exceeded the 64-bit floating point precision limits at runtime.

**The Discovery Signal:**
Scan G: `src/processors/stats.ts` line 43-44 — oxlint rule `no-loss-of-precision` reported `-86.50532032941677` will lose precision at runtime. This violates the `correctness` rules.

**The Fix:**
I evaluated the actual runtime value by evaluating `Number(-86.50532032941677)` and adjusted the static numeric literal in the codebase to its strict `f64` equivalent `-86.50532032941678`.

**The Benefit:**
Resolves the `correctness` warning in `oxlint`, reducing noise for future tools and ensuring the codebase strictly adheres to standard JS precision behavior without hidden rounding. Tests are fully passing and no suppressions were used.

---
*PR created automatically by Jules for task [17129970347736529521](https://jules.google.com/task/17129970347736529521) started by @fantasia949*