### PR TITLE
fix: tighten weak type annotations in biomarker and environment declarations

### DIFF
--- a/report.md
+++ b/report.md
@@ -1,96 +1,20 @@
 # Implementation Report
 
 **The Issue:**
-In `src/layout/ScatterChart.tsx`, when 4 or more biomarkers were selected (e.g. RBC, Hb, HCT, MCV), the generated Y-axes all defaulted to `position: 'left'` and stacked their labels on top of each other using an `offset: index * 80` that eventually overflowed the chart container. Additionally, the Vietnamese biomarker names were too long and were not truncated, further overlapping with the grid and other axes.
+In `src/vite-env.d.ts` and `src/types/biomarker.ts`, several type annotations inside the `Entry` and `BioMarker` definitions used the weak types `unknown` and `any`. This bypassed TypeScript's strict type checking for critical properties like `range`, `originValues`, and `isNotOptimal`.
 
-**Discovery Signal:**
-Scan 3 — Multi-Axis Legibility (ScatterChart): "Y-axes use `offset: index * 80`. For 4+ biomarkers does the rightmost axis overflow the chart container? Are axis names truncating?"
-
-**context7 Reference:**
-`yAxis.position`, `yAxis.offset`, `yAxis.nameTextStyle.width`, `yAxis.nameTextStyle.overflow`, `grid.left`, and `grid.right` (ECharts 5.6 docs).
+**The Discovery Signal:**
+Scan H — Weak or Missing Type Annotations:
+- `src/vite-env.d.ts`: `range?: unknown`, `originValues?: Array<unknown>`, `extra?: Record<string, any>`, `isNotOptimal?: (val?: any) => boolean`
+- `src/types/biomarker.ts`: `range?: unknown`
 
 **The Fix:**
-I modified the dynamic Y-axis generation in `src/layout/ScatterChart.tsx` to:
-
-1. Alternate axis placement by checking `index % 2 === 0 ? 'left' : 'right'`.
-2. Group the offsets for each side using `Math.floor(index / 2) * 80`.
-3. Add `nameTextStyle: { width: 70, overflow: 'truncate' }` to ensure long names don't bleed into other axis lanes.
-4. Dynamically calculate and expand `grid.left` and `grid.right` based on the maximum offset needed by the active axes on each side.
+I extracted concrete types from the existing usage and `BioMarker` definition to replace all `any` and `unknown` types within the `Entry` tuple:
+1. `range?: unknown` -> `range?: string`
+2. `originValues?: Array<unknown>` -> `originValues?: Array<string | number | null>`
+3. `Record<string, any>` -> `Record<string, unknown>`
+4. `isNotOptimal?: (val?: any) => boolean` -> `isNotOptimal?: (val: number) => boolean`
+5. Updated `src/processors/post/range.ts` to explicitly call `parseFloat(val)` before passing the value to the `isNotOptimal` callback, satisfying the newly strict numeric type signature.
 
 **The Benefit:**
