### PR TITLE
⚡ Bolt: Optimize Table column and selection state array allocations

### DIFF
--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -429,16 +429,14 @@ export default React.memo(
     }, [convertedEntries, showRecords])
 
     const columnState = React.useMemo(() => {
-      let state: Record<string, boolean> = { tag: false }
+      // Optimization: Consolidate chained .filter().map() into a single loop
+      // to avoid multiple array allocations and garbage collection overhead.
+      const state: Record<string, boolean> = { tag: false }
 
       if (showRecords) {
-        state = {
-          ...state,
-          ...Object.fromEntries(
-            labels
-              .filter((_, index) => index < labels.length - showRecords)
-              .map((label) => [label, false]),
-          ),
+        const limit = labels.length - showRecords
+        for (let i = 0; i < limit; i++) {
+          state[labels[i]] = false
         }
       }
 
@@ -449,10 +447,15 @@ export default React.memo(
       return state
     }, [showRecords, showOrigColumns])
 
-    const rowSelection = React.useMemo(
-      () => Object.fromEntries(selected.map((item) => [item, true])),
-      [selected],
-    )
+    const rowSelection = React.useMemo(() => {
+      // Optimization: Replace chained Array.map() and Object.fromEntries()
+      // with a single loop to reduce object allocation.
+      const state: Record<string, boolean> = {}
+      for (let i = 0; i < selected.length; i++) {
+        state[selected[i]] = true
+      }
+      return state
+    }, [selected])
 
     const [grouping, setGrouping] = React.useState<GroupingState>(['tag'])
     const [expanded, setExpanded] = React.useState<ExpandedState>(true)


### PR DESCRIPTION
💡 What: Replaced chained `.filter().map()` and `.map() -> Object.fromEntries()` operations inside the `React.useMemo` blocks of `src/layout/Table.tsx` with standard, pre-allocated `for` loops.
🎯 Why: In high-frequency render paths like table filtering and selection updates, chained array methods create unnecessary intermediate array objects and closures, causing memory bloat and garbage collection pauses.
📊 Impact: Eliminates multiple intermediate array allocations (`O(N)` space overhead per render) when updating selected table rows or changing visible historical columns, reducing garbage collection pressure and main thread blocking time.
🔬 Measurement: Verify functional parity and absence of regressions by running the test suite (`pnpm exec playwright test`). Run `pnpm lint` to ensure code remains compliant.

---
*PR created automatically by Jules for task [9217920568263324257](https://jules.google.com/task/9217920568263324257) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized table column and row selection state computation in `Table.tsx` by replacing chained array methods with single-pass loops. This removes per-render intermediate allocations and reduces GC pauses during filtering and selection updates.

<sup>Written for commit 29249a23242fd6f7615f3e5fb452a1bac7d8a97f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

