### PR TITLE
⚡ Bolt: Use dataMapAtom to prevent redundant Map allocations in charts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -42,3 +42,7 @@
 
 **Learning:** Extracting data elements or objects via `.map()` directly inside component render cycles (like preparing configurations for ReactECharts elements such as LineChart, Chart, or Table columns) causes closure allocations and new intermediate arrays on every interaction or parent state change, contributing to rendering jitter.
 **Action:** When iterating over a fixed length like `keys` or `labels` for ECharts data initialization, replace `Array.prototype.map` with an explicit `new Array(size)` pre-allocation combined with a classic `for` loop to eliminate functional closure overhead, and wrap it tightly in a `useMemo` where appropriate.
+
+## 2025-04-10 - Utilize dataMapAtom to prevent redundant Map allocations in chart components
+**Learning:** Generating the same data lookup map across multiple chart components on every render cycle using `new Map()` introduces redundant object allocation and closure creation, specifically inside heavy `useMemo` hooks. This increases garbage collection pressure, particularly when handling large biomarker arrays or responding rapidly to UI state changes (like filter text debouncing or axis selections). A pre-existing Jotai derived atom (`dataMapAtom`) correctly handles this operation dynamically once.
+**Action:** Use global derived atoms (e.g., `useAtomValue(dataMapAtom)`) for shared lookups rather than duplicating local mapping overhead (`new Map()`) inside individual component logic.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -270,7 +270,7 @@ export default function App() {
             />
           )}
           {chartKeys && chartKeys.length > 0 && chartType === 'scatter' && (
-            <ScatterChart data={data} keys={chartKeys} />
+            <ScatterChart keys={chartKeys} />
           )}
         </React.Suspense>
         <Table {...tableProps} />

--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -1,12 +1,12 @@
 import { memo, useRef, useEffect, useMemo } from 'react'
+import { useAtomValue } from 'jotai'
+import { dataMapAtom } from '../atom/dataAtom'
 import { ChartProvider, ChartContext } from '@echarts-readymade/core'
 import { Line } from '@echarts-readymade/line'
 import { labels } from '../data'
-import { BioMarker } from '../types/biomarker'
 import { CHART_PALETTE } from './Chart2'
 
 interface ChartProps {
-  data: BioMarker[]
   keys: string[]
 }
 
@@ -66,8 +66,8 @@ const formatTime = (label: string) => {
   return `20${label.slice(0, 2)}/${label.slice(2, 4)}/${label.slice(4, 6)}`
 }
 
