### PR TITLE
🎨 Palette: Stateful Button Announcements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -102,3 +102,8 @@
 
 **Learning:** Static `aria-label`s on buttons with dynamic text content (like "Copy" changing to "Copied!", or "Save" changing to "Saving...") completely hide the state change from screen readers. This is because the `aria-label` attribute takes precedence in the accessible name calculation, overriding any visible text changes.
 **Action:** Remove redundant `aria-label`s from buttons that have clear visible text, allowing the screen reader to announce the actual text content and any dynamic changes to it naturally.
+
+## 2026-03-30 - Stateful Button Announcements
+
+**Learning:** Dynamic text changes on buttons (like 'Copy' -> 'Copied!' or 'Save' -> 'Saving...') are not automatically announced by screen readers. This leaves visually impaired users without feedback that an async action has started or succeeded.
+**Action:** Add `aria-live="polite"` directly to these buttons. This simple attribute ensures that assistive technologies announce the new text state as soon as it updates, drastically improving UX for these interactions.

--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -197,6 +197,7 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                             : 'border-gray-600 text-gray-300 hover:bg-gray-700 hover:text-white'
                         }`}
                         title="Copy analysis to clipboard"
+                        aria-live="polite"
                       >
                         {isCopied ? (
                           <>

--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -180,6 +180,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                                   : 'border-gray-600 text-gray-300 hover:bg-gray-700 hover:text-white'
                               }`}
                               title="Copy analysis to clipboard"
+                              aria-live="polite"
                             >
                               {isCopied ? (
                                 <>

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -354,6 +354,7 @@ export default React.memo<NavProps>(
                       title={isAsking ? 'Asking AI...' : 'Ask AI'}
                       className="px-3 py-1 text-xs font-medium bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 transition-colors flex items-center justify-center gap-1 min-w-[70px]"
                       aria-busy={isAsking}
+                      aria-live="polite"
                     >
                       {isAsking ? <Spinner /> : null}
                       {isAsking ? 'Asking...' : 'Ask AI'}
@@ -487,6 +488,7 @@ export default React.memo<NavProps>(
                             : 'border-gray-600 text-gray-300 hover:bg-gray-700 hover:text-white'
                         }`}
                         title="Copy analysis to clipboard"
+                        aria-live="polite"
                       >
                         {isCopied ? (
                           <>
@@ -504,6 +506,7 @@ export default React.memo<NavProps>(
                         disabled={isGistLoading}
                         aria-busy={isGistLoading}
                         title="Save analysis to Gist"
+                        aria-live="polite"
                         onClick={async () => {
                           setIsGistLoading(true)
                           setGistError(null)

--- a/src/layout/PValue.tsx
+++ b/src/layout/PValue.tsx
@@ -151,6 +151,7 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                           : 'border-gray-600 text-gray-300 hover:bg-gray-700 hover:text-white'
                       }`}
                       title="Copy analysis to clipboard"
+                      aria-live="polite"
                     >
                       {isCopied ? (
                         <>


### PR DESCRIPTION
💡 **What:** Added `aria-live="polite"` to stateful buttons in the UI that change their visible text during async operations or interactions.
🎯 **Why:** Static text updates (like "Copy" -> "Copied!") are not automatically announced by screen readers. Adding an `aria-live` region to the button makes it announce the new text immediately, providing proper feedback to visually impaired users.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now announce "Copied!", "Asking...", and "Saving..." dynamically as the button text updates.

---
*PR created automatically by Jules for task [7608364222210117205](https://jules.google.com/task/7608364222210117205) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added aria-live="polite" to stateful buttons so screen readers announce dynamic text updates (e.g., "Copy" -> "Copied!", "Ask AI" -> "Asking...", "Save" -> "Saving..."). Improves accessibility feedback during async actions; no visual changes.

<sup>Written for commit 804bf37227c3f9967c3541057cb7cc758ececc7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

