### PR TITLE
🎨 Palette: Prevent accidental text selection on interactive table rows and cells

### DIFF
--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -185,7 +185,7 @@ const TableRow = React.memo(
           >
             <label
               htmlFor={safeNameId}
-              className="cursor-pointer hover:text-blue-400 block w-full h-full"
+              className="cursor-pointer hover:text-blue-400 block w-full h-full select-none"
             >
               {name}
             </label>
@@ -354,7 +354,7 @@ export default React.memo(
       const count = showRecords || labels.length
       return Array.from({ length: count }, (_, index) => {
         const dist = count - 1 - index
-        return cn('p-2 border border-gray-700 text-right cursor-pointer', {
+        return cn('p-2 border border-gray-700 text-right cursor-pointer select-none', {
           'is-latest': dist === 0,
           'hidden sm:table-cell': dist === 2,
           'hidden md:table-cell': dist > 2 && dist <= 4,


### PR DESCRIPTION
This PR adds a small UX improvement by applying the `select-none` Tailwind utility class to interactive elements in the main data table (`src/layout/Table.tsx`).

### 💡 What
Added the `select-none` class to:
1. The `<label>` elements acting as clickable row identifiers.
2. The `<td>` data cells that trigger the copy-to-clipboard functionality.

### 🎯 Why
When users interact with tables—especially when quickly clicking multiple items or accidentally double-clicking a cell while trying to copy data—the browser's default behavior is to select/highlight the text. This is visually jarring and breaks the illusion of interacting with an application UI component (a button or actionable area) versus a static document.

### ♿ Accessibility
This change does not impact accessibility. Screen readers and keyboard navigation (tab focus) function exactly as they did before. It purely prevents mouse-driven text selection on elements that have dedicated click handlers.

---
*PR created automatically by Jules for task [12469623454862195542](https://jules.google.com/task/12469623454862195542) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents accidental text selection on interactive table rows and cells by adding Tailwind `select-none` to the clickable row label and copy-to-clipboard cells in `src/layout/Table.tsx`. Improves rapid-click behavior without affecting accessibility.

<sup>Written for commit d5cc005e4c5cae110b7d0c43aed7c544fc94f4c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

