### PR TITLE
⚡ Bolt: Optimize parallel array lookups with direct indexing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -44,5 +44,11 @@
 **Action:** When iterating over a fixed length like `keys` or `labels` for ECharts data initialization, replace `Array.prototype.map` with an explicit `new Array(size)` pre-allocation combined with a classic `for` loop to eliminate functional closure overhead, and wrap it tightly in a `useMemo` where appropriate.
 
 ## 2025-04-10 - Utilize dataMapAtom to prevent redundant Map allocations in chart components
+
 **Learning:** Generating the same data lookup map across multiple chart components on every render cycle using `new Map()` introduces redundant object allocation and closure creation, specifically inside heavy `useMemo` hooks. This increases garbage collection pressure, particularly when handling large biomarker arrays or responding rapidly to UI state changes (like filter text debouncing or axis selections). A pre-existing Jotai derived atom (`dataMapAtom`) correctly handles this operation dynamically once.
 **Action:** Use global derived atoms (e.g., `useAtomValue(dataMapAtom)`) for shared lookups rather than duplicating local mapping overhead (`new Map()`) inside individual component logic.
+
+## 2025-07-28 - Optimize array lookups with direct indexing
+
+**Learning:** In `src/layout/Chart.tsx`, using `Array.find()` inside a loop over an array of equal length (`keys` and `valueList`) to correlate corresponding objects creates an unnecessary `O(N^2)` operation. Since `valueList` is directly mapped from `keys` index-for-index, the arrays are guaranteed to be parallel.
+**Action:** Replace `Array.find((entry) => entry.fieldName === key)` with direct array indexing `valueList[i]` when operating on parallel arrays inside a `useMemo` block to drop time complexity from `O(N^2)` to `O(N)`.

--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -104,8 +104,10 @@ export default memo(({ keys }: ChartProps) => {
       const key = keys[i]
       const entry = dataMap.get(key)
       if (entry) {
-        const k = valueList.find((entry) => entry.fieldName === key)
-        if (k) {
+        // Optimization: Replace O(N) Array.find() with O(1) direct array indexing.
+        // valueList is generated directly from keys, so their indices perfectly align.
+        const k = valueList[i]
+        if (k && k.fieldName === key) {
           validSeries.push({ fieldKey: k.fieldKey, values: entry[1] })
         }
       }


### PR DESCRIPTION
💡 **What**: Replaced an `Array.find` call inside the `chartData` generation loop in `src/layout/Chart.tsx` with a direct array index access (`valueList[i]`).

🎯 **Why**: Because `valueList` is generated directly from the `keys` array inside a `useMemo` block, the indices of elements in both arrays map to each other exactly 1:1. Using `.find((entry) => entry.fieldName === key)` inside a loop over `keys.length` created an unnecessary `O(N^2)` lookup. Replacing it with `valueList[i]` guarantees an `O(1)` access time and lowers the overall function complexity to `O(N)`.

📊 **Impact**: Eliminates repeated array traversal during hot render paths (chart updates), dropping time complexity from `O(N^2)` to `O(N)` for establishing valid data series in the Chart layout.

🔬 **Measurement**: Confirmed correctness via `pnpm exec playwright test`, specifically ensuring no regression in visualization and performance benchmarks.

---
*PR created automatically by Jules for task [8465700681307826464](https://jules.google.com/task/8465700681307826464) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized chart series building by replacing an `Array.find` in `src/layout/Chart.tsx` with direct indexing to cut work from O(N^2) to O(N) during renders. Uses the 1:1 index alignment between `keys` and `valueList` for O(1) lookups.

- **Refactors**
  - `src/layout/Chart.tsx`: use `valueList[i]` with a safety check (`k && k.fieldName === key`) instead of `.find(...)`.
  - Updated `.jules/bolt.md` with this pattern; verified no regressions with Playwright tests.

<sup>Written for commit 1c8c5da6f30c32e639a34db4a06145d198eeffe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

