### PR TITLE
⚡ Bolt: Optimize array allocations in Chart2.tsx inside useMemo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,8 @@
 ## 2025-07-28 - ECharts data transformation: Replace chained Array methods with single-pass loops
 **Learning:** Extracting multiple series from a multi-dimensional array for chart rendering (like mapping keys to entries, reducing to pairs, and filtering out nulls) via chained `.map().reduce().filter()` creates severe object allocation and closure overhead on every re-render (e.g. `useMemo` in ReactECharts components like Scatter charts).
 **Action:** Replace `Array.map().reduce().filter()` combinations with a traditional `for` loop that iterates over a fixed length (like the data labels length) and performs all extraction, matching, and null-checking in a single pass before pushing only the valid points into a final array.
+
+## 2025-07-28 - Prevent array mapping and spreading stack overflows
+
+**Learning:** Calculating `Math.min(...mappedScatterData.map(...))` inside React `useMemo` blocks is extremely inefficient and dangerous. First, `map` creates a completely new intermediate array on every render. Second, spreading (`...`) a large mapped array into `Math.min` or `Math.max` evaluates arguments on the call stack, which can crash the application with a "Maximum call stack size exceeded" error if the data array grows too large.
+**Action:** Replace `Math.min(...array.map(...))` combinations with a single-pass `for` loop that iterates over the dataset once and evaluates min/max boundary variables simultaneously. This avoids the `O(N)` memory allocation of `.map()`, avoids the secondary iteration of `Math.min()`, and protects against stack overflow crashes.

--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -243,6 +243,24 @@ export default memo(({ data, keys }: ChartProps) => {
         : []),
     ]
 
+    // Optimization: Calculate min/max data boundaries in a single O(N) pass
+    // to avoid allocating 4 intermediate arrays via chained .map() and
+    // preventing stack overflow from spreading (...) large arrays into Math.min/max.
+    let minX = 0, maxX = 100, minY = 0, maxY = 100
+    if (mappedScatterData.length > 0) {
+      minX = mappedScatterData[0][0]
+      maxX = mappedScatterData[0][0]
+      minY = mappedScatterData[0][1]
+      maxY = mappedScatterData[0][1]
+      for (let i = 1; i < mappedScatterData.length; i++) {
+        const item = mappedScatterData[i]
+        if (item[0] < minX) minX = item[0]
+        if (item[0] > maxX) maxX = item[0]
+        if (item[1] < minY) minY = item[1]
+        if (item[1] > maxY) maxY = item[1]
+      }
+    }
+
     return {
       ...echartsOptions,
       tooltip: {
@@ -268,25 +286,13 @@ export default memo(({ data, keys }: ChartProps) => {
       dataZoom: [
         {
           ...(echartsOptions.dataZoom as any[])[0],
-          startValue:
-            mappedScatterData.length > 0
-              ? Math.min(...mappedScatterData.map((item) => item[0]))
-              : 0,
-          endValue:
-            mappedScatterData.length > 0
-              ? Math.max(...mappedScatterData.map((item) => item[0]))
-              : 100,
+          startValue: minX,
+          endValue: maxX,
         },
         {
           ...(echartsOptions.dataZoom as any[])[1],
-          startValue:
-            mappedScatterData.length > 0
-              ? Math.min(...mappedScatterData.map((item) => item[1]))
-              : 0,
-          endValue:
-            mappedScatterData.length > 0
-              ? Math.max(...mappedScatterData.map((item) => item[1]))
-              : 100,
+          startValue: minY,
+          endValue: maxY,
         },
       ],
     }


### PR DESCRIPTION
💡 **What:** Optimized `Chart2.tsx` to pre-calculate min/max boundaries using a single `O(N)` loop instead of redundant `.map()` chains and `Math.min/max(...)` spreads.
🎯 **Why:** To improve rendering performance inside `useMemo` by eliminating intermediate array allocations and protecting against maximum call stack size exceeded errors when scaling the `mappedScatterData`.
📊 **Impact:** Reduces object allocation by preventing the creation of four distinct intermediate `.map()` arrays on every relevant `useMemo` re-evaluation. It completely averts stack overflow crashes when visualizing large datasets.
🔬 **Measurement:** Verify with `pnpm exec playwright test`. The change leaves data zoom boundaries logically intact while making the calculation significantly cheaper per cycle.

---
*PR created automatically by Jules for task [9843210638480332139](https://jules.google.com/task/9843210638480332139) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized `Chart2.tsx` by computing `dataZoom` min/max bounds in a single O(N) loop inside `useMemo`. This removes extra array allocations and prevents spread-based stack overflows on large datasets.

- **Refactors**
  - Replaced `.map()` + `Math.min/max(...spread)` with one pass that tracks `minX/maxX/minY/maxY` and sets `dataZoom` start/end values.

- **Bug Fixes**
  - Prevents "Maximum call stack size exceeded" when `mappedScatterData` is large.

<sup>Written for commit df257613c3ff319456cc305aa9ae7a196f928596. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

