### PR TITLE
Fix Null/NaN Rendering in Tooltips

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -42,7 +42,14 @@ const echartsOptions: any = {
           const dimName = p.dimensionNames[p.encode.y[0]]
           const val = p.value[dimName]
 
-          if (val !== '-' && val !== null && val !== undefined) {
+          if (
+            val !== '-' &&
+            val !== '' &&
+            val !== 'NaN' &&
+            val !== null &&
+            val !== undefined &&
+            !Number.isNaN(val)
+          ) {
             tooltipStr += `<br/>${p.marker} ${p.seriesName}: <strong>${val}</strong>`
             hasValidValues = true
           }

--- a/src/layout/LineChart.tsx
+++ b/src/layout/LineChart.tsx
@@ -25,7 +25,15 @@ const echartsOptions = {
     formatter: (params: any) => {
       // ECharts axis trigger passes an array of series data for that axis index
       const p = Array.isArray(params) ? params[0] : params
-      if (!p || p.value[1] === '-' || p.value[1] === null || p.value[1] === undefined) {
+      if (
+        !p ||
+        p.value[1] === '-' ||
+        p.value[1] === '' ||
+        p.value[1] === 'NaN' ||
+        p.value[1] === null ||
+        p.value[1] === undefined ||
+        Number.isNaN(p.value[1])
+      ) {
         return ''
       }
       return `${p.seriesName}<br/>${p.value[0]}<br/><strong>${p.value[1]}</strong>`


### PR DESCRIPTION
Fixes an issue identified in Discovery Scan 1 ("Null Value Handling") where invalid time-series values could bypass mapping logic and incorrectly render as 'NaN' inside axis-triggered tooltip containers. This targeted implementation correctly filters out visually empty strings and NaN values inside the `formatter` loops.

---
*PR created automatically by Jules for task [18223488505885164903](https://jules.google.com/task/18223488505885164903) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters invalid values in ECharts tooltip formatters to stop "NaN" and empty boxes from appearing on hover in time-series charts. Improves tooltip clarity for axis-triggered tooltips.

- **Bug Fixes**
  - Updated custom formatters in `Chart.tsx` and `LineChart.tsx` to ignore `'-'`, `''`, `'NaN'`, `null`, `undefined`, and numeric `NaN` via `Number.isNaN`.
  - Returns an empty tooltip when values are invalid; shows only valid data.

<sup>Written for commit 26f7bbd3d3e372602e487a1417acb215746e76c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

