### PR TITLE
Refactor: Eliminate weak any type in BiomarkerCorrelation

### DIFF
--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -122,7 +122,7 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
       // Optimization: Point-biserial correlation is mathematically equivalent to Pearson
       // correlation on the ranked continuous variable against the unranked binary indicator variable.
       // This bypasses the ranking overhead for the binary vectors completely.
-      const result: any = calculatePearson(rankedBiomarker, filteredSuppVector, options)
+      const result = calculatePearson(rankedBiomarker, filteredSuppVector, options)
 
       const rho = result.pcorr
       const pVal = result.pValue


### PR DESCRIPTION
**The Issue:**
`src/layout/BiomarkerCorrelation.tsx` on line 125 defines `const result: any = calculatePearson(...)`. This assigns an explicit `any` annotation to a result object that TypeScript can otherwise perfectly infer from the `calculatePearson` function signature (which returns `{ pcorr, statistic, pValue, ... }`). This is a structural problem representing an unsafe typing pattern surfaced by Scan H.

**The Discovery Signal:**
Scan H: `src/layout/BiomarkerCorrelation.tsx` line 125 - Explicit `any` used on the `result` variable where a concrete type is directly inferrable from usage and the function signature.

**The Fix:**
Removed the `: any` annotation from `const result: any = calculatePearson(...)`, allowing TypeScript to implicitly infer the correct strong type from `src/processors/stats.ts`.

**The Benefit:**
Eliminates a weak type assignment, thereby improving type safety without needing to invent or import new interfaces. Future agents and tooling will encounter cleaner type analysis output, and the codebase will avoid potential regressions related to accessing properties on an `any`-typed result.

---
*PR created automatically by Jules for task [812404504958864777](https://jules.google.com/task/812404504958864777) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the explicit any type from the calculatePearson result in `src/layout/BiomarkerCorrelation.tsx` to use TypeScript inference and improve type safety. No runtime behavior changes.

<sup>Written for commit af7d0c2b1552cef8f499a08ef4fdf6f2e5d56125. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

