### PR TITLE
Fix regression line wiring and visualization proposals

### DIFF
--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -3,7 +3,11 @@ import { ChartProvider, ChartContext } from '@echarts-readymade/core'
 import { Scatter } from '@echarts-readymade/scatter'
 import { labels } from '../data'
 import ReactECharts from 'echarts-for-react'
+import * as echarts from 'echarts'
+import * as ecStat from 'echarts-stat'
 import { BioMarker } from '../types/biomarker'
+
+echarts.registerTransform((ecStat as any).transform.regression)
 
 interface ChartProps {
   data: BioMarker[]


### PR DESCRIPTION
Fix ecStat:regression transform failing silently due to unregistered plugin. Wrote 3 visualization proposals in proposals.md grounded in existing data model.

---
*PR created automatically by Jules for task [18401791423309036524](https://jules.google.com/task/18401791423309036524) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores regression line rendering by registering the `ecStat` regression transform with `echarts` in Chart2. Also adds three visualization proposals in `proposals.md` based on the current data model.

- **Bug Fixes**
  - Register `(ecStat as any).transform.regression` with `echarts` in `Chart2.tsx` to prevent silent failures.
  - Import `echarts` and `echarts-stat` to ensure the transform is available at runtime.

<sup>Written for commit 54314f2c5675b98e9d32e36093b61c69b699a3d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

