### PR TITLE
⚡ Bolt: Optimize pre-processor array iterations

### DIFF
--- a/src/processors/pre/convertUnit.ts
+++ b/src/processors/pre/convertUnit.ts
@@ -98,14 +98,42 @@ const valueMapper = (
 }
 
 export default ([name, values, unit, extra]: Entry): Entry => {
-  const mappedResult = values.map((value) => valueMapper(value, unit, name))
-  const newValues = mappedResult.map((entry) => entry[0] as string)
-  const newUnit = mappedResult.map((entry) => entry[1]).filter(Boolean)[0] || unit
+  const len = values.length
+  // Optimization: Pre-allocate target arrays and use a single for-loop
+  // instead of chaining Array.map(), Array.filter(), and Array.some()
+  // to eliminate redundant iteration, reduce closure creation, and avoid
+  // heavy garbage collection overhead on intermediate array allocations.
+  const newValues = new Array(len)
+  const originValues = new Array(len)
+
+  let newUnit: string | undefined = undefined
+  let originUnit: string | undefined = undefined
+  let hasOrigin = false
+
+  for (let i = 0; i < len; i++) {
+    const [mappedVal, mappedUnit, mappedOriginVal, mappedOriginUnit] = valueMapper(values[i], unit, name)
+    newValues[i] = mappedVal as string
+
+    if (newUnit === undefined && mappedUnit) {
+      newUnit = mappedUnit
+    }
+
+    if (mappedOriginVal !== undefined) {
+      hasOrigin = true
+      originValues[i] = mappedOriginVal
+    } else {
+      originValues[i] = null
+    }
+
+    if (originUnit === undefined && mappedOriginUnit) {
+      originUnit = mappedOriginUnit
+    }
+  }
 
   const newExtra = extra || {}
-  newExtra.hasOrigin = mappedResult.some((entry) => entry[2] !== undefined)
-  newExtra.originValues = mappedResult.map((entry) => entry[2] ?? null)
-  newExtra.originUnit = mappedResult.map((entry) => entry[3]).filter(Boolean)[0]
+  newExtra.hasOrigin = hasOrigin
+  newExtra.originValues = originValues
+  newExtra.originUnit = originUnit
 
-  return [name, newValues, newUnit, newExtra]
+  return [name, newValues, newUnit || unit, newExtra]
 }


### PR DESCRIPTION
💡 **What:** Optimized the unit conversion logic in `src/processors/pre/convertUnit.ts`. Replaced chained array methods (`.map()`, `.filter()`, `.some()`) with a single pre-allocated `for` loop.
🎯 **Why:** The previous implementation iterated over the `values` array 5 times to construct the final output object, creating multiple intermediate arrays and closures. This created unnecessary garbage collection overhead and redundant iterations in the pre-processing pipeline.
📊 **Impact:** Reduces time complexity of the operation from O(5N) to O(N). Eliminates allocations for 5 intermediate arrays per data entry. This speeds up the initial data loading phase, particularly for large historical datasets.
🔬 **Measurement:** Evaluated by observing faster initial render times and verified by running all UI and performance test suites (`pnpm exec playwright test`).

---
*PR created automatically by Jules for task [7076304631012341197](https://jules.google.com/task/7076304631012341197) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized unit conversion in `src/processors/pre/convertUnit.ts` by replacing chained array methods with a single pre-allocated loop. This removes extra iterations and allocations, improving load time on large datasets.

- **Refactors**
  - Replaced `.map()/.filter()/.some()` chain with one for-loop over `values`.
  - Pre-allocated `newValues` and `originValues`; compute `newUnit`, `originUnit`, and `hasOrigin` in-loop.
  - Falls back to original `unit` when no converted unit is found; output shape unchanged.

<sup>Written for commit a82331a4ae15d753124634d6be7d9c1d67748450. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

