### PR TITLE
Fix: Improve ScatterChart multi-axis legibility and color coding

### DIFF
--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -53,13 +53,13 @@ export default memo(({ data, keys }: ScatterChartProps) => {
       name: key,
       position: isEven ? 'left' : 'right',
       offset: sideOffset,
-      nameTextStyle: {
-        width: 70,
-        overflow: 'truncate',
-        ellipsis: '...',
-      },
+      nameLocation: 'middle',
+      nameGap: 50,
       axisLine: {
         show: true,
+        lineStyle: {
+          color: CHART_PALETTE[index % CHART_PALETTE.length],
+        },
       },
       axisLabel: {
         formatter: '{value}',


### PR DESCRIPTION
This PR updates the multi-axis legibility for ScatterChart to ensure multiple Y-axes render cleanly without overlapping or unreadable truncation, and to allow for proper color coding matching the respective data series.

---
*PR created automatically by Jules for task [4920644224699101754](https://jules.google.com/task/4920644224699101754) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves `ScatterChart` multi-axis readability by centering Y-axis titles, removing truncation, and color-coding axis lines to match their series. Charts with multiple Y-axes are now easier to scan and compare.

- **Bug Fixes**
  - Center Y-axis names and add spacing (`nameLocation: 'middle'`, `nameGap: 50`) to prevent overlap.
  - Remove truncation so axis names stay readable.
  - Apply dynamic axis line colors from `CHART_PALETTE` to match each data series.

<sup>Written for commit 5b92f2a11df3abb31e7234304ba6ca3d054ae21a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

