### PR TITLE
Improve ScatterChart visual consistency and tooltip legibility

### DIFF
--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import { BioMarker } from '../types/biomarker'
 import { labels } from '../data'
+import { CHART_PALETTE } from './Chart2'
 
 interface ScatterChartProps {
   data: BioMarker[]
@@ -12,20 +13,7 @@ const echartsOptions = {
   style: { height: 400 },
   theme: 'dark',
   backgroundColor: 'transparent',
-  color: [
-    '#c23531',
-    '#ADD4EF',
-    '#BFDAA7',
-    '#FCAC65',
-    '#C6C1D2',
-    '#7598E4',
-    '#CF6D6C',
-    '#4979CF',
-    '#E1934B',
-    '#829649',
-    '#7D70AC',
-    '#2559B7',
-  ],
+  color: CHART_PALETTE,
   xAxis: {
     type: 'time',
   },
@@ -40,9 +28,9 @@ const echartsOptions = {
     },
     formatter: (params: any) => {
       const date = params.value[0]
-      const value = params.value[1]
+      const value = params.value[1] !== null && params.value[1] !== undefined ? params.value[1] : '-'
       const unit = params.value[2] ? ` ${params.value[2]}` : ''
-      return `${params.seriesName}<br/>${date}<br/><strong>${value}${unit}</strong>`
+      return `${params.marker} ${params.seriesName}<br/>${date}<br/><strong>${value}${unit}</strong>`
     },
   },
   legend: {


### PR DESCRIPTION
This change targets visual consistency and legibility improvements for the `ScatterChart` component (resolving Scan 2 and Scan 7). It imports the standardized `CHART_PALETTE` and incorporates series color markers in the tooltip, improving the readability of multi-axis scatter plots. It also incorporates a null-guard for tooltip value display.

---
*PR created automatically by Jules for task [17109073169603984107](https://jules.google.com/task/17109073169603984107) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `ScatterChart` with the shared dark-theme palette and makes tooltips clearer for multi-series plots. Tooltips now include the series color marker and show '-' when a value is missing.

<sup>Written for commit 2178a6891ec9e3306dd7be32d79eb949102c091e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

