### PR TITLE
⚡ Bolt: Optimize render loop array map allocations in Chart components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@
 ## 2024-03-24 - Jotai Derived Atom Closure Overhead
 **Learning:** During rapid user input (like search filtering), derived Jotai atoms (e.g. `visibleDataAtom`) recalculate frequently. Utilizing array prototype methods like `.filter()` and `.some()` inside these atoms causes measurable garbage collection and callback execution overhead due to repeated closure creations per row, leading to typing lag on large datasets.
 **Action:** Always replace chained/nested array methods (`.map`, `.filter`, `.some`) with traditional `for` loops inside frequently updating Jotai derived atoms to ensure zero-allocation recalculation.
+
+## 2025-07-28 - ECharts mapping allocations in hot paths
+**Learning:** Extracting data elements or objects via `.map()` directly inside component render cycles (like preparing configurations for ReactECharts elements such as LineChart, Chart, or Table columns) causes closure allocations and new intermediate arrays on every interaction or parent state change, contributing to rendering jitter.
+**Action:** When iterating over a fixed length like `keys` or `labels` for ECharts data initialization, replace `Array.prototype.map` with an explicit `new Array(size)` pre-allocation combined with a classic `for` loop to eliminate functional closure overhead, and wrap it tightly in a `useMemo` where appropriate.

--- a/src/layout/BoxplotChart.tsx
+++ b/src/layout/BoxplotChart.tsx
@@ -110,45 +110,59 @@ function prepareBoxplotData(data: number[][]) {
   return { boxData, outliers }
 }
 
