### PR TITLE
Fix Chart2 Regression Wiring and Tooltip

### DIFF
--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -4,6 +4,10 @@ import { Scatter } from '@echarts-readymade/scatter'
 import { labels } from '../data'
 import ReactECharts from 'echarts-for-react'
 import { BioMarker } from '../types/biomarker'
+import * as echarts from 'echarts'
+import * as ecStat from 'echarts-stat'
+
+echarts.registerTransform((ecStat as any).transform.regression)
 
 interface ChartProps {
   data: BioMarker[]
@@ -215,7 +219,9 @@ export default memo(({ data, keys }: ChartProps) => {
       dataset.push({
         transform: {
           type: 'ecStat:regression',
+          config: { method: 'linear', formulaOn: 'end' }
         },
+        fromDatasetIndex: 0
       })
     }
 
@@ -228,8 +234,8 @@ export default memo(({ data, keys }: ChartProps) => {
               ...series[1],
               datasetIndex: 1,
               tooltip: {
-                formatter: (_params: any) => {
-                  return `<strong>Regression Trend</strong>`
+                formatter: (params: any) => {
+                  return `<strong>Regression Trend</strong><br/>${params.value[2]}`
                 },
               },
             },
@@ -275,7 +281,7 @@ export default memo(({ data, keys }: ChartProps) => {
               `${params.marker} ${keys[1]}: <strong>${val2}${u1}</strong>`
             )
           }
-          return `<strong>Regression Trend</strong>`
+          return `<strong>Regression Trend</strong><br/>${params.value[2]}`
         },
       },
       dataset,


### PR DESCRIPTION
Fixes an issue in Chart2 where the regression transform crashed or failed silently without registration in ECharts 5.x. Also fixes the tooltip to show the dynamic equation string instead of a hardcoded text.

---
*PR created automatically by Jules for task [6291644230439143558](https://jules.google.com/task/6291644230439143558) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Chart2 regression in ECharts 5.x by registering and wiring the `ecStat:regression` transform. Updates tooltips to show the computed regression equation instead of hardcoded text.

- **Bug Fixes**
  - Registers `echarts-stat` regression with `echarts` to prevent crashes/silent failures.
  - Wires the transform with `{ method: 'linear', formulaOn: 'end' }` and `fromDatasetIndex: 0`, and points the regression series to the transform dataset.
  - Tooltips now display the equation via `params.value[2]`.

<sup>Written for commit 4bac13efa5597e296c4b6c31ce6edbe44aaec75a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

