### PR TITLE
refactor: extract DarkVeil Props to sibling types file

### DIFF
--- a/src/layout/DarkVeil.tsx
+++ b/src/layout/DarkVeil.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from 'react'
 import { Renderer, Program, Mesh, Triangle, Vec2 } from 'ogl'
+import { DarkVeilProps } from './DarkVeil.types'
 
 const vertex = `
 attribute vec2 position;
@@ -73,15 +74,6 @@ void main(){
 }
 `
 
-type Props = {
-  hueShift?: number
-  noiseIntensity?: number
-  scanlineIntensity?: number
-  speed?: number
-  scanlineFrequency?: number
-  warpAmount?: number
-  resolutionScale?: number
-}
 
 export default function DarkVeil({
   hueShift = 0,
@@ -91,7 +83,7 @@ export default function DarkVeil({
   scanlineFrequency = 0,
   warpAmount = 0,
   resolutionScale = 1,
-}: Props) {
+}: DarkVeilProps) {
   const ref = useRef<HTMLCanvasElement>(null)
   useEffect(() => {
     const canvas = ref.current as HTMLCanvasElement

--- a/src/layout/DarkVeil.types.ts
+++ b/src/layout/DarkVeil.types.ts
@@ -1,0 +1,9 @@
+export type DarkVeilProps = {
+  hueShift?: number
+  noiseIntensity?: number
+  scanlineIntensity?: number
+  speed?: number
+  scanlineFrequency?: number
+  warpAmount?: number
+  resolutionScale?: number
+}


### PR DESCRIPTION
- **The Issue**: `src/layout/DarkVeil.tsx` defined a complex `Props` type inline and did not export it, violating the repository's structural pattern where components with complex props must have a sibling `.types.ts` file. This was surfaced during Phase 1 Scan D (Misplaced Shared Types).
- **The Discovery Signal**: Scan D found that `DarkVeil.tsx` defined `Props` internally rather than extracting it to a `.types.ts` file.
- **The Fix**: Created `src/layout/DarkVeil.types.ts`, extracted the `Props` type into it, renamed it to `DarkVeilProps`, and exported it. Updated `DarkVeil.tsx` to import and use the new type.
- **The Benefit**: Reduced structural confusion, standardized component typing in accordance with established repository patterns, and eliminated a misplaced type.

---
*PR created automatically by Jules for task [6209887109585625133](https://jules.google.com/task/6209887109585625133) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the inline `Props` from src/layout/DarkVeil.tsx into a new src/layout/DarkVeil.types.ts as `DarkVeilProps`, and updated the component to import it. This aligns `DarkVeil` with the repo’s typing pattern and removes a misplaced shared type.

<sup>Written for commit 340923863a5ba92f18cf390e128aa5d5bb90b325. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

