### PR TITLE
⚡ Bolt: Unroll reduce calls and consolidate array loops in processors

### DIFF
--- a/src/processors/post/index.ts
+++ b/src/processors/post/index.ts
@@ -3,10 +3,21 @@ import applyRange from './range'
 import applyDescription from './description'
 
 const postProcessEntry = (entry: Entry): Entry => {
-  const funcs = [applyTag, applyRange, applyDescription]
-  return funcs.reduce((result, func) => func(result), entry)
+  // Optimization: Unroll reduce loop and array allocation for better performance
+  // Avoids `reduce` overhead in a hot loop processing every single entry.
+  let result = applyTag(entry)
+  result = applyRange(result)
+  result = applyDescription(result)
+  return result
 }
 
 export default (entries: Entry[]): Entry[] => {
-  return entries.map(postProcessEntry)
+  // Optimization: Use a classic for-loop with pre-allocated array instead of .map()
+  // to reduce object allocation and garbage collection overhead.
+  const len = entries.length
+  const result = new Array(len)
+  for (let i = 0; i < len; i++) {
+    result[i] = postProcessEntry(entries[i])
+  }
+  return result
 }

--- a/src/processors/post/range.ts
+++ b/src/processors/post/range.ts
@@ -126,7 +126,13 @@ export default (entry: Entry, strict?: boolean): Entry => {
       if (min !== MAX_VALUE) min = +convert(min).toFixed(2)
       if (max !== MAX_VALUE) max = +convert(max).toFixed(2)
 
-      rangeValues = rangeValues.map((x) => (x != MAX_VALUE ? convert(x as number).toFixed(2) : '-'))
+      // Optimization: Replace array.map with a classic for loop and pre-allocated array.
+      const newRangeValues = new Array(rangeValues.length)
+      for (let i = 0; i < rangeValues.length; i++) {
+        const x = rangeValues[i]
+        newRangeValues[i] = x != MAX_VALUE ? convert(x as number).toFixed(2) : '-'
+      }
+      rangeValues = newRangeValues
     }
 
     if (rangeValues.includes(MAX_VALUE)) {
@@ -141,11 +147,21 @@ export default (entry: Entry, strict?: boolean): Entry => {
       return !isNaN(value) && (value < min || value > max)
     }
 
-    // Optimization: pre-calculate optimality to avoid repeated calculations in render loops
-    extra.optimality = values.map((val) => extra.isNotOptimal?.(parseFloat(val)) ?? false)
+    // Optimization: pre-calculate optimality using a classic loop to avoid map overhead
+    const len = values.length
+    const optimality = new Array(len)
+    for (let i = 0; i < len; i++) {
+      optimality[i] = extra.isNotOptimal?.(parseFloat(values[i])) ?? false
+    }
+    extra.optimality = optimality
   } else if (extra) {
     extra.isNotOptimal = () => false
-    extra.optimality = values.map(() => false)
+    const len = values.length
+    const optimality = new Array(len)
+    for (let i = 0; i < len; i++) {
+      optimality[i] = false
+    }
+    extra.optimality = optimality
   }
   return entry
 }

--- a/src/processors/pre/index.ts
+++ b/src/processors/pre/index.ts
@@ -28,12 +28,24 @@ const setup = (entry: Entry): Entry => {
 }
 
 const preProcessEntry = (entry: Entry): Entry => {
-  const funcs = [setup, convertName, convertUnit]
-  return funcs.reduce((result, func) => func(result), entry)
+  // Optimization: Unroll reduce loop and array allocation for better performance
+  // Avoids `reduce` overhead in a hot loop processing every single entry.
+  let result = setup(entry)
+  result = convertName(result)
+  result = convertUnit(result)
+  return result
 }
 
 export default (entries: Entry[]): Entry[] => {
-  entries = entries.filter((entry) => !excludes.includes(entry[0]))
-  entries = entries.map(preProcessEntry)
-  return entries
+  // Optimization: Consolidate chained .filter().map() into a single loop
+  // to avoid allocating intermediate arrays and reducing iterations.
+  const result: Entry[] = []
+  const len = entries.length
+  for (let i = 0; i < len; i++) {
+    const entry = entries[i]
+    if (!excludes.includes(entry[0])) {
+      result.push(preProcessEntry(entry))
+    }
+  }
+  return result
 }


### PR DESCRIPTION
💡 **What:** 
Unrolled the array of transformation functions `[setup, convertName, convertUnit].reduce(...)` and `[applyTag, applyRange, applyDescription].reduce(...)` inside the hot loops that process every data entry. Also replaced multiple chained array methods (`.filter().map()`) with single-pass classic loops in `src/processors/pre/index.ts`, `src/processors/post/index.ts`, and `src/processors/post/range.ts`.

🎯 **Why:** 
The previous implementation defined a new array of functions and ran `Array.reduce` for *every single element* in the dataset. This caused immense object allocation, closure generation, and immediate garbage collection pressure during the initial data load, blocking the main thread longer than necessary. Chained `.map()` operations created further intermediate redundant arrays.

📊 **Impact:** 
Reduces memory allocation rate significantly and speeds up the initial synchronous parsing of dataset entries. Avoids allocating thousands of throwaway arrays on initialization.

🔬 **Measurement:** 
Run `pnpm test` and `pnpm exec playwright test`. The application loads cleanly and all visualization parameters, tags, and ranges correctly match expected data outputs.

---
*PR created automatically by Jules for task [11051003565583981679](https://jules.google.com/task/11051003565583981679) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unrolled reduce calls and replaced chained array methods with single-pass loops in pre/post processors to cut allocations and speed up dataset parsing. This lowers GC pressure in hot paths and improves initial load time.

- **Performance**
  - Unrolled `[setup, convertName, convertUnit]` and `[applyTag, applyRange, applyDescription]` reduce chains inside per-entry loops.
  - Replaced `filter().map()` with a single pass in `src/processors/pre/index.ts`.
  - Switched `.map()` to for-loops with pre-allocated arrays in `src/processors/post/index.ts` and `src/processors/post/range.ts` (including optimality precompute).

<sup>Written for commit edb0d22f569214291849b23af2f8089960dff7ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

