### PR TITLE
🎨 Palette: Improve chart loading state UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -107,3 +107,8 @@
 
 **Learning:** Dynamic text changes on buttons (like 'Copy' -> 'Copied!' or 'Save' -> 'Saving...') are not automatically announced by screen readers. This leaves visually impaired users without feedback that an async action has started or succeeded.
 **Action:** Add `aria-live="polite"` directly to these buttons. This simple attribute ensures that assistive technologies announce the new text state as soon as it updates, drastically improving UX for these interactions.
+
+## 2026-04-10 - Accessible Suspense Loading States
+
+**Learning:** Lazy-loaded visual components (like charts) using React `Suspense` often fallback to unstyled static text (e.g., "Loading chart..."). This lacks visual polish and, more importantly, is completely ignored by screen readers because the text is simply rendered into the DOM without semantic meaning.
+**Action:** Always replace plain text Suspense fallbacks with a styled loading container that includes a visual indicator (like `<Spinner />`) and an accessible text node with `role="status"` and `aria-live="polite"`. This ensures the loading state is announced immediately to assistive technologies.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import {
 } from './atom/dataAtom'
 import { BioMarker } from './types/biomarker'
 import { PasswordInput } from './layout/PasswordInput'
+import { Spinner } from './layout/Spinner'
 
 export default function App() {
   const data = useAtomValue(getBioMarkersAtom)
@@ -247,7 +248,14 @@ export default function App() {
       <PValue comparedSourceTarget={comparedSourceTarget} onClose={onPValueClose} />
       <Correlation target={corrlationKey} onClose={onCorrelationClose} />
       <React.Suspense
-        fallback={<div className="text-center p-4 text-gray-400">Loading chart...</div>}
+        fallback={
+          <div className="flex flex-col items-center justify-center p-12 gap-3 text-gray-400">
+            <Spinner />
+            <span role="status" aria-live="polite">
+              Loading chart...
+            </span>
+          </div>
+        }
       >
         {filterTag && (!chartKeys || chartKeys.length === 0) && (
           <RadarChart

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -27,6 +27,7 @@ import {
 import { averageCountAtom } from '../atom/averageValueAtom'
 import BiomarkerCorrelation from './BiomarkerCorrelation'
 import { TableProps, DisplayedEntry } from './Table.types'
+import { Spinner } from './Spinner'
 
 const LineChart = React.lazy(() => import('./LineChart'))
 const BoxplotChart = React.lazy(() => import('./BoxplotChart'))
@@ -234,7 +235,14 @@ const TableRow = React.memo(
           <tr className="bg-gray-800">
             <td colSpan={visibleLeafColumnsCount} className="border border-gray-700">
               <React.Suspense
-                fallback={<div className="p-4 text-center text-gray-400">Loading charts...</div>}
+                fallback={
+                  <div className="p-8 flex flex-col items-center justify-center gap-3 text-gray-400">
+                    <Spinner />
+                    <span role="status" aria-live="polite">
+                      Loading charts...
+                    </span>
+                  </div>
+                }
               >
                 <div className="p-3 grid grid-cols-1 md:grid-cols-2 gap-4">
                   <LineChart
@@ -474,7 +482,16 @@ export default React.memo(
     const selectedSet = React.useMemo(() => new Set(selected), [selected])
 
     return (
-      <React.Suspense fallback="Loading...">
+      <React.Suspense
+        fallback={
+          <div className="p-12 flex flex-col items-center justify-center gap-3 text-gray-400">
+            <Spinner />
+            <span role="status" aria-live="polite">
+              Loading table...
+            </span>
+          </div>
+        }
+      >
         <table className="w-full text-sm text-left border-collapse bg-dark-table-row text-dark-text">
           <thead className="sticky top-[39px] z-10 bg-dark-table-header">
             {table.getHeaderGroups().map((headerGroup) => (


### PR DESCRIPTION
This PR improves the UX and accessibility of React Suspense fallbacks for lazy-loaded charts and tables.

### 💡 What
Replaced plain text fallbacks (e.g., `Loading chart...`) with a styled container that includes:
- A visual `<Spinner />` indicator.
- An accessible text node with `role="status"` and `aria-live="polite"`.

### 🎯 Why
Unstyled text lacks visual polish and is often missed by screen readers when dynamically inserted. Adding `role="status"` and `aria-live="polite"` ensures that assistive technologies immediately announce the loading state, and the `Spinner` makes the wait feel intentional and responsive for sighted users.

### ♿ Accessibility
Added `role="status"` and `aria-live="polite"` to all Suspense loading messages. The `Spinner` component itself already has `role="status"` and `aria-label="Loading"`.

---
*PR created automatically by Jules for task [1228389022969486705](https://jules.google.com/task/1228389022969486705) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved loading UX for lazy-loaded charts and tables by replacing plain text Suspense fallbacks with a styled spinner and an announced status message. Screen readers now announce loading states immediately.

- **New Features**
  - `src/App.tsx`: Chart fallback now shows a `Spinner` and “Loading chart...” with `role="status"` and `aria-live="polite"`.
  - `src/layout/Table.tsx`: Added the same accessible fallback for expanded chart rows and the main table Suspense.
  - `.Jules/palette.md`: Documented guidance on accessible Suspense loading states.

<sup>Written for commit 77039fcd72fe200ac8037a05a101e95868e833c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

