### PR TITLE
build: update echarts dependency to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@stdlib/stats-pcorrtest": "0.2.3",
     "@tanstack/react-table": "^8.21.3",
     "classnames": "2.5.1",
-    "echarts": "5.6.0",
+    "echarts": "6.0.0",
     "echarts-for-react": "^3.0.6",
     "echarts-stat": "^1.2.0",
     "jotai": "^2.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
         version: 1.2.0
       '@echarts-readymade/line':
         specifier: 1.2.0
-        version: 1.2.0(echarts-for-react@3.0.6(echarts@5.6.0)(react@19.2.4))(echarts@5.6.0)
+        version: 1.2.0(echarts-for-react@3.0.6(echarts@6.0.0)(react@19.2.4))(echarts@6.0.0)
       '@echarts-readymade/scatter':
         specifier: 1.2.0
-        version: 1.2.0(echarts-for-react@3.0.6(echarts@5.6.0)(react@19.2.4))(echarts@5.6.0)
+        version: 1.2.0(echarts-for-react@3.0.6(echarts@6.0.0)(react@19.2.4))(echarts@6.0.0)
       '@headlessui/react':
         specifier: ^2.2.9
         version: 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -33,11 +33,11 @@ importers:
         specifier: 2.5.1
         version: 2.5.1
       echarts:
-        specifier: 5.6.0
-        version: 5.6.0
+        specifier: 6.0.0
+        version: 6.0.0
       echarts-for-react:
         specifier: ^3.0.6
-        version: 3.0.6(echarts@5.6.0)(react@19.2.4)
+        version: 3.0.6(echarts@6.0.0)(react@19.2.4)
       echarts-stat:
         specifier: ^1.2.0
         version: 1.2.0
@@ -3569,8 +3569,8 @@ packages:
   echarts-stat@1.2.0:
     resolution: {integrity: sha512-zLd7Kgs+tuTSeaK0VQEMNmnMivEkhvHIk1gpBtLzpRerfcIQ+Bd5XudOMmtwpaTc1WDZbA7d1V//iiBccR46Qg==}
 
-  echarts@5.6.0:
-    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+  echarts@6.0.0:
+    resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
 
   editorconfig@1.0.4:
     resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
@@ -5133,8 +5133,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zrender@5.6.1:
-    resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
+  zrender@6.0.0:
+    resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -5806,21 +5806,21 @@ snapshots:
     dependencies:
       big.js: 6.2.2
 
-  '@echarts-readymade/line@1.2.0(echarts-for-react@3.0.6(echarts@5.6.0)(react@19.2.4))(echarts@5.6.0)':
+  '@echarts-readymade/line@1.2.0(echarts-for-react@3.0.6(echarts@6.0.0)(react@19.2.4))(echarts@6.0.0)':
     dependencies:
       '@echarts-readymade/core': 1.2.0
       big.js: 6.2.2
       clone: 2.1.2
-      echarts: 5.6.0
-      echarts-for-react: 3.0.6(echarts@5.6.0)(react@19.2.4)
+      echarts: 6.0.0
+      echarts-for-react: 3.0.6(echarts@6.0.0)(react@19.2.4)
 
-  '@echarts-readymade/scatter@1.2.0(echarts-for-react@3.0.6(echarts@5.6.0)(react@19.2.4))(echarts@5.6.0)':
+  '@echarts-readymade/scatter@1.2.0(echarts-for-react@3.0.6(echarts@6.0.0)(react@19.2.4))(echarts@6.0.0)':
     dependencies:
       '@echarts-readymade/core': 1.2.0
       big.js: 6.2.2
       clone: 2.1.2
-      echarts: 5.6.0
-      echarts-for-react: 3.0.6(echarts@5.6.0)(react@19.2.4)
+      echarts: 6.0.0
+      echarts-for-react: 3.0.6(echarts@6.0.0)(react@19.2.4)
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -9216,19 +9216,19 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  echarts-for-react@3.0.6(echarts@5.6.0)(react@19.2.4):
+  echarts-for-react@3.0.6(echarts@6.0.0)(react@19.2.4):
     dependencies:
-      echarts: 5.6.0
+      echarts: 6.0.0
       fast-deep-equal: 3.1.3
       react: 19.2.4
       size-sensor: 1.0.2
 
   echarts-stat@1.2.0: {}
 
-  echarts@5.6.0:
+  echarts@6.0.0:
     dependencies:
       tslib: 2.3.0
-      zrender: 5.6.1
+      zrender: 6.0.0
 
   editorconfig@1.0.4:
     dependencies:
@@ -11176,7 +11176,7 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zrender@5.6.1:
+  zrender@6.0.0:
     dependencies:
       tslib: 2.3.0
 


### PR DESCRIPTION
- Bump `echarts` version to `6.0.0` in `package.json` and resolve updates in `pnpm-lock.yaml`.
- Validated upgrade with `tsc` type checking and full Playwright test suite.
- Current ECharts companion packages (`echarts-for-react`, `echarts-stat`, `@echarts-readymade/*`) remain unchanged and function normally with the new major version without requiring any immediate local code fixes.

---
*PR created automatically by Jules for task [16896271800287717746](https://jules.google.com/task/16896271800287717746) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `echarts` to `6.0.0` to stay current and maintain compatibility. Verified with `tsc` and the full Playwright suite; no app code changes needed.

- **Dependencies**
  - Bump `echarts` from `5.6.0` to `6.0.0` and update `pnpm-lock.yaml`.
  - Transitive update to `zrender` `6.0.0`.
  - `echarts-for-react`, `echarts-stat`, and `@echarts-readymade/*` remain compatible.

<sup>Written for commit 32eb82856184c61a1346df2c54e93e23e87f11aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