+import { useMemo } from 'react'
+
 export default memo(({ name, values }: BoxplotChartProps) => {
-  // Group values by 6-month period (H1/H2)
-  const groupedData: Record<string, number[]> = {}
+  const { periods, data } = useMemo(() => {
+    // Group values by 6-month period (H1/H2)
+    const groupedData: Record<string, number[]> = {}
 
-  values.forEach((item, index) => {
-    if (item === null || item === undefined) return
+    const len = values.length
+    for (let index = 0; index < len; index++) {
+      const item = values[index]
+      if (item === null || item === undefined) continue
 
-    const label = labels[index]
-    if (!label || label.length < 6) return
+      const label = labels[index]
+      if (!label || label.length < 6) continue
 
-    // Label is YYMMDD
-    const yy = label.slice(0, 2)
-    const mm = parseInt(label.slice(2, 4), 10)
+      // Label is YYMMDD
+      const yy = label.slice(0, 2)
+      const mm = parseInt(label.slice(2, 4), 10)
 
-    const year = `20${yy}`
-    const half = mm <= 6 ? 'H1' : 'H2'
-    const period = `${half} ${year}`
+      const year = `20${yy}`
+      const half = mm <= 6 ? 'H1' : 'H2'
+      const period = `${half} ${year}`
 
-    if (!groupedData[period]) {
-      groupedData[period] = []
+      if (!groupedData[period]) {
+        groupedData[period] = []
+      }
+      groupedData[period].push(item)
     }
-    groupedData[period].push(item)
-  })
 
-  // Ensure chronological ordering by sorting keys
-  const periods = Object.keys(groupedData).sort((a, b) => {
-    // a and b are like 'H1 2023', 'H2 2023'
-    const [halfA, yearA] = a.split(' ')
-    const [halfB, yearB] = b.split(' ')
-    if (yearA !== yearB) return yearA.localeCompare(yearB)
-    return halfA.localeCompare(halfB)
-  })
+    // Ensure chronological ordering by sorting keys
+    const periods = Object.keys(groupedData).sort((a, b) => {
+      // a and b are like 'H1 2023', 'H2 2023'
+      const [halfA, yearA] = a.split(' ')
+      const [halfB, yearB] = b.split(' ')
+      if (yearA !== yearB) return yearA.localeCompare(yearB)
+      return halfA.localeCompare(halfB)
+    })
 
-  const datasets = periods.map((p) => groupedData[p])
+    // Optimization: Replace Object.keys().map() chaining with a single classic loop
+    const datasetsLen = periods.length
+    // eslint-disable-next-line eslint-plugin-unicorn/no-new-array
+    const datasets = new Array(datasetsLen)
+    for (let i = 0; i < datasetsLen; i++) {
+      datasets[i] = groupedData[periods[i]]
+    }
 
-  if (datasets.length === 0) return null
+    if (datasets.length === 0) return { periods: [], data: null }
 
-  // prepareBoxplotData expects an array of datasets
-  const data = prepareBoxplotData(datasets)
+    // prepareBoxplotData expects an array of datasets
+    return { periods, data: prepareBoxplotData(datasets) }
+  }, [values])
+
+  if (!data || periods.length === 0) return null
 
   const options = {
     ...echartsOptions,

--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -76,14 +76,20 @@ export default memo(({ data, keys }: ChartProps) => {
 
   console.log(data, keys)
 
-  const yAxis: any[] = useMemo(
-    () =>
-      keys.map((k) => ({
+  const yAxis: any[] = useMemo(() => {
+    // Optimization: Replace array map in the render loop with a classic for-loop
+    // and pre-allocated array to avoid closure and garbage collection overhead.
+    const numKeys = keys.length
+    // eslint-disable-next-line eslint-plugin-unicorn/no-new-array
+    const result = new Array(numKeys)
+    for (let i = 0; i < numKeys; i++) {
+      result[i] = {
         scale: true,
-        name: k,
-      })),
-    [keys],
-  )
+        name: keys[i],
+      }
+    }
+    return result
+  }, [keys])
 
   const chartData = useMemo(() => {
     // Optimization: use a local O(1) map for data lookups instead of O(N) array.find inside a map.

--- a/src/layout/LineChart.tsx
+++ b/src/layout/LineChart.tsx
@@ -60,12 +60,24 @@ const formatTime = (label: string) => {
   return `20${label.slice(0, 2)}/${label.slice(2, 4)}/${label.slice(4, 6)}`
 }
 
+import { useMemo } from 'react'
+
 export default memo(({ name, values, rangeStr }: LineChartProps) => {
   // Map null/undefined values to '-' and pair them with labels
   // Preserving missing points prevents misrepresenting data gaps (connectNulls: false by default)
-  const data = values.map((value, index) => {
-    return [formatTime(labels[index]), value !== null && value !== undefined ? value : '-']
-  })
+  const data = useMemo(() => {
+    // Optimization: Replace array map in the render loop with a pre-allocated array.
+    // Also, wrap in useMemo so that the date formatting isn't re-run unneccessarily when
+    // other props (like rangeStr or parent component states) trigger a re-render.
+    const numLabels = labels.length
+    // eslint-disable-next-line eslint-plugin-unicorn/no-new-array
+    const result = new Array(numLabels)
+    for (let i = 0; i < numLabels; i++) {
+      const value = values[i]
+      result[i] = [formatTime(labels[i]), value !== null && value !== undefined ? value : '-']
+    }
+    return result
+  }, [values])
 
   let markArea: any = undefined
 

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -280,25 +280,26 @@ export default React.memo<NavProps>(
               })}
             >
               <ul className="contents lg:flex lg:flex-row xl:gap-1 lg:items-center list-none p-0 m-0">
-                {tags.map((tag: string) => (
-                  <li className="nav-item contents lg:block" key={tag}>
-                    <button
-                      type="button"
-                      data-tag={tag}
-                      aria-pressed={filterTag === tag}
-                      className={cn(
-                        'px-3 py-2 rounded transition-colors w-full lg:w-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
-                        {
-                          'bg-blue-600 text-white': filterTag == tag,
-                          'text-gray-300 hover:text-white hover:bg-gray-700': filterTag != tag,
-                        },
-                      )}
-                      onClick={onFilterByTag}
-                    >
-                      {tag.slice(2)}
-                    </button>
-                  </li>
-                ))}
+                {tags.map((tag: string) => {
+                  const isSelectedTag = filterTag == tag
+                  return (
+                    <li className="nav-item contents lg:block" key={tag}>
+                      <button
+                        type="button"
+                        data-tag={tag}
+                        aria-pressed={isSelectedTag}
+                        className={`px-3 py-2 rounded transition-colors w-full lg:w-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                          isSelectedTag
+                            ? 'bg-blue-600 text-white'
+                            : 'text-gray-300 hover:text-white hover:bg-gray-700'
+                        }`}
+                        onClick={onFilterByTag}
+                      >
+                        {tag.slice(2)}
+                      </button>
+                    </li>
+                  )
+                })}
               </ul>
 
               <button

--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -80,34 +80,46 @@ export default memo(({ data, keys }: ScatterChartProps) => {
       dataMap.set(data[i][0], data[i])
     }
 
-    return keys.map((key, index) => {
+    // Optimization: Replace chained Array.map() with a classic for-loop and pre-allocated array.
+    // This eliminates the closure allocation and avoids garbage collection spikes in component render paths.
+    const numKeys = keys.length
+    // eslint-disable-next-line eslint-plugin-unicorn/no-new-array
+    const result = new Array(numKeys)
+    for (let k = 0; k < numKeys; k++) {
+      const key = keys[k]
       const bioMarker = dataMap.get(key)
+
       if (!bioMarker) {
-        return {
+        result[k] = {
           name: key,
           type: 'scatter',
-          yAxisIndex: index,
+          yAxisIndex: k,
           data: [],
         }
+        continue
       }
 
       const values = bioMarker[1]
       const unit = bioMarker[2]
-
       const validData = []
-      for (let i = 0; i < values.length; i++) {
-        if (values[i] !== null && values[i] !== undefined) {
-          validData.push([formatTime(labels[i]), values[i], unit])
+
+      const numLabels = labels.length
+      // Assuming labels length matches values length
+      for (let i = 0; i < numLabels; i++) {
+        const val = values[i]
+        if (val !== null && val !== undefined) {
+          validData.push([formatTime(labels[i]), val, unit])
         }
       }
 
-      return {
+      result[k] = {
         name: key,
         type: 'scatter',
-        yAxisIndex: index,
+        yAxisIndex: k,
         data: validData,
       }
-    })
+    }
+    return result
   }, [data, keys])
 
   const options = {

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -277,23 +277,32 @@ const columns: ColumnDef<DisplayedEntry, any>[] = [
     header: 'Name',
     footer: 'Supp',
   }),
-  ...labels.map((label, index) =>
-    columnHelper.accessor(label as any, {
-      header: getKeyFromTime(label),
-      meta: {
-        isRecord: true,
-        isLatest: index === labels.length - 1,
-        title: label,
-        className: (() => {
-          const dist = labels.length - 1 - index
-          if (dist <= 1) return ''
-          if (dist === 2) return 'hidden sm:table-cell'
-          if (dist <= 4) return 'hidden md:table-cell'
-          if (dist > 4) return 'hidden lg:table-cell'
-        })(),
-      },
-    }),
-  ),
+  ...(() => {
+    // Optimization: Replace labels.map() with a classic for-loop and pre-allocated array.
+    // This avoids closure allocation overhead and speeds up the module initialization.
+    const numLabels = labels.length
+    // eslint-disable-next-line eslint-plugin-unicorn/no-new-array
+    const result = new Array(numLabels)
+    for (let index = 0; index < numLabels; index++) {
+      const label = labels[index]
+      const dist = numLabels - 1 - index
+      let className = ''
+      if (dist === 2) className = 'hidden sm:table-cell'
+      else if (dist > 2 && dist <= 4) className = 'hidden md:table-cell'
+      else if (dist > 4) className = 'hidden lg:table-cell'
+
+      result[index] = columnHelper.accessor(label as any, {
+        header: getKeyFromTime(label),
+        meta: {
+          isRecord: true,
+          isLatest: index === numLabels - 1,
+          title: label,
+          className,
+        },
+      })
+    }
+    return result
+  })(),
   columnHelper.accessor('placeholder' as any, {
     header: '',
     meta: {


### PR DESCRIPTION
💡 **What:** Replaced idiomatic `Array.map` iteration logic with classic `for` loops and pre-allocated arrays (e.g. `new Array(size)`) across multiple charting components (`ScatterChart`, `LineChart`, `BoxplotChart`, `Chart`) and `Table.tsx`.
🎯 **Why:** Standard `Array.map()` operations executed directly in React render cycles or `useMemo` blocks create a new closure for every element, which repeatedly generates array garbage. When charting libraries like ReactECharts are fed heavily re-calculated datasets upon user interactions (like tooltips or filtering), this builds up garbage collection spikes and typing lag.
📊 **Impact:** Reduces unneeded object allocations during render paths by O(N) operations, helping the JS engine run hot paths faster and avoid micro-stuttering during interactions.
🔬 **Measurement:** Verify by running standard `pnpm exec playwright test` ensuring data rendering does not regress, or measuring ECharts rendering allocation using Chrome DevTools Memory/Performance tab during continuous interactions.

---
*PR created automatically by Jules for task [573850736435027587](https://jules.google.com/task/573850736435027587) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts render-time allocations in chart components by replacing `.map()` with pre-allocated loops and adding memoization. This reduces GC pressure and smooths chart and table interactions.

- **Refactors**
  - `ScatterChart`, `LineChart`, `BoxplotChart`, `Chart`: replaced `.map()` with `for` loops and pre-allocated arrays; added `useMemo` for computed series/axes.
  - `Table.tsx`: build column definitions with a loop; compute responsive classes once per column.
  - `Nav.tsx`: simplify tag button rendering by precomputing selection and inlining classes.
  - `.jules/bolt.md`: add guidance on avoiding `.map()` in hot render paths.

<sup>Written for commit 744133b079e30b2b6def33c09aea66c5455d81ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

