### PR TITLE
🎨 Palette: Add explicit label associations for select elements

### DIFF
--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -377,11 +377,14 @@ export default React.memo<NavProps>(
                       {isAsking ? 'Asking...' : 'Ask AI'}
                     </button>
                     <div className="w-px h-4 bg-gray-600 mx-0.5 hidden sm:block"></div>
+                    <label htmlFor="chart-type" className="sr-only">
+                      Select chart type
+                    </label>
                     <select
+                      id="chart-type"
                       className="px-2 py-1 bg-dark-bg text-dark-text border border-gray-600 rounded text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                       value={chartType}
                       onChange={(e) => onChartTypeChange(e.target.value)}
-                      aria-label="Select chart type"
                     >
                       <option value="scatter">Scatter Chart</option>
                     </select>
@@ -409,11 +412,14 @@ export default React.memo<NavProps>(
 
               <div className="hidden contents lg:flex lg:ml-auto lg:flex-row lg:gap-4 lg:items-center">
                 <div className="flex items-center gap-2 w-full lg:w-auto">
+                  <label htmlFor="average-count" className="sr-only">
+                    Select average count
+                  </label>
                   <select
+                    id="average-count"
                     className="flex-1 lg:flex-none px-3 py-1 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     value={averageCount.toString()}
                     onChange={onAverageCount}
-                    aria-label="Select average count"
                   >
                     <option value="">No average</option>
                     <option value="3">Average of last 3 tests</option>
@@ -423,11 +429,14 @@ export default React.memo<NavProps>(
                   </select>
                 </div>
                 <div className="hidden lg:flex items-center gap-2 lg:w-auto">
+                  <label htmlFor="show-records" className="sr-only">
+                    Select number of records to show
+                  </label>
                   <select
+                    id="show-records"
                     className="flex-1 lg:flex-none px-3 py-1 bg-dark-bg text-dark-text border border-gray-600 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     value={showRecords.toString()}
                     onChange={onShowRecordsChange}
-                    aria-label="Select number of records to show"
                   >
                     <option value="0">All</option>
                     <option value="3">Last 3 records</option>

--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -305,13 +305,14 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                 {availableTags.length > 0 && (
                   <div className="flex gap-4 mb-6 bg-[#1a1a1a] p-3 rounded-lg border border-[#3a3a3a]">
                     <div className="flex flex-col gap-1 w-1/2">
-                      <label className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                      <label htmlFor="x-axis-group" className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
                         X-Axis Group
                       </label>
                       <select
+                        id="x-axis-group"
                         value={xAxisTag}
                         onChange={(e) => setXAxisTag(e.target.value)}
-                        className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500"
+                        className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
                       >
                         {availableTags.map((t) => (
                           <option key={t} value={t}>
@@ -321,13 +322,14 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                       </select>
                     </div>
                     <div className="flex flex-col gap-1 w-1/2">
-                      <label className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                      <label htmlFor="y-axis-group" className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
                         Y-Axis Group
                       </label>
                       <select
+                        id="y-axis-group"
                         value={yAxisTag}
                         onChange={(e) => setYAxisTag(e.target.value)}
-                        className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500"
+                        className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
                       >
                         {availableTags.map((t) => (
                           <option key={t} value={t}>


### PR DESCRIPTION
🎨 Palette: Add explicit label associations for select elements

💡 **What:** Added proper `htmlFor` and `id` associations for `<select>` elements, and added visually hidden `sr-only` labels where visual labels were missing or not feasible.
🎯 **Why:** To improve screen reader accessibility by ensuring all form elements have proper, strongly-associated labels rather than relying solely on `aria-label` or implicit wrappers.
♿ **Accessibility:**
- Added `sr-only` labels linked to the "Select chart type", "Select average count", and "Select number of records to show" dropdowns in the Navigation bar.
- Correctly linked the existing "X-Axis Group" and "Y-Axis Group" visual labels to their respective `<select>` inputs in the System Clustering dialog using `id` and `htmlFor`.

---
*PR created automatically by Jules for task [9244300455013422011](https://jules.google.com/task/9244300455013422011) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit label-to-select associations and sr-only labels to improve screen reader support and keyboard focus in the Nav and System Clustering views. Satisfies task 9244300455013422011 by ensuring all selects have proper labels.

- **Bug Fixes**
  - Nav (`Nav.tsx`): Added `id` + matching `label` for "chart type", "average count", and "records to show"; removed redundant `aria-label`s.
  - System Clustering (`SystemClustering.tsx`): Linked "X-Axis Group" and "Y-Axis Group" labels via `htmlFor`/`id`; added `focus-visible` rings for clearer keyboard focus.

<sup>Written for commit 854708adc693f1108cf2536f00745907c851d789. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

