### PR TITLE
refactor: replace weak `any` type annotation in PasswordInput

### DIFF
--- a/src/layout/PasswordInput.tsx
+++ b/src/layout/PasswordInput.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
 
-export const PasswordInput = React.memo(({ show, setShow, ...props }: any) => (
+export const PasswordInput = React.memo(
+  ({ show, setShow, ...props }: { show: boolean; setShow: (show: boolean) => void } & React.InputHTMLAttributes<HTMLInputElement>) => (
   <div className="relative w-full">
     <input
       type={show ? 'text' : 'password'}


### PR DESCRIPTION
**The Issue:**
`src/layout/PasswordInput.tsx` on line 4 explicitly used the `any` type for the component props: `({ show, setShow, ...props }: any)`. This is a structural problem because it circumvents TypeScript's type safety, potentially allowing invalid props to be passed silently at build time. This issue surfaced during Discovery Scan H (Weak or Missing Type Annotations).

**The Discovery Signal:**
Scan H: `src/layout/PasswordInput.tsx` line 4 — explicit `any` annotation on component props detected.

**The Fix:**
Edited `src/layout/PasswordInput.tsx` to replace the `: any` annotation with the inline intersection type `{ show: boolean; setShow: (show: boolean) => void } & React.InputHTMLAttributes<HTMLInputElement>`. No new file or interface was added; standard React types directly inferrable from usage were used instead.

**The Benefit:**
Improved codebase health by tightening types. This eliminates a weak runtime pattern and makes editor autocompletion strictly type-safe, preventing future bugs where incorrect HTML input properties might be supplied to `PasswordInput`.

---
*PR created automatically by Jules for task [1310002577567611796](https://jules.google.com/task/1310002577567611796) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `any` prop type in `PasswordInput` with `{ show: boolean; setShow: (show: boolean) => void } & React.InputHTMLAttributes<HTMLInputElement>`. This tightens type safety and prevents invalid input props.

<sup>Written for commit 1bd3524d5af8c0b54a2d9343f0d94318b415545d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

