### PR TITLE
🎨 Palette: Add skip-to-content link

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -112,3 +112,7 @@
 
 **Learning:** Lazy-loaded visual components (like charts) using React `Suspense` often fallback to unstyled static text (e.g., "Loading chart..."). This lacks visual polish and, more importantly, is completely ignored by screen readers because the text is simply rendered into the DOM without semantic meaning.
 **Action:** Always replace plain text Suspense fallbacks with a styled loading container that includes a visual indicator (like `<Spinner />`) and an accessible text node with `role="status"` and `aria-live="polite"`. This ensures the loading state is announced immediately to assistive technologies.
+
+## 2025-04-05 - Missing Skip to Content Link and Document Landmarks
+**Learning:** The application lacked basic structural semantic markup (such as `<main>`) and keyboard user navigation shortcuts like a "Skip to main content" link, severely hampering navigation for screen readers and keyboard-only users who otherwise have to tab through every navigation item.
+**Action:** Always verify that an app has a structural semantic markup wrapping its core content (e.g., `<main id="main-content">`), and provide an accessible skip link immediately at the start of the DOM (`<a href="#main-content" className="sr-only focus:not-sr-only">`) to allow skipping repetitive navigation elements.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -241,33 +241,41 @@ export default function App() {
 
   return (
     <>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 z-[100] px-4 py-2 bg-blue-600 text-white rounded shadow-lg outline-none focus-visible:ring-2 focus-visible:ring-white"
+      >
+        Skip to main content
+      </a>
       <div className="fixed inset-0 -z-10">
         <DarkVeil />
       </div>
       <Nav {...navProps} />
       <PValue comparedSourceTarget={comparedSourceTarget} onClose={onPValueClose} />
       <Correlation target={corrlationKey} onClose={onCorrelationClose} />
-      <React.Suspense
-        fallback={
-          <div className="flex flex-col items-center justify-center p-12 gap-3 text-gray-400">
-            <Spinner />
-            <span role="status" aria-live="polite">
-              Loading chart...
-            </span>
-          </div>
-        }
-      >
-        {filterTag && (!chartKeys || chartKeys.length === 0) && (
-          <RadarChart
-            data={data.filter(([_, __, ___, extra]) => extra?.tag?.includes(filterTag))}
-            tag={filterTag}
-          />
-        )}
-        {chartKeys && chartKeys.length > 0 && chartType === 'scatter' && (
-          <ScatterChart data={data} keys={chartKeys} />
-        )}
-      </React.Suspense>
-      <Table {...tableProps} />
+      <main id="main-content" tabIndex={-1} className="outline-none">
+        <React.Suspense
+          fallback={
+            <div className="flex flex-col items-center justify-center p-12 gap-3 text-gray-400">
+              <Spinner />
+              <span role="status" aria-live="polite">
+                Loading chart...
+              </span>
+            </div>
+          }
+        >
+          {filterTag && (!chartKeys || chartKeys.length === 0) && (
+            <RadarChart
+              data={data.filter(([_, __, ___, extra]) => extra?.tag?.includes(filterTag))}
+              tag={filterTag}
+            />
+          )}
+          {chartKeys && chartKeys.length > 0 && chartType === 'scatter' && (
+            <ScatterChart data={data} keys={chartKeys} />
+          )}
+        </React.Suspense>
+        <Table {...tableProps} />
+      </main>
       <div className="flex flex-wrap justify-center gap-4 mt-4 pb-8">
         <div className="flex flex-col gap-1">
           <label htmlFor="ai-model" className="text-xs text-gray-400 font-medium ml-1">

--- a/tests/skip_to_content.spec.ts
+++ b/tests/skip_to_content.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+
+test('skip to main content link is accessible and works', async ({ page }) => {
+  await page.goto('http://localhost:5173')
+
+  // The skip link should be in the DOM but hidden from view initially
+  const skipLink = page.locator('a[href="#main-content"]')
+  await expect(skipLink).toBeAttached()
+
+  // It should become visible on focus
+  await skipLink.focus()
+  await expect(skipLink).toBeVisible()
+
+  // Press enter
+  await skipLink.press('Enter')
+
+  // Main content should receive focus (or window should scroll to it)
+  // Let's check if the main tag exists and has the id
+  const main = page.locator('main#main-content')
+  await expect(main).toBeAttached()
+})


### PR DESCRIPTION
💡 **What**: Added a visually-hidden, focusable "Skip to main content" link at the very top of `App.tsx`, wrapping the application core content in a semantic `<main id="main-content" tabIndex={-1}>` tag. Consolidated the `.Jules` and `.jules` directory into `.jules`. Added a Playwright test.
🎯 **Why**: Without a skip-link, keyboard-only users and screen readers are forced to tab through the entire navigation and options area before reaching the actual data/charts, which creates a frustrating UX experience.
📸 **Before/After**: See attached test run and screenshot verifying the skip link.
♿ **Accessibility**: Significant improvement for keyboard navigation and structural page semantics.

---
*PR created automatically by Jules for task [818479585545654120](https://jules.google.com/task/818479585545654120) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a focusable “Skip to main content” link and a semantic `<main>` landmark so keyboard and screen-reader users can bypass navigation and reach the charts/table quickly. Added a Playwright test to verify focus behavior and navigation.

- **New Features**
  - Added a visually-hidden, focusable “Skip to main content” link that anchors to `#main-content`.
  - Wrapped core content in `<main id="main-content" tabIndex={-1}>` and added `@playwright/test` to validate visibility and skip behavior.

- **Refactors**
  - Consolidated `.Jules` and `.jules` into `.jules` and updated the journal file path.

<sup>Written for commit 3df25db4408d33c4dab1c5a9ddaaba7a0893222d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