-export default memo(({ data, keys }: ChartProps) => {
-  console.log(data, keys)
+export default memo(({ keys }: ChartProps) => {
+  const dataMap = useAtomValue(dataMapAtom)
 
   const valueList = useMemo(() => {
     // Optimization: Wrap with useMemo to prevent creating a new array reference every render,
@@ -96,13 +96,6 @@ export default memo(({ data, keys }: ChartProps) => {
   }, [keys])
 
   const chartData = useMemo(() => {
-    // Optimization: use a local O(1) map for data lookups instead of O(N) array.find inside a map.
-    // This reduces lookup complexity from O(N*K) to O(N + K).
-    const dataMap = new Map()
-    for (let i = 0; i < data.length; i++) {
-      dataMap.set(data[i][0], data[i])
-    }
-
     // Optimization: Replace chained .reduce(), .forEach() and Object.values() with a
     // single-pass loop over the data length. This eliminates closure creation, higher-order
     // array method overhead, and repetitive dictionary allocations per render.
@@ -132,7 +125,7 @@ export default memo(({ data, keys }: ChartProps) => {
     }
 
     return result
-  }, [data, keys, valueList, labels])
+  }, [dataMap, keys, valueList, labels])
 
   const ref = useRef<any>(null)
 

--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -1,16 +1,16 @@
 import { memo, useRef, useEffect, useMemo } from 'react'
+import { useAtomValue } from 'jotai'
+import { dataMapAtom } from '../atom/dataAtom'
 import { ChartProvider, ChartContext } from '@echarts-readymade/core'
 import { Scatter } from '@echarts-readymade/scatter'
 import { labels } from '../data'
 import ReactECharts from 'echarts-for-react'
-import { BioMarker } from '../types/biomarker'
 import * as echarts from 'echarts'
 import * as ecStat from 'echarts-stat'
 
 echarts.registerTransform((ecStat as any).transform.regression)
 
 interface ChartProps {
-  data: BioMarker[]
   keys: string[]
 }
 
@@ -131,7 +131,8 @@ const echartsOptions: any = {
   ],
 }
 
-export default memo(({ data, keys }: ChartProps) => {
+export default memo(({ keys }: ChartProps) => {
+  const dataMap = useAtomValue(dataMapAtom)
   const valueList = [
     { fieldKey: keys[0], fieldName: keys[0], decimalLength: 2 },
     { fieldKey: keys[1], fieldName: keys[1], decimalLength: 2 },
@@ -158,13 +159,6 @@ export default memo(({ data, keys }: ChartProps) => {
   }
 
   const [scatterData, mappedScatterData] = useMemo(() => {
-    // Optimization: use a local O(1) map for data lookups instead of O(N) array.find inside a map.
-    // This reduces lookup complexity from O(N*K) to O(N + K).
-    const dataMap = new Map()
-    for (let i = 0; i < data.length; i++) {
-      dataMap.set(data[i][0], data[i])
-    }
-
     // Optimization: Replace O(K*N) chained .map(), .reduce(), and .filter() array allocations
     // with a single-pass O(N) loop to eliminate closure creation and garbage collection overhead.
     const entry0 = dataMap.get(keys[0])
@@ -198,7 +192,7 @@ export default memo(({ data, keys }: ChartProps) => {
     }
 
     return [scatterData, mappedScatterData]
-  }, [keys, data])
+  }, [dataMap, keys])
 
   const scatterRef = useRef<any>(null)
 

--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -1,11 +1,11 @@
 import { memo, useMemo } from 'react'
+import { useAtomValue } from 'jotai'
+import { dataMapAtom } from '../atom/dataAtom'
 import ReactECharts from 'echarts-for-react'
-import { BioMarker } from '../types/biomarker'
 import { labels } from '../data'
 import { CHART_PALETTE } from './Chart2'
 
 interface ScatterChartProps {
-  data: BioMarker[]
   keys: string[]
 }
 
@@ -43,7 +43,8 @@ const echartsOptions = {
   },
 }
 
-export default memo(({ data, keys }: ScatterChartProps) => {
+export default memo(({ keys }: ScatterChartProps) => {
+  const dataMap = useAtomValue(dataMapAtom)
   const yAxes = keys.map((key, index) => {
     const isEven = index % 2 === 0
     const sideOffset = Math.floor(index / 2) * 80
@@ -73,13 +74,6 @@ export default memo(({ data, keys }: ScatterChartProps) => {
   }
 
   const chartData = useMemo(() => {
-    // Optimization: use a local O(1) map for data lookups instead of O(N) array.find inside a map.
-    // This reduces lookup complexity from O(N*K) to O(N + K).
-    const dataMap = new Map()
-    for (let i = 0; i < data.length; i++) {
-      dataMap.set(data[i][0], data[i])
-    }
-
     // Optimization: Replace chained Array.map() with a classic for-loop and pre-allocated array.
     // This eliminates the closure allocation and avoids garbage collection spikes in component render paths.
     const numKeys = keys.length
@@ -120,7 +114,7 @@ export default memo(({ data, keys }: ScatterChartProps) => {
       }
     }
     return result
-  }, [data, keys])
+  }, [dataMap, keys])
 
   const options = {
     ...echartsOptions,


### PR DESCRIPTION
💡 **What:** Replaced the redundant `new Map()` instantiation logic inside the `useMemo` dependency blocks of `Chart.tsx`, `Chart2.tsx`, and `ScatterChart.tsx` with a shared Jotai derived atom lookup via `useAtomValue(dataMapAtom)`. Additionally, the redundant `data` prop propagation in `App.tsx` has been cleaned up.
🎯 **Why:** Creating individual maps inside component render cycles produces duplicated O(N) execution paths, and triggers closure allocations per update. This elevates garbage collection overhead. Since the `dataMapAtom` already handles the data-to-map conversion dynamically at the global state level, reusing it is significantly more efficient.
📊 **Impact:** Reduces lookup complexity and eliminates object re-allocation (`new Map()`) inside charting components, directly preventing unnecessary garbage collection spikes on UI interaction or state updates.
🔬 **Measurement:** Code correctly passes all existing unit and e2e interaction tests via Playwright (`pnpm exec playwright test`), and TypeScript strictly validates the safe consumption of `dataMapAtom`. The `vite_output.log` artifact was reverted to avoid polluting the workspace.

---
*PR created automatically by Jules for task [17819300254854415533](https://jules.google.com/task/17819300254854415533) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reused the shared `dataMapAtom` in chart components to remove redundant `new Map()` allocations and reduce GC overhead during renders.

- **Refactors**
  - Replaced local map creation in `Chart.tsx`, `Chart2.tsx`, and `ScatterChart.tsx` with `useAtomValue(dataMapAtom)` and updated memo deps.
  - Removed the `data` prop from `Chart`, `Chart2`, and `ScatterChart`; updated `App.tsx` to stop passing it.
  - Documented the pattern in `.jules/bolt.md`.

<sup>Written for commit 06c0a03abfd2c750c2d6b54dbf816ab77d07cc7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

