### PR TITLE
fix: resolve oxlint no-new-array in convertUnit.ts

### DIFF
--- a/src/processors/pre/convertUnit.ts
+++ b/src/processors/pre/convertUnit.ts
@@ -103,8 +103,8 @@ export default ([name, values, unit, extra]: Entry): Entry => {
   // instead of chaining Array.map(), Array.filter(), and Array.some()
   // to eliminate redundant iteration, reduce closure creation, and avoid
   // heavy garbage collection overhead on intermediate array allocations.
-  const newValues = new Array(len)
-  const originValues = new Array(len)
+  const newValues = Array.from({ length: len }) as string[]
+  const originValues = Array.from({ length: len }) as (string | number | null)[]
 
   let newUnit: string | undefined = undefined
   let originUnit: string | undefined = undefined


### PR DESCRIPTION
**The Issue:**
`src/processors/pre/convertUnit.ts` lines 106 and 107. The code uses `new Array(len)` to pre-allocate arrays, which violates the `unicorn/no-new-array` rule in oxlint's correctness category. This pattern is flagged because it is often confusing whether the argument is intended as the array length or the sole element.

**The Discovery Signal:**
Scan G: `src/processors/pre/convertUnit.ts` - oxlint rule `correctness/no-new-array` reports "Do not use `new Array(singleArgument)`".

**The Fix:**
Replaced `new Array(len)` with `Array.from({ length: len })` and explicitly cast the results using `as string[]` and `as (string | number | null)[]` to ensure TypeScript correctly infers the dense array type without widening to `unknown[]` and breaking the strict compile step.

**The Benefit:**
Eliminates an active `correctness` lint violation in a core data processor, leading to a cleaner build output and establishing a safer array initialization pattern.

---
*PR created automatically by Jules for task [10446500026297923743](https://jules.google.com/task/10446500026297923743) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace new Array(len) with Array.from({ length: len }) in convertUnit.ts to resolve the `oxlint` `correctness/no-new-array` rule. Adds explicit type assertions to preserve dense array types and avoid widening to unknown[] without changing behavior.

<sup>Written for commit 1b6abc038cd860e45630bfcf0fd0ef643faaba5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

