### PR TITLE
Fix `setOption` correctly using `replaceMerge` in `src/layout/Chart.tsx`

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -146,7 +146,7 @@ export default memo(({ data, keys }: ChartProps) => {
               connectNulls: false,
             })),
           },
-          { notMerge: true },
+          { replaceMerge: ['series', 'yAxis'] },
         )
       }
     }

--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -305,7 +305,10 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                 {availableTags.length > 0 && (
                   <div className="flex gap-4 mb-6 bg-[#1a1a1a] p-3 rounded-lg border border-[#3a3a3a]">
                     <div className="flex flex-col gap-1 w-1/2">
-                      <label htmlFor="x-axis-group" className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                      <label
+                        htmlFor="x-axis-group"
+                        className="text-xs font-semibold text-gray-400 uppercase tracking-wider"
+                      >
                         X-Axis Group
                       </label>
                       <select
@@ -322,7 +325,10 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                       </select>
                     </div>
                     <div className="flex flex-col gap-1 w-1/2">
-                      <label htmlFor="y-axis-group" className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                      <label
+                        htmlFor="y-axis-group"
+                        className="text-xs font-semibold text-gray-400 uppercase tracking-wider"
+                      >
                         Y-Axis Group
                       </label>
                       <select


### PR DESCRIPTION
The ECharts instance in `src/layout/Chart.tsx` was using `notMerge: true` within `setOption`. This correctly prevented stale series from rendering when the selected number of series decreased, but also entirely overwrote the base chart configuration (e.g., `backgroundColor: 'transparent'` and custom tooltips) initialized via the wrapper.

This commit replaces `notMerge: true` with `replaceMerge: ['series', 'yAxis']`. This tells ECharts to specifically overwrite and remove stale series and yAxis data, whilst preserving the base visual and tooltip configurations.

**Proposals for new visualisations:**

1. **Proposal 1 of 3: Radar Chart for Tag Groups**
   *   **ECharts type:** `radar`
   *   **Which existing data it uses:** uses the `dataAtom` to extract all `BioMarker` items matching a specific tag (e.g. from `src/processors/post/tag.ts` like `1-RBC`), plotting their latest value relative to their `extra.range` boundaries.
   *   **What it reveals that current charts don't:** shows whether all biomarkers in a specific group (e.g. Metabolic) are simultaneously within range at a glance, rather than requiring the user to scan each table row individually.
   *   **Where it would live:** New `src/layout/GroupRadarChart.tsx`, rendered when a specific tag filter is active in `App.tsx` (e.g., below the main table).
   *   **Trigger / entry point:** Clicking one of the tag filter chips at the top of the screen (which sets `tagAtom`). The radar chart could auto-render showing the balance of that specific group.
   *   **Implementation complexity:** Medium (requires mapping disparate biomarker units/scales onto a normalized 0-100 radar axis based on their optimal ranges).
   *   **ECharts 5.6.0 API confirmed via context7:** yes (`radar` component and `series-radar` options checked).

2. **Proposal 2 of 3: Correlation Heatmap**
   *   **ECharts type:** `heatmap` (using `cartesian2d` coordinate system)
   *   **Which existing data it uses:** uses the `correlationAtom` which already contains Pearson/Spearman pairwise results between different biomarkers and supplements.
   *   **What it reveals that current charts don't:** Provides a macro-level, color-coded visual matrix of how all tracked metrics relate to each other simultaneously, instantly highlighting strong positive (red) or negative (blue) correlations without needing to click into individual dialogs.
   *   **Where it would live:** New `src/layout/CorrelationHeatmap.tsx`, accessible via a new dedicated tab or a prominent "View Correlation Matrix" button near the search bar.
   *   **Trigger / entry point:** A toggle or button in the main navigation/header that switches the main view from the data table to the heatmap visualization.
   *   **Implementation complexity:** Low (the correlation data is already fully computed in `correlationAtom`; it just needs to be mapped to the `[x, y, value]` format required by ECharts heatmap).
   *   **ECharts 5.6.0 API confirmed via context7:** yes (`series-heatmap` options checked).

3. **Proposal 3 of 3: Calendar Heatmap for Supplement Tracking**
   *   **ECharts type:** `calendar` combined with `heatmap` or `scatter` series.
   *   **Which existing data it uses:** uses the `labels` array (dates) from `src/data/index.ts` and the `supps` (supplements) data found within the `BioMarker` notes/originValues or the correlation processors.
   *   **What it reveals that current charts don't:** Provides a bird's-eye view of supplement adherence over the year, allowing users to easily spot gaps in their regimen or correlate long-term habits with seasonal health changes.
   *   **Where it would live:** New `src/layout/SupplementCalendar.tsx`, perhaps shown when clicking on a specific supplement pill/chip.
   *   **Trigger / entry point:** Clicking on a specific supplement name in the correlation dialog or a dedicated supplements list.
   *   **Implementation complexity:** Low (requires formatting the `labels` into `yyyy-MM-dd` and mapping the boolean presence of a supplement on that date to a calendar coordinate).
   *   **ECharts 5.6.0 API confirmed via context7:** yes (`calendar` coordinate system and `series-heatmap`/`series-scatter` options checked).

---
*PR created automatically by Jules for task [11161190191414452266](https://jules.google.com/task/11161190191414452266) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched `echarts` `setOption` from `notMerge: true` to `replaceMerge: ['series', 'yAxis']` to remove stale series/axes while preserving base chart options like transparent background and custom tooltips. Also cleaned up label markup in `SystemClustering` for better readability.

<sup>Written for commit 1e46ca23eb82298b928d3af379837affad82b881. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

