### PR TITLE
🎨 Palette: Add skip-to-content link and structural layout accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-04-06 - Structural Accessibility (Skip to content)
+**Learning:** While individual components (buttons, inputs) had strong accessibility (ARIA labels, tooltips), the overall layout lacked structural accessibility primitives like a skip-to-content link and a semantic `<main>` wrapper. Without these, keyboard users cannot efficiently bypass top-level navigation components.
+**Action:** Always verify high-level DOM structure for keyboard navigation accessibility alongside component-level ARIA compliance.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -241,34 +241,41 @@ export default function App() {
 
   return (
     <>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-blue-600 focus:text-white focus:rounded focus:m-2"
+      >
+        Skip to content
+      </a>
       <div className="fixed inset-0 -z-10">
         <DarkVeil />
       </div>
       <Nav {...navProps} />
-      <PValue comparedSourceTarget={comparedSourceTarget} onClose={onPValueClose} />
-      <Correlation target={corrlationKey} onClose={onCorrelationClose} />
-      <React.Suspense
-        fallback={
-          <div className="flex flex-col items-center justify-center p-12 gap-3 text-gray-400">
-            <Spinner />
-            <span role="status" aria-live="polite">
-              Loading chart...
-            </span>
-          </div>
-        }
-      >
-        {filterTag && (!chartKeys || chartKeys.length === 0) && (
-          <RadarChart
-            data={data.filter(([_, __, ___, extra]) => extra?.tag?.includes(filterTag))}
-            tag={filterTag}
-          />
-        )}
-        {chartKeys && chartKeys.length > 0 && chartType === 'scatter' && (
-          <ScatterChart data={data} keys={chartKeys} />
-        )}
-      </React.Suspense>
-      <Table {...tableProps} />
-      <div className="flex flex-wrap justify-center gap-4 mt-4 pb-8">
+      <main id="main-content" tabIndex={-1} className="outline-none">
+        <PValue comparedSourceTarget={comparedSourceTarget} onClose={onPValueClose} />
+        <Correlation target={corrlationKey} onClose={onCorrelationClose} />
+        <React.Suspense
+          fallback={
+            <div className="flex flex-col items-center justify-center p-12 gap-3 text-gray-400">
+              <Spinner />
+              <span role="status" aria-live="polite">
+                Loading chart...
+              </span>
+            </div>
+          }
+        >
+          {filterTag && (!chartKeys || chartKeys.length === 0) && (
+            <RadarChart
+              data={data.filter(([_, __, ___, extra]) => extra?.tag?.includes(filterTag))}
+              tag={filterTag}
+            />
+          )}
+          {chartKeys && chartKeys.length > 0 && chartType === 'scatter' && (
+            <ScatterChart data={data} keys={chartKeys} />
+          )}
+        </React.Suspense>
+        <Table {...tableProps} />
+        <div className="flex flex-wrap justify-center gap-4 mt-4 pb-8">
         <div className="flex flex-col gap-1">
           <label htmlFor="ai-model" className="text-xs text-gray-400 font-medium ml-1">
             AI Model
@@ -314,6 +321,7 @@ export default function App() {
           />
         </div>
       </div>
+      </main>
     </>
   )
 }


### PR DESCRIPTION
💡 **What:** Added a "Skip to content" link at the top of the DOM that jumps keyboard focus directly to a new semantic `<main>` wrapper surrounding the core application elements.
🎯 **Why:** Previously, the app lacked structural accessibility primitives. Keyboard users and screen readers had no efficient way to bypass top-level navigation, forcing them to tab through repetitive elements before reaching the primary content.
📸 **Before/After:** The visually hidden link elegantly overlays the UI in the top-left corner only when focused via the `Tab` key, preserving visual design while drastically improving a11y.
♿ **Accessibility:** This directly addresses WCAG guidelines for bypassing blocks of content (Criterion 2.4.1), providing a cleaner structural hierarchy (`<main>`) and keyboard interaction paradigm.

---
*PR created automatically by Jules for task [8858951282009945568](https://jules.google.com/task/8858951282009945568) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a keyboard-accessible “Skip to content” link and a semantic `<main>` wrapper so users can bypass top navigation and jump to primary content. Improves keyboard and screen reader navigation (WCAG 2.4.1).

- **New Features**
  - Visually hidden link appears on focus and moves focus to `#main-content`.
  - Wrapped core content in `<main id="main-content" tabIndex={-1}>` for programmatic focus.
  - No visual changes for pointer users; existing behavior is unchanged.

<sup>Written for commit 19a270abdae47b521988e05c216fdb139c5f9665. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

