### PR TITLE
refactor(types): replace 'any' with strong inferred type in Table DataCell props

### DIFF
--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -41,8 +41,21 @@ function getKeyFromTime(label: string) {
 // Optimization: DataCell accepts stable props (unit, displayValue) instead of children
 // to ensure React.memo works effectively. Passing JSX as children (e.g. <a...>)
 // creates new object references on every render, defeating memoization.
-const DataCell = React.memo(({ className, rawValue, onCopy, unit, displayValue }: any) => {
-  const [copied, setCopied] = React.useState(false)
+const DataCell = React.memo(
+  ({
+    className,
+    rawValue,
+    onCopy,
+    unit,
+    displayValue,
+  }: {
+    className?: string
+    rawValue: string
+    onCopy?: (text: string) => Promise<void>
+    unit: string | { url: string } | undefined
+    displayValue: string | number | null
+  }) => {
+    const [copied, setCopied] = React.useState(false)
 
   const handleInteraction = React.useCallback(async () => {
     if (onCopy) await onCopy(rawValue)


### PR DESCRIPTION
**The Issue:**
`src/layout/Table.tsx` line 44 used an explicit `: any` type annotation for the props of the `DataCell` component. This was a structural problem because it bypassed TypeScript's checking, leading to weak typings that mask potential mismatches between the provided arguments and expected prop shapes inside the cell implementation.

**The Discovery Signal:**
Scan H (Weak or Missing Type Annotations): I searched for `: any` under `src/` and discovered multiple candidates. The `DataCell` component's props parameter (`{ className, rawValue, onCopy, unit, displayValue }: any`) was flagged as an easily inferable yet completely untyped structure.

**The Fix:**
Replaced the `any` keyword with a precise inline type definition:
```typescript
{
  className?: string
  rawValue: string
  onCopy?: (text: string) => Promise<void>
  unit: string | { url: string } | undefined
  displayValue: string | number | null
}
```
No extra `.types.ts` exports or interfaces were created, respecting the constraint to not invent new structures while performing this isolated fix.

**The Benefit:**
Improved codebase typing strictness by resolving a `tsc --noEmit --strict` implicit-any vulnerability in a frequently rendered component without introducing side-effects or altering business logic. Future agents and developers will benefit from clearer type contracts and fewer type-widening issues.

---
*PR created automatically by Jules for task [16485367817508798476](https://jules.google.com/task/16485367817508798476) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `any` in `DataCell` props with a precise inline type in `src/layout/Table.tsx` to improve type safety and strict `tsc` compliance. No behavior changes; this tightens contracts for `className`, `rawValue`, `onCopy`, `unit` (string or `{ url: string }`), and `displayValue`.

<sup>Written for commit cf6ea096089f267dd2e3b1d9e52126ef3f89e492. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

