### PR TITLE
refactor(table): replace explicit any with precise inline props type

### DIFF
--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -128,7 +128,21 @@ const TableRow = React.memo(
     averageCountValue,
     visibleLeafColumnsCount,
     onCellClick,
-  }: any) => {
+  }: {
+    entry: DisplayedEntry
+    isSelected: boolean
+    isExpanded: boolean
+    rowId: string
+    toggleExpand: (id: string) => void
+    onSelect: (name: string) => void
+    onCorrelation: (name: string) => void
+    setCorrelationBiomarker: (name: string | null) => void
+    cellBaseClasses: string[]
+    showOrigColumns: boolean
+    averageCountValue: string
+    visibleLeafColumnsCount: number
+    onCellClick: (text: string) => Promise<void>
+  }) => {
     const { name, values, visibleValues, visibleOptimality, visibleOriginValues, unit, extra } =
       entry
     const safeNameId = String(name).replace(/[^a-zA-Z0-9-_]/g, '-')


### PR DESCRIPTION
**The Issue:**
`src/layout/Table.tsx` line 131. The `TableRow` component parameters were typed with an explicit `any`, which bypasses TypeScript checking for component props and breaks type inference inside the component. This is a structural problem because it leads to unsafe code where prop changes aren't caught by the compiler.

**The Discovery Signal:**
Scan H: `src/layout/Table.tsx` line 131 — `tsc --noEmit --strict` implicit `any` patterns or explicit `any` usage. The explicit `any` was assigned to the destructured props of `TableRow`.

**The Fix:**
Replaced the `any` type with an inline object type signature that accurately describes all the destructured props:
```tsx
  }: {
    entry: DisplayedEntry
    isSelected: boolean
    isExpanded: boolean
    rowId: string
    toggleExpand: (id: string) => void
    onSelect: (name: string) => void
    onCorrelation: (name: string) => void
    setCorrelationBiomarker: (name: string | null) => void
    cellBaseClasses: string[]
    showOrigColumns: boolean
    averageCountValue: string
    visibleLeafColumnsCount: number
    onCellClick: (text: string) => Promise<void>
  }) => {
```
The `DisplayedEntry` type was already imported from `./Table.types` and no new interfaces were created, respecting constraints.

**The Benefit:**
Eliminates an unsafe runtime pattern and fixes a weak type annotation without creating new technical debt. This reduces confusion for future developers/agents by providing clear prop typings and ensures `tsc` will now catch any regressions if the props passed to `<TableRow>` change in the future.

---
*PR created automatically by Jules for task [635975002007286145](https://jules.google.com/task/635975002007286145) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `any` props type in `TableRow` (`src/layout/Table.tsx`) with a precise inline object type using `DisplayedEntry`. This restores type safety and improves inference so `tsc --strict` will catch prop regressions.

- **Refactors**
  - Typed the destructured `TableRow` props with an inline object type; no new interfaces or runtime changes.

<sup>Written for commit 659425b653bc9a910ee8f57f2fb79e909fc3ff57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

