### PR TITLE
🎨 Palette: Improve clarity and context for icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -92,3 +92,6 @@
 
 **Learning:** Found that `<select>` elements and secondary action buttons (like "Copy Analysis" or "Save to Gist") in modals often lose their default browser focus rings when styled with Tailwind (e.g., using `outline-none` or custom borders). This renders them completely inaccessible to keyboard users navigating via Tab.
 **Action:** Always ensure that custom-styled form inputs and interactive elements explicitly include `focus-visible:ring-2 focus-visible:ring-blue-500` to restore clear keyboard focus indicators without adding unintended visual outlines for mouse clicks.
+## 2025-05-24 - Enhance clarity and accessibility of repeating table buttons
+**Learning:** Repeating icon-only buttons in table rows (like 'Expand chart' or 'Correlation Analysis') create a highly ambiguous experience for screen reader users and those reliant on tooltips, as they lack row-specific context.
+**Action:** When rendering lists or tables with repeated action buttons, inject dynamic row-specific context into the `aria-label` and `title` attributes (e.g., `aria-label="Expand chart for ${itemName}"`) to eliminate ambiguity and provide clearer tooltips. Update corresponding Playwright tests using CSS prefix/suffix selectors (e.g., `locator('button[title^="Expand chart for"]')`) to ensure robust validation.

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -204,11 +204,11 @@ export default React.memo<NavProps>(
               className="lg:hidden p-2 text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
               type="button"
               onClick={onToggle}
-              aria-label="Toggle menu"
-              title="Toggle menu"
+              aria-label={show ? "Close menu" : "Open menu"}
+              title={show ? "Close menu" : "Open menu"}
               aria-expanded={show}
             >
-              <Bars3Icon className="h-6 w-6" />
+              {show ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
             </button>
             <div className="w-full min-w-40 lg:w-auto flex-1 lg:flex-none">
               <div className="relative text-gray-400 focus-within:text-gray-200">

--- a/src/layout/SupplementsPopover.tsx
+++ b/src/layout/SupplementsPopover.tsx
@@ -11,8 +11,8 @@ export default function SupplementsPopover({ supps }: Props) {
   return (
     <Popover className="w-full h-full flex justify-center items-center">
       <PopoverButton
-        aria-label="View supplements"
-        title="View supplements taken on this date"
+        aria-label={`View ${supps.length} supplement${supps.length !== 1 ? 's' : ''}`}
+        title={`View ${supps.length} supplement${supps.length !== 1 ? 's' : ''} taken on this date`}
         className="w-full h-full cursor-pointer hover:bg-gray-800 hover:text-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded font-bold transition-colors flex justify-center items-center p-1"
       >
         <BeakerIcon className="h-5 w-5" />

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -145,9 +145,9 @@ const TableRow = React.memo(
               <button
                 type="button"
                 onClick={() => toggleExpand(rowId)}
-                title={isExpanded ? 'Collapse chart' : 'Expand chart'}
+                title={isExpanded ? `Collapse chart for ${name}` : `Expand chart for ${name}`}
                 className="hover:text-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded p-1"
-                aria-label={isExpanded ? 'Collapse chart' : 'Expand chart'}
+                aria-label={isExpanded ? `Collapse chart for ${name}` : `Expand chart for ${name}`}
                 aria-expanded={isExpanded}
               >
                 {isExpanded ? (
@@ -159,18 +159,18 @@ const TableRow = React.memo(
               <button
                 type="button"
                 onClick={() => onCorrelation(name)}
-                title="Correlation Analysis"
+                title={`Correlate ${name} with other biomarkers`}
                 className="hover:text-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded p-1"
-                aria-label="Correlation Analysis"
+                aria-label={`Correlate ${name} with other biomarkers`}
               >
                 <ArrowsRightLeftIcon className="h-5 w-5" />
               </button>
               <button
                 type="button"
                 onClick={() => setCorrelationBiomarker(name)}
-                title="View Correlations"
+                title={`Correlate ${name} with supplements`}
                 className="hover:text-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded p-1"
-                aria-label={`View correlations for ${name}`}
+                aria-label={`Correlate ${name} with supplements`}
               >
                 <CalculatorIcon className="h-5 w-5" />
               </button>

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -5,21 +5,24 @@ test('chart toggle button is accessible', async ({ page }) => {
 
   // Wait for the table to populate by waiting for the toggle button to be attached
   // We use first() because there are multiple buttons
-  const toggleButton = page.locator('button[title="Expand chart"]').first()
+  const toggleButton = page.locator('button[title^="Expand chart for"]').first()
 
   // Wait for it to be visible. This implicitly waits for the element to appear.
   await expect(toggleButton).toBeVisible({ timeout: 10000 })
 
+  const title = await toggleButton.getAttribute('title')
+  const biomarkerName = title?.replace('Expand chart for ', '') || ''
+
   // Verify it has aria-expanded="false"
   await expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
-  await expect(toggleButton).toHaveAttribute('aria-label', 'Expand chart')
+  await expect(toggleButton).toHaveAttribute('aria-label', `Expand chart for ${biomarkerName}`)
 
   // Click it
   await toggleButton.click()
 
-  // Verify aria-label changes to "Collapse chart"
-  const expandedButton = page.locator('button[title="Collapse chart"]').first()
-  await expect(expandedButton).toHaveAttribute('aria-label', 'Collapse chart')
+  // Verify aria-label changes to "Collapse chart for <name>"
+  const expandedButton = page.locator(`button[title="Collapse chart for ${biomarkerName}"]`).first()
+  await expect(expandedButton).toHaveAttribute('aria-label', `Collapse chart for ${biomarkerName}`)
 
   // Verify aria-expanded changes to "true"
   await expect(expandedButton).toHaveAttribute('aria-expanded', 'true')
@@ -147,14 +150,14 @@ test('supplements popover button has accessible label', async ({ page }) => {
 
   // Find the button with visible text "?"
   // We use filter hasText to find the button element containing "?"
-  const popoverButton = page.locator('button[aria-label="View supplements"]').first()
+  const popoverButton = page.locator('button[aria-label^="View "][aria-label$=" supplement"]').or(page.locator('button[aria-label^="View "][aria-label$=" supplements"]')).first()
 
   // Verify it's visible
   await expect(popoverButton).toBeVisible()
 
   // Verify it has the expected aria-label
-  await expect(popoverButton).toHaveAttribute('aria-label', 'View supplements')
+  await expect(popoverButton).toHaveAttribute('aria-label', /^View \d+ supplements?$/)
 
   // Verify it has the expected title
-  await expect(popoverButton).toHaveAttribute('title', 'View supplements taken on this date')
+  await expect(popoverButton).toHaveAttribute('title', /^View \d+ supplements? taken on this date$/)
 })

--- a/tests/correlation_controls.spec.ts
+++ b/tests/correlation_controls.spec.ts
@@ -12,7 +12,7 @@ test('Correlation controls appear and are functional', async ({ page }) => {
   await expect(rowLocator).toBeVisible({ timeout: 10000 })
 
   // Locate the new button in the first row
-  const correlationButton = rowLocator.locator('button[aria-label="Correlation Analysis"]')
+  const correlationButton = rowLocator.locator('button[title^="Correlate "][title$=" other biomarkers"]')
   await expect(correlationButton).toBeVisible()
 
   // Click it
@@ -53,7 +53,7 @@ test('Correlation controls appear and are functional', async ({ page }) => {
 
   // Re-open using the row button
   const newRowLocator = page.locator('tbody tr:has(input[type="checkbox"])').first()
-  await newRowLocator.locator('button[aria-label="Correlation Analysis"]').click()
+  await newRowLocator.locator('button[title^="Correlate "][title$=" other biomarkers"]').click()
 
   // Check values
   await expect(alphaSelect).toHaveValue('0.05')

--- a/tests/dialog_focus.spec.ts
+++ b/tests/dialog_focus.spec.ts
@@ -12,7 +12,7 @@ test('dialog close buttons should have visible focus styles', async ({ page }) =
   await firstCheckbox.check()
 
   // Click "Correlations" button in Nav
-  await page.getByRole('button', { name: 'View correlations for RBC' }).click()
+  await page.getByRole('button', { name: 'Correlate RBC with supplements' }).click()
 
   // Wait for button (this implies dialog is open)
   const closeCorrelation = page.getByRole('button', { name: 'Close dialog' }).first()

--- a/tests/pearson_perf_verification.spec.ts
+++ b/tests/pearson_perf_verification.spec.ts
@@ -9,7 +9,7 @@ test('Verify Pearson correlation functionality and performance', async ({ page }
   await expect(rowLocator).toBeVisible({ timeout: 15000 })
 
   // 3. Click "Correlation Analysis" on the first row
-  const correlationButton = rowLocator.locator('button[aria-label="Correlation Analysis"]')
+  const correlationButton = rowLocator.locator('button[title^="Correlate "][title$=" other biomarkers"]')
   await expect(correlationButton).toBeVisible()
   await correlationButton.click()
 

--- a/tests/popover_verification.spec.ts
+++ b/tests/popover_verification.spec.ts
@@ -13,7 +13,7 @@ test('supplements popover functionality', async ({ page }) => {
 
   // Locate the "?" button in the footer
   // Use a specific locator to avoid confusion with other "?"
-  const popoverButton = page.locator('tfoot button[aria-label="View supplements"]').first()
+  const popoverButton = page.locator('tfoot button[aria-label^="View "]').first()
 
   // Ensure it exists
   const count = await popoverButton.count()

--- a/tests/ux_verification.spec.ts
+++ b/tests/ux_verification.spec.ts
@@ -8,26 +8,28 @@ test('table has accessible chart toggle buttons', async ({ page }) => {
   await page.waitForTimeout(2000)
 
   // Look for ANY chart toggle button using title which is stable
-  const toggleButton = page.locator('button[title="Expand chart"]').first()
+  const toggleButton = page.locator('button[title^="Expand chart for"]').first()
 
   // Check if it's visible
   await expect(toggleButton).toBeVisible()
 
   // Check ARIA attributes (initial state)
   // It should be expanded false initially
+  const title = await toggleButton.getAttribute('title')
+  const biomarkerName = title?.replace('Expand chart for ', '')
   await expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
-  await expect(toggleButton).toHaveAttribute('aria-label', 'Expand chart')
+  await expect(toggleButton).toHaveAttribute('aria-label', `Expand chart for ${biomarkerName}`)
 
   // Test interaction
   await toggleButton.click()
 
-  const expandedButton = page.locator('button[title="Collapse chart"]').first()
+  const expandedButton = page.locator(`button[title="Collapse chart for ${biomarkerName}"]`).first()
 
   // After click, it should be expanded true and label should change
   await expect(expandedButton).toBeVisible()
   await expect(expandedButton).toHaveAttribute('aria-expanded', 'true')
-  await expect(expandedButton).toHaveAttribute('aria-label', 'Collapse chart')
-  await expect(expandedButton).toHaveAttribute('title', 'Collapse chart')
+  await expect(expandedButton).toHaveAttribute('aria-label', `Collapse chart for ${biomarkerName}`)
+  await expect(expandedButton).toHaveAttribute('title', `Collapse chart for ${biomarkerName}`)
 })
 
 test('data cells show copied feedback on click', async ({ context, page }) => {

--- a/tests/verify_correlation_table.spec.ts
+++ b/tests/verify_correlation_table.spec.ts
@@ -16,7 +16,7 @@ test('Correlation results are rendered in a semantic table', async ({ page }) =>
   await firstCheckbox.check()
 
   // Click "Correlation" button in the table row.
-  const correlationButton = page.getByRole('button', { name: 'View correlations for RBC' })
+  const correlationButton = page.getByRole('button', { name: 'Correlate RBC with supplements' })
   await expect(correlationButton).toBeVisible()
   await correlationButton.click()
 

--- a/tests/verify_correlation_ui.spec.ts
+++ b/tests/verify_correlation_ui.spec.ts
@@ -16,7 +16,7 @@ test('Verify correlation dialog functionality', async ({ page }) => {
   await firstCheckbox.check()
 
   // Click "Correlation" button in the table row.
-  const correlationButton = page.getByRole('button', { name: 'View correlations for RBC' })
+  const correlationButton = page.getByRole('button', { name: 'Correlate RBC with supplements' })
   await expect(correlationButton).toBeVisible()
   await correlationButton.click()
 

--- a/tests/verify_popover.spec.ts
+++ b/tests/verify_popover.spec.ts
@@ -9,7 +9,7 @@ test('verify supplements popover functionality', async ({ page }) => {
   // Locate the first supplements popover button (beaker icon) in the footer
   // It's in the tfoot > tr > th > button
   // We can select by aria-label "View supplements"
-  const popoverButton = page.locator('button[aria-label="View supplements"]').first()
+  const popoverButton = page.locator('button[aria-label^="View "]').first()
 
   await expect(popoverButton).toBeVisible()
 


### PR DESCRIPTION
💡 **What:**
- Enhanced `aria-label` and `title` attributes for `Table.tsx`'s "Expand chart", "Correlation Analysis", and "View Correlations" icon-only buttons to be dynamic, injecting the specific biomarker name to eliminate ambiguity (e.g. `Correlate RBC with other biomarkers`).
- Updated `Nav.tsx`'s mobile menu toggle button to explicitly state "Open menu" or "Close menu" depending on its state, and swaps its icon dynamically.
- Enhanced `SupplementsPopover.tsx`'s button to read out the exact number of supplements it contains.

🎯 **Why:**
Screen reader users and users reliant on tooltips struggle when lists or tables repeat generic icon-only buttons (like "Expand chart" on every single row) because it's unclear *which* row they are interacting with. Adding context to the `aria-label` and `title` makes the UI substantially more predictable and accessible.

📸 **Before/After:**
- **Before:** "Correlation Analysis"
- **After:** "Correlate Glucose with other biomarkers"

♿ **Accessibility:**
- Better ARIA labels for screen reader navigation
- Dynamic tooltips for clear, disambiguated hover intent

---
*PR created automatically by Jules for task [9278905742931150192](https://jules.google.com/task/9278905742931150192) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make icon-only buttons context-aware and screen-reader friendly by adding dynamic aria-label and title text across tables, the mobile nav, and the supplements popover. This removes ambiguity in repeated actions and improves tooltip clarity; tests were updated accordingly.

- **New Features**
  - Table: dynamic labels/titles for expand/collapse charts and both correlation buttons (e.g., “Expand chart for Glucose”, “Correlate Glucose with supplements”).
  - Nav: mobile menu button now says “Open menu”/“Close menu” and swaps between `Bars3Icon`/`XMarkIcon`.
  - Supplements popover: button now announces the exact count (e.g., “View 3 supplements”) with correct pluralization.
  - Tests: Playwright locators updated to match new dynamic titles/labels using prefix/suffix selectors.

<sup>Written for commit a517011bc785b6e9c8b70820522dcef7c9e8e4ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

