### PR TITLE
Refactor: Strongly type TableRow component props in Table.tsx

### DIFF
--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -26,7 +26,7 @@ import {
 } from '@heroicons/react/24/outline'
 import { averageCountAtom } from '../atom/averageValueAtom'
 import BiomarkerCorrelation from './BiomarkerCorrelation'
-import { TableProps, DisplayedEntry } from './Table.types'
+import { TableProps, DisplayedEntry, TableRowProps } from './Table.types'
 
 const LineChart = React.lazy(() => import('./LineChart'))
 const BoxplotChart = React.lazy(() => import('./BoxplotChart'))
@@ -114,7 +114,7 @@ const TableRow = React.memo(
     averageCountValue,
     visibleLeafColumnsCount,
     onCellClick,
-  }: any) => {
+  }: TableRowProps) => {
     const { name, values, visibleValues, visibleOptimality, visibleOriginValues, unit, extra } =
       entry
     const safeNameId = String(name).replace(/[^a-zA-Z0-9-_]/g, '-')

--- a/src/layout/Table.types.ts
+++ b/src/layout/Table.types.ts
@@ -21,3 +21,19 @@ export type DisplayedEntry = {
   displayTag: string
   sortKey: string
 }
+
+export interface TableRowProps {
+  entry: DisplayedEntry
+  isSelected: boolean
+  isExpanded: boolean
+  rowId: string
+  toggleExpand: (id: string) => void
+  onSelect: (name: string) => void
+  onCorrelation: (name: string) => void
+  setCorrelationBiomarker: (name: string | null) => void
+  cellBaseClasses: string[]
+  showOrigColumns: boolean
+  averageCountValue: string
+  visibleLeafColumnsCount: number
+  onCellClick: (text: string) => Promise<void>
+}


### PR DESCRIPTION
Replaced weak explicit `any` annotation in `src/layout/Table.tsx`'s `TableRow` with a precise type definition `TableRowProps` mapped in `src/layout/Table.types.ts`. Fixes the single highest-priority issue identified in Scan H (Weak or Missing Type Annotations).

---
*PR created automatically by Jules for task [803921205023987131](https://jules.google.com/task/803921205023987131) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strongly types the TableRow component by replacing its props annotated as any with a new TableRowProps interface. The interface is defined in src/layout/Table.types.ts and used in src/layout/Table.tsx; no runtime changes.

<sup>Written for commit 0d67a1540acff3c2c7640c351df9656ca0f05943. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