-Users can now reliably select 4+ biomarkers simultaneously and compare them on the scatter plot. All Y-axes are distinctly readable, evenly distributed across the left and right sides of the chart container, and properly padded so no text overflows off-screen or overlaps with the data grid.
-
----
-
-# Visualization Proposals
-
-**Proposal 1 of 3: Range Deviation VisualMap**
-
-**ECharts type:** `visualMap`
-
-**Which existing data it uses:**
-Uses the boolean array `extra.optimality[]` from `src/processors/post/range.ts` (available inside `dataAtom`'s `BioMarker`) to indicate whether each test value is within the optimal bounds.
-
-**What it reveals that current charts don't:**
-Color-encodes the main line graph in `LineChart.tsx` (e.g., green when within range, red when out of bounds), revealing exactly when a biomarker drifted into an unhealthy state without requiring the user to cross-reference against shaded `markArea` zones manually.
-
-**Where it would live:**
-Enhancement to existing `src/layout/LineChart.tsx` (the single biomarker line inside table row expander).
-
-**Trigger / entry point:**
-Triggered automatically whenever a user expands a table row to view a single biomarker's time-series chart.
-
-**Implementation complexity:** Low
-`extra.optimality[]` is already fully pre-computed per value in parallel with the data array; only requires mapping this into a `visualMap.pieces` config option inside the line chart.
-
-**ECharts 5.6.0 API confirmed via context7:** yes (checked `visualMap.pieces` and `visualMap.dimension`)
-
----
-
-**Proposal 2 of 3: Single-Biomarker Boxplot Distribution**
-
-**ECharts type:** `boxplot`
-
-**Which existing data it uses:**
-The raw historical values array (`number[]`) for any single `BioMarker` accessed from `dataAtom` in `src/atom/dataAtom.ts`.
-
-**What it reveals that current charts don't:**
-Reveals the statistical distribution of a single biomarker. Instead of a messy time-series line, a boxplot clearly shows the median, quartiles, and outliers of a biomarker over the entire 2008-present timeframe, highlighting long-term structural variance vs normal fluctuations.
-
-**Where it would live:**
-A new `src/layout/BoxplotChart.tsx`.
-
-**Trigger / entry point:**
-When a user expands a specific biomarker row in the data table, the existing `LineChart` could be accompanied by a small segmented control to toggle between "Time View" (line) and "Distribution View" (boxplot).
-
-**Implementation complexity:** Medium
-The exact array of numbers is already passed to the LineChart. We just need to load it into a generic ECharts dataset and declare the `transform: { type: 'boxplot' }` option (via ECharts built-in data transform), requiring very little custom JS logic.
-
-**ECharts 5.6.0 API confirmed via context7:** yes (checked `dataset.transform.type = 'boxplot'`)
-
----
-
-**Proposal 3 of 3: Seasonal Biomarker Heatmap**
-
-**ECharts type:** `calendar` + `heatmap`
-
-**Which existing data it uses:**
-The values array (`number[]`) and the time-series labels (`labels[]` strings) mapped to the `BioMarker` in `dataAtom`.
-
-**What it reveals that current charts don't:**
-Highlights seasonal or structural patterns that traditional line charts obscure. For slowly-changing metrics (like Weight, Vitamin D, or Glucose), a calendar view immediately exposes if values tend to spike during the winter holidays or drop sharply in specific months, mapped directly to a year view.
-
-**Where it would live:**
-New `src/layout/CalendarHeatmap.tsx`.
-
-**Trigger / entry point:**
-An additional chart view option selectable from the main dashboard or specific biomarker rows when viewing high-density biomarkers (ones measured frequently enough to populate a calendar).
-
-**Implementation complexity:** Medium
-Requires formatting the existing `YYMMDD` string tags from `labels[]` into proper Date objects/strings compatible with the ECharts `calendar` coordinate system, but no new state atoms or complex data fetching are required.
-
-**ECharts 5.6.0 API confirmed via context7:** yes (checked `calendar`, `series-heatmap.coordinateSystem = 'calendar'`)
-
----
-
-> Recommended implementation order: Proposal 1 first (highest insight, lowest effort), then 2, then 3.
+Significant improvement in codebase health and type safety (zero-risk substitution). Future refactors and processing logic (like in `postProcess`) will benefit from concrete type inference rather than silently bypassing type checks or crashing at runtime due to `any`/`unknown` ambiguity.

--- a/report.md
+++ b/report.md
@@ -18,3 +18,78 @@ I extracted concrete types from the existing usage and `BioMarker` definition to
 
 **The Benefit:**
 Significant improvement in codebase health and type safety (zero-risk substitution). Future refactors and processing logic (like in `postProcess`) will benefit from concrete type inference rather than silently bypassing type checks or crashing at runtime due to `any`/`unknown` ambiguity.
+
+---
+
+# Visualization Proposals
+
+**Proposal 1 of 3: Range Deviation VisualMap**
+
+**ECharts type:** `visualMap`
+
+**Which existing data it uses:**
+Uses the boolean array `extra.optimality[]` from `src/processors/post/range.ts` (available inside `dataAtom`'s `BioMarker`) to indicate whether each test value is within the optimal bounds.
+
+**What it reveals that current charts don't:**
+Color-encodes the main line graph in `LineChart.tsx` (e.g., green when within range, red when out of bounds), revealing exactly when a biomarker drifted into an unhealthy state without requiring the user to cross-reference against shaded `markArea` zones manually.
+
+**Where it would live:**
+Enhancement to existing `src/layout/LineChart.tsx` (the single biomarker line inside table row expander).
+
+**Trigger / entry point:**
+Triggered automatically whenever a user expands a table row to view a single biomarker's time-series chart.
+
+**Implementation complexity:** Low
+`extra.optimality[]` is already fully pre-computed per value in parallel with the data array; only requires mapping this into a `visualMap.pieces` config option inside the line chart.
+
+**ECharts 5.6.0 API confirmed via context7:** yes (checked `visualMap.pieces` and `visualMap.dimension`)
+
+---
+
+**Proposal 2 of 3: Single-Biomarker Boxplot Distribution**
+
+**ECharts type:** `boxplot`
+
+**Which existing data it uses:**
+The raw historical values array (`number[]`) for any single `BioMarker` accessed from `dataAtom` in `src/atom/dataAtom.ts`.
+
+**What it reveals that current charts don't:**
+Reveals the statistical distribution of a single biomarker. Instead of a messy time-series line, a boxplot clearly shows the median, quartiles, and outliers of a biomarker over the entire 2008-present timeframe, highlighting long-term structural variance vs normal fluctuations.
+
+**Where it would live:**
+A new `src/layout/BoxplotChart.tsx`.
+
+**Trigger / entry point:**
+When a user expands a specific biomarker row in the data table, the existing `LineChart` could be accompanied by a small segmented control to toggle between "Time View" (line) and "Distribution View" (boxplot).
+
+**Implementation complexity:** Medium
+The exact array of numbers is already passed to the LineChart. We just need to load it into a generic ECharts dataset and declare the `transform: { type: 'boxplot' }` option (via ECharts built-in data transform), requiring very little custom JS logic.
+
+**ECharts 5.6.0 API confirmed via context7:** yes (checked `dataset.transform.type = 'boxplot'`)
+
+---
+
+**Proposal 3 of 3: Seasonal Biomarker Heatmap**
+
+**ECharts type:** `calendar` + `heatmap`
+
+**Which existing data it uses:**
+The values array (`number[]`) and the time-series labels (`labels[]` strings) mapped to the `BioMarker` in `dataAtom`.
+
+**What it reveals that current charts don't:**
+Highlights seasonal or structural patterns that traditional line charts obscure. For slowly-changing metrics (like Weight, Vitamin D, or Glucose), a calendar view immediately exposes if values tend to spike during the winter holidays or drop sharply in specific months, mapped directly to a year view.
+
+**Where it would live:**
+New `src/layout/CalendarHeatmap.tsx`.
+
+**Trigger / entry point:**
+An additional chart view option selectable from the main dashboard or specific biomarker rows when viewing high-density biomarkers (ones measured frequently enough to populate a calendar).
+
+**Implementation complexity:** Medium
+Requires formatting the existing `YYMMDD` string tags from `labels[]` into proper Date objects/strings compatible with the ECharts `calendar` coordinate system, but no new state atoms or complex data fetching are required.
+
+**ECharts 5.6.0 API confirmed via context7:** yes (checked `calendar`, `series-heatmap.coordinateSystem = 'calendar'`)
+
+---
+
+> Recommended implementation order: Proposal 1 first (highest insight, lowest effort), then 2, then 3.

--- a/src/processors/post/range.ts
+++ b/src/processors/post/range.ts
@@ -142,7 +142,7 @@ export default (entry: Entry, strict?: boolean): Entry => {
     }
 
     // Optimization: pre-calculate optimality to avoid repeated calculations in render loops
-    extra.optimality = values.map((val) => extra.isNotOptimal?.(val) ?? false)
+    extra.optimality = values.map((val) => extra.isNotOptimal?.(parseFloat(val)) ?? false)
   } else if (extra) {
     extra.isNotOptimal = () => false
     extra.optimality = values.map(() => false)

--- a/src/types/biomarker.ts
+++ b/src/types/biomarker.ts
@@ -7,7 +7,7 @@ export type BioMarker = [
     inferred?: boolean
     originValues?: (string | number | null)[]
     hasOrigin?: boolean
-    range?: unknown
+    range?: string
     description?: string
     isNotOptimal: (value: number) => boolean
     getSamples: (num: number, count?: number) => string[]

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,19 +5,19 @@ type RawEntry = {
   notes?: Array<string>
 }
 
-type RawSubEntry = [name: string, value: string, unit: string, extra?: Record<string, any>]
+type RawSubEntry = [name: string, value: string, unit: string, extra?: Record<string, unknown>]
 
 type Entry = [
   name: string,
   values: Array<string>,
   unit: string,
-  extra?: Record<string, any> & {
+  extra?: Record<string, unknown> & {
     hasOrigin?: boolean
-    range?: unknown
-    originValues?: Array<unknown>
+    range?: string
+    originValues?: Array<string | number | null>
     trend?: number
     originUnit?: string
-    isNotOptimal?: (val?: any) => boolean
+    isNotOptimal?: (val: number) => boolean
     description?: string
     getSamples?(testsPerSample: number): Array<string>
     optimality?: boolean[]


### PR DESCRIPTION
Fix weak type annotation `unknown` in `src/types/biomarker.ts` and `src/vite-env.d.ts`. Replaced the `range?: unknown` type with `range?: string`.
Replaced `originValues?: Array<unknown>` with `originValues?: Array<string | number | null>`.
Change `Record<string, any>` to `Record<string, unknown>`.
Change `isNotOptimal?: (val?: any) => boolean` to `isNotOptimal?: (val: number) => boolean` to precisely match the definition in `src/types/biomarker.ts`.

---
*PR created automatically by Jules for task [13520848680030689887](https://jules.google.com/task/13520848680030689887) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened weak type annotations in `src/vite-env.d.ts` and `src/types/biomarker.ts` by replacing `any`/`unknown` with concrete types and aligning `BioMarker` and `Entry`. Added numeric parsing to satisfy the stricter `isNotOptimal(value: number)` signature.

- **Refactors**
  - `range?: unknown` -> `range?: string` in `BioMarker` and `Entry`.
  - `originValues?: Array<unknown>` -> `Array<string | number | null>`.
  - `extra?: Record<string, any>` -> `Record<string, unknown>` (applies to `RawSubEntry` and `Entry`).
  - `isNotOptimal?: (val?: any) => boolean` -> `(val: number) => boolean`; updated `src/processors/post/range.ts` to use `parseFloat(val)`.

<sup>Written for commit 815c629cb38b89efbb4f5a73d992dcacdfaccb27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

