### PR TITLE
fix: remove unused formatTime function in Chart2.tsx

### DIFF
--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -125,11 +125,6 @@ const echartsOptions: any = {
   ],
 }
 
-const formatTime = (label: string) => {
-  if (!label || label.length < 6) return label
-  return `20${label.slice(0, 2)}/${label.slice(2, 4)}/${label.slice(4, 6)}`
-}
-
 export default memo(({ data, keys }: ChartProps) => {
   const valueList = [
     { fieldKey: keys[0], fieldName: keys[0], decimalLength: 2 },


### PR DESCRIPTION
Removed the module-level `formatTime` function in `src/layout/Chart2.tsx` to resolve an active `eslint(no-unused-vars)` oxlint violation.

---
*PR created automatically by Jules for task [2092450101655638072](https://jules.google.com/task/2092450101655638072) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `formatTime` helper from `src/layout/Chart2.tsx` to fix an `eslint(no-unused-vars)` oxlint violation and remove dead code.

<sup>Written for commit dd908b62cfe99b636439fd074ccf7e015f7204c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

