### PR TITLE
⚡ Bolt: Optimize convertUnit data mapping loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-03-04 - Eliminate garbage collection overhead by hoisting invariants
 **Learning:** React component memoization (`useMemo`) is often not enough for heavy statistical operations (like P-value / Correlation mapping across datasets). Object literals inside hot loops (e.g., passing `{ alpha: 0.05 }` to a statistical test) or repeatedly allocating math coefficients inside pure functions will flood the engine with short-lived objects. This triggers garbage collection spikes that block the main thread.
 **Action:** Always hoist configuration objects (`options`) to the top of loops/closures or to module scope. For mathematical function constants, extract them directly to module-scoped `const` arrays instead of allocating them dynamically within the function call.
+
+## 2025-03-28 - Optimizing `Array.map().filter().some()` chains
+**Learning:** Chained array methods like `.map().filter(Boolean)[0]` or `.some()` inside the data processing pipeline (`convertUnit.ts`) create unnecessary O(N*M) iterations and repeated memory allocations, triggering garbage collection delays on hot paths.
+**Action:** Replace chained array methods with a single-pass `for` loop, allocating the output array directly (`new Array(len)`) and updating flags concurrently.

--- a/src/processors/pre/convertUnit.ts
+++ b/src/processors/pre/convertUnit.ts
@@ -98,14 +98,40 @@ const valueMapper = (
 }
 
 export default ([name, values, unit, extra]: Entry): Entry => {
-  const mappedResult = values.map((value) => valueMapper(value, unit, name))
-  const newValues = mappedResult.map((entry) => entry[0] as string)
-  const newUnit = mappedResult.map((entry) => entry[1]).filter(Boolean)[0] || unit
+  // Optimization: Consolidate multiple O(N) array iterations (.map, .filter, .some)
+  // into a single-pass O(N) loop with pre-allocated arrays.
+  // This significantly reduces closure creation and garbage collection overhead in the data pipeline.
+  const len = values.length
+  const newValues = new Array(len)
+  const originValues = new Array(len)
+
+  let newUnit = ''
+  let originUnit = ''
+  let hasOrigin = false
+
+  for (let i = 0; i < len; i++) {
+    const [resVal, resUnit, origVal, origUnit] = valueMapper(values[i], unit, name)
+
+    newValues[i] = resVal as string
+    originValues[i] = origVal ?? null
+
+    if (resUnit && !newUnit) {
+      newUnit = resUnit
+    }
+
+    if (origVal !== undefined) {
+      hasOrigin = true
+    }
+
+    if (origUnit && !originUnit) {
+      originUnit = origUnit
+    }
+  }
 
   const newExtra = extra || {}
-  newExtra.hasOrigin = mappedResult.some((entry) => entry[2] !== undefined)
-  newExtra.originValues = mappedResult.map((entry) => entry[2] ?? null)
-  newExtra.originUnit = mappedResult.map((entry) => entry[3]).filter(Boolean)[0]
+  newExtra.hasOrigin = hasOrigin
+  newExtra.originValues = originValues
+  newExtra.originUnit = originUnit || undefined
 
-  return [name, newValues, newUnit, newExtra]
+  return [name, newValues, newUnit || unit, newExtra]
 }


### PR DESCRIPTION
⚡ Bolt: Optimize convertUnit data mapping loops

💡 What: Replaced chained array mapping methods (`.map().filter().some()`) inside `src/processors/pre/convertUnit.ts` with a single-pass `for` loop using pre-allocated arrays.
🎯 Why: Chaining `Array.map` on multi-value arrays in a hot data processing pipeline creates redundant closures and intermediate arrays that bloat memory and trigger garbage collection.
📊 Impact: Reduces array allocations and iteration overhead for biomarker conversions significantly.
🔬 Measurement: Verified by `pnpm lint` and `pnpm test`. All E2E Playwright tests and statistical benchmarks still pass.

---
*PR created automatically by Jules for task [10165189840110211361](https://jules.google.com/task/10165189840110211361) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up unit conversion by replacing chained array operations with a single-pass loop to cut allocations and GC in a hot path. Behavior is unchanged and unit defaults are preserved.

- **Refactors**
  - Replaced `.map/.filter/.some` in `src/processors/pre/convertUnit.ts` with a single `for` loop and pre-allocated arrays.
  - Compute `newUnit`, `originUnit`, `hasOrigin`, and `originValues` during the loop; fall back to the input `unit` when none is returned.
  - Added guidance to `.jules/bolt.md` on avoiding chained array allocations.

<sup>Written for commit 5b985bc62235b6f53586f9faec4756834c57a0f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

