### PR TITLE
fix: use consistent CHART_PALETTE in LineChart

### DIFF
--- a/src/layout/LineChart.tsx
+++ b/src/layout/LineChart.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import { labels } from '../data'
+import { CHART_PALETTE } from './Chart2'
 
 interface LineChartProps {
   name: string
@@ -12,6 +13,7 @@ const echartsOptions = {
   style: { height: 300, width: '100%' },
   theme: 'dark',
   backgroundColor: 'transparent',
+  color: CHART_PALETTE,
   animation: false,
   tooltip: {
     trigger: 'axis',


### PR DESCRIPTION
This PR addresses a visual consistency issue where `LineChart.tsx` was relying on ECharts default colors instead of the 12-color custom palette defined for the rest of the application. 

**Changes:**
- Imported `CHART_PALETTE` from `Chart2.tsx`
- Applied `color: CHART_PALETTE` within the `echartsOptions` configuration object in `LineChart.tsx`

**Verification:**
- Confirmed there are no type errors with `npx tsc --noEmit`
- Validated via Playwright screenshot that the `LineChart` now accurately uses the designated accent color (red) matching the application's dark theme palette.

---
*PR created automatically by Jules for task [14485352099758250915](https://jules.google.com/task/14485352099758250915) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `LineChart` to use the app’s 12-color `CHART_PALETTE` for consistent dark-theme colors instead of ECharts defaults. Imported `CHART_PALETTE` from `Chart2` and set `echartsOptions.color` accordingly.

<sup>Written for commit 429a1d1ea1dbe2771cf711980450cb0e224b9b3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

