### PR TITLE
refactor: resolve Note type collision in vite-env.d.ts

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -28,11 +28,11 @@ type Entry = [
   },
 ]
 
-type Note = {
+type NoteRecord = {
   date: string
   items: string[]
   supps: string[]
 }
 
-type Notes = Record<string, Note>
-type NoteItem = Note
+type Notes = Record<string, NoteRecord>
+type NoteItem = NoteRecord


### PR DESCRIPTION
**The Issue:**
The `Note` type was declared twice with conflicting definitions. In `src/vite-env.d.ts` it was defined as a record object containing `date`, `items`, and `supps`, but in `src/types/notes.ts` it was exported as a union of strings representing specific supplements. This duplicate ambient declaration caused type shadowing and agent confusion within the codebase.

**The Discovery Signal:**
Scan A: `src/vite-env.d.ts` line 31 — The ambient type `Note` is declared, which conflicts with the explicit `Note` type exported in `src/types/notes.ts`.

**The Fix:**
Renamed the ambient `Note` type in `src/vite-env.d.ts` to `NoteRecord`. Updated the internal dependent types (`Notes` and `NoteItem`) in the same file to reference the newly renamed `NoteRecord`.

**The Benefit:**
Eliminates duplicate type declarations and name collisions across the codebase, resulting in cleaner and unambiguous type definitions for future agents and developers running `tsc` or modifying the codebase.

---
*PR created automatically by Jules for task [379370409148238703](https://jules.google.com/task/379370409148238703) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a type name collision between the ambient `Note` in `src/vite-env.d.ts` and the exported `Note` union in `src/types/notes.ts`. Renames the ambient type to `NoteRecord` and updates `Notes` and `NoteItem` to use it.

<sup>Written for commit f67e344bc196a3e2ef9220818ebeb8b6382ef057. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

