### PR TITLE
Refactor: replace weak `Record<string, any>` type with `Record<string, unknown>` in Chart2.tsx

### DIFF
--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -171,7 +171,7 @@ export default memo(({ data, keys }: ChartProps) => {
     const entry1 = dataMap.get(keys[1])
 
     const mappedScatterData: any[][] = []
-    const scatterData: Record<string, unknown>[] = []
+    const scatterData: Record<string, number | string>[] = []
 
     if (entry0 && entry1) {
       const values0 = entry0[1]

--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -171,7 +171,7 @@ export default memo(({ data, keys }: ChartProps) => {
     const entry1 = dataMap.get(keys[1])
 
     const mappedScatterData: any[][] = []
-    const scatterData: Record<string, any>[] = []
+    const scatterData: Record<string, unknown>[] = []
 
     if (entry0 && entry1) {
       const values0 = entry0[1]


### PR DESCRIPTION
**The Issue:**
In `src/layout/Chart2.tsx` on line 174, a weakly typed array accumulator `const scatterData: Record<string, any>[] = []` was discovered. Using `any` bypasses type checking for downstream property access, introducing unnecessary runtime risks, and contradicts the memory constraints advising the preference for `Record<string, unknown>`.

**The Discovery Signal:**
Scan H (Weak or Missing Type Annotations) flagged explicit use of `any` types.

**The Fix:**
Updated `Record<string, any>[]` to `Record<string, unknown>[]` on line 174 of `src/layout/Chart2.tsx`.

**The Benefit:**
Improved static analysis type safety. `unknown` requires explicit narrowing or structural checks when consuming properties from objects inside `scatterData`, directly addressing the weak typing without introducing circular dependencies or runtime behavior changes. Playwright tests and oxlint confirm no regressions.

---
*PR created automatically by Jules for task [5165562945878906204](https://jules.google.com/task/5165562945878906204) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the weak `Record<string, any>[]` `scatterData` accumulator in `src/layout/Chart2.tsx` with `Record<string, number | string>[]` to strengthen type safety based on actual usage, with no runtime changes.

<sup>Written for commit a85f53082d4651bb53ecf1510e953256f469488a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

