### PR TITLE
fix: correctly configure ECharts merging strategy

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -146,7 +146,7 @@ export default memo(({ data, keys }: ChartProps) => {
               connectNulls: false,
             })),
           },
-          { replaceMerge: ['series', 'yAxis'] },
+          { notMerge: true },
         )
       }
     }

--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -311,7 +311,7 @@ export default memo(({ data, keys }: ChartProps) => {
             series: [{ symbolSize: 40 }],
             dataZoom: options.dataZoom,
           },
-          { notMerge: true },
+          { replaceMerge: ['series', 'dataZoom'] },
         )
         // console.log("ch1", instance.getOption());
       }


### PR DESCRIPTION
Addresses issues with React ECharts instance state bleed-through and configuration destruction by correctly applying `notMerge` and `replaceMerge` strategies based on the supplied ECharts options.

---
*PR created automatically by Jules for task [3120236359622418742](https://jules.google.com/task/3120236359622418742) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ECharts setOption merging to stop state bleed-through and keep base chart config intact. We now clear stale series in `Chart.tsx` with `{ notMerge: true }`, and limit updates in `Chart2.tsx` to `series` and `dataZoom` using `{ replaceMerge: ['series', 'dataZoom'] }`.

<sup>Written for commit 47b8ccccde6f67b099f15f43cd914582f0c1bcff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

