### PR TITLE
fix(charts): prevent setOption from overwriting base config in Chart.tsx

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -146,7 +146,7 @@ export default memo(({ data, keys }: ChartProps) => {
               connectNulls: false,
             })),
           },
-          { notMerge: true },
+          { replaceMerge: ['series', 'yAxis'] },
         )
       }
     }


### PR DESCRIPTION
**The Issue:**
In `src/layout/Chart.tsx` (line 146), `instance.setOption()` was called with `{ notMerge: true }`. This causes ECharts to replace the entire option model with only the partial configuration provided in that specific update call. As a result, critical base configurations provided by the `ChartProvider` wrapper (like the tooltip formatter, `backgroundColor: 'transparent'`, and dark theme text colors) were destroyed, leading to a stale or completely incorrect render state when the user interacted with the chart.

**Discovery Signal:**
Scan 5 — setOption Correctness.

**context7 Reference:**
Confirmed via ECharts 5.6 documentation for `setOption`: `replaceMerge` is the correct API to use when intending to replace specific component types (like `series` or `yAxis`) without blowing away the rest of the option tree.

**The Fix:**
Changed `{ notMerge: true }` to `{ replaceMerge: ['series', 'yAxis'] }`.

**The Benefit:**
Multi-axis line charts in `Chart.tsx` now correctly merge new series and axes data without losing their tooltips or breaking the dark theme visualization.

---

### Part 2 — Visualization Proposals

No new visualization proposals are being offered at this time. The core issue affecting the visual integrity of existing charts took precedence. I have evaluated `boxplot`, `radar`, and `heatmap`, but none provided a high enough insight-to-effort ratio using the currently existing atom structures without either extensive restructuring or producing overwhelming/noisy visual output.

---
*PR created automatically by Jules for task [4667467383209833229](https://jules.google.com/task/4667467383209833229) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent ECharts updates from overwriting the base chart config by switching `setOption` from `{ notMerge: true }` to `{ replaceMerge: ['series', 'yAxis'] }` in `src/layout/Chart.tsx`. This preserves provider options like the tooltip formatter, transparent background, and dark theme while still updating series and axes.

<sup>Written for commit 1bbcdaae720357421ad77e0a7fb3b55819ff4c16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

