### PR TITLE
🎨 Palette: Dynamic Row Action Labels & Tooltips

### DIFF
--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -145,9 +145,9 @@ const TableRow = React.memo(
               <button
                 type="button"
                 onClick={() => toggleExpand(rowId)}
-                title={isExpanded ? 'Collapse chart' : 'Expand chart'}
+                title={isExpanded ? `Collapse chart for ${name}` : `Expand chart for ${name}`}
                 className="hover:text-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded p-1"
-                aria-label={isExpanded ? 'Collapse chart' : 'Expand chart'}
+                aria-label={isExpanded ? `Collapse chart for ${name}` : `Expand chart for ${name}`}
                 aria-expanded={isExpanded}
               >
                 {isExpanded ? (
@@ -159,16 +159,16 @@ const TableRow = React.memo(
               <button
                 type="button"
                 onClick={() => onCorrelation(name)}
-                title="Correlation Analysis"
+                title={`Correlation Analysis for ${name}`}
                 className="hover:text-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded p-1"
-                aria-label="Correlation Analysis"
+                aria-label={`Correlation Analysis for ${name}`}
               >
                 <ArrowsRightLeftIcon className="h-5 w-5" />
               </button>
               <button
                 type="button"
                 onClick={() => setCorrelationBiomarker(name)}
-                title="View Correlations"
+                title={`View correlations for ${name}`}
                 className="hover:text-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded p-1"
                 aria-label={`View correlations for ${name}`}
               >

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -5,21 +5,21 @@ test('chart toggle button is accessible', async ({ page }) => {
 
   // Wait for the table to populate by waiting for the toggle button to be attached
   // We use first() because there are multiple buttons
-  const toggleButton = page.locator('button[title="Expand chart"]').first()
+  const toggleButton = page.locator('button[title^="Expand chart"]').first()
 
   // Wait for it to be visible. This implicitly waits for the element to appear.
   await expect(toggleButton).toBeVisible({ timeout: 10000 })
 
   // Verify it has aria-expanded="false"
   await expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
-  await expect(toggleButton).toHaveAttribute('aria-label', 'Expand chart')
+  await expect(toggleButton).toHaveAttribute('aria-label', /^Expand chart for /)
 
   // Click it
   await toggleButton.click()
 
   // Verify aria-label changes to "Collapse chart"
-  const expandedButton = page.locator('button[title="Collapse chart"]').first()
-  await expect(expandedButton).toHaveAttribute('aria-label', 'Collapse chart')
+  const expandedButton = page.locator('button[title^="Collapse chart"]').first()
+  await expect(expandedButton).toHaveAttribute('aria-label', /^Collapse chart for /)
 
   // Verify aria-expanded changes to "true"
   await expect(expandedButton).toHaveAttribute('aria-expanded', 'true')

--- a/tests/correlation_controls.spec.ts
+++ b/tests/correlation_controls.spec.ts
@@ -12,7 +12,7 @@ test('Correlation controls appear and are functional', async ({ page }) => {
   await expect(rowLocator).toBeVisible({ timeout: 10000 })
 
   // Locate the new button in the first row
-  const correlationButton = rowLocator.locator('button[aria-label="Correlation Analysis"]')
+  const correlationButton = rowLocator.locator('button[aria-label^="Correlation Analysis for"]')
   await expect(correlationButton).toBeVisible()
 
   // Click it
@@ -53,7 +53,7 @@ test('Correlation controls appear and are functional', async ({ page }) => {
 
   // Re-open using the row button
   const newRowLocator = page.locator('tbody tr:has(input[type="checkbox"])').first()
-  await newRowLocator.locator('button[aria-label="Correlation Analysis"]').click()
+  await newRowLocator.locator('button[aria-label^="Correlation Analysis for"]').click()
 
   // Check values
   await expect(alphaSelect).toHaveValue('0.05')

--- a/tests/pearson_perf_verification.spec.ts
+++ b/tests/pearson_perf_verification.spec.ts
@@ -9,7 +9,7 @@ test('Verify Pearson correlation functionality and performance', async ({ page }
   await expect(rowLocator).toBeVisible({ timeout: 15000 })
 
   // 3. Click "Correlation Analysis" on the first row
-  const correlationButton = rowLocator.locator('button[aria-label="Correlation Analysis"]')
+  const correlationButton = rowLocator.locator('button[aria-label^="Correlation Analysis for"]')
   await expect(correlationButton).toBeVisible()
   await correlationButton.click()
 

--- a/tests/ux_verification.spec.ts
+++ b/tests/ux_verification.spec.ts
@@ -8,7 +8,7 @@ test('table has accessible chart toggle buttons', async ({ page }) => {
   await page.waitForTimeout(2000)
 
   // Look for ANY chart toggle button using title which is stable
-  const toggleButton = page.locator('button[title="Expand chart"]').first()
+  const toggleButton = page.locator('button[title^="Expand chart"]').first()
 
   // Check if it's visible
   await expect(toggleButton).toBeVisible()
@@ -16,18 +16,18 @@ test('table has accessible chart toggle buttons', async ({ page }) => {
   // Check ARIA attributes (initial state)
   // It should be expanded false initially
   await expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
-  await expect(toggleButton).toHaveAttribute('aria-label', 'Expand chart')
+  await expect(toggleButton).toHaveAttribute('aria-label', /^Expand chart for /)
 
   // Test interaction
   await toggleButton.click()
 
-  const expandedButton = page.locator('button[title="Collapse chart"]').first()
+  const expandedButton = page.locator('button[title^="Collapse chart"]').first()
 
   // After click, it should be expanded true and label should change
   await expect(expandedButton).toBeVisible()
   await expect(expandedButton).toHaveAttribute('aria-expanded', 'true')
-  await expect(expandedButton).toHaveAttribute('aria-label', 'Collapse chart')
-  await expect(expandedButton).toHaveAttribute('title', 'Collapse chart')
+  await expect(expandedButton).toHaveAttribute('aria-label', /^Collapse chart for /)
+  await expect(expandedButton).toHaveAttribute('title', /^Collapse chart for /)
 })
 
 test('data cells show copied feedback on click', async ({ context, page }) => {


### PR DESCRIPTION
🎨 Palette: Dynamic Row Action Labels & Tooltips

**💡 What:** 
Updated the action buttons in the data table ("Expand chart", "Correlation Analysis", "View Correlations") to include the specific biomarker name in their `title` and `aria-label` attributes.
Updated all corresponding Playwright end-to-end tests to use prefix matching (`^=`) for locators to remain robust against the dynamic strings.

**🎯 Why:** 
Previously, these buttons had generic labels (e.g., "Expand chart"). When using a screen reader or hovering for a tooltip, it was unclear *which* specific row/biomarker the button interacted with, creating ambiguity. By injecting the row's `name` context (e.g., "Expand chart for RBC"), we improve both accessibility and general usability.

**♿ Accessibility:**
Screen reader users will now hear exactly which item an action applies to when navigating interactive elements out of context, rather than hearing "Expand chart" repeatedly without context.

---
*PR created automatically by Jules for task [15167816731572973356](https://jules.google.com/task/15167816731572973356) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Row action buttons now include the biomarker name in their title and aria-label (Expand/Collapse chart, Correlation Analysis, View correlations) for clearer tooltips and better accessibility. Updated end-to-end tests to use prefix matching for the new dynamic strings.

<sup>Written for commit 7cccf2259fe4e489c0c2b7a4326875da7444b3d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

