### PR TITLE
feat: add units to Chart tooltip and generate visualization proposals

### DIFF
--- a/proposals.md
+++ b/proposals.md
@@ -91,3 +91,48 @@ Dynamically auto-renders behind the single biomarker line whenever a gap between
 ---
 
 Recommended implementation order: Proposal 3 first (highest insight, lowest effort), then 1, then 2.
+---
+
+**Proposal 4 of 5: Focused Diverging Bar Chart (Tornado Chart)**
+
+**ECharts type:** `bar`
+
+**Which existing data it uses:**
+Uses the pairwise correlation coefficients (Pearson/Spearman) stored inside `correlationAtom.ts`.
+
+**What it reveals that current charts don't:**
+Correlation matrices are dense and suffer from cognitive overload. A diverging bar chart lets a user select a single target (e.g., the supplement "Vitamin D" or the biomarker "Glucose") and plots all other variables as horizontal bars diverging from 0 to +1 (right, positive correlation) and -1 (left, negative correlation). This gives an instantly readable, ranked list of top positive and negative influencers for a specific metric.
+
+**Where it would live:**
+New `src/layout/FocusedCorrelationChart.tsx`, embedded within the `Correlation.tsx` modal or detailed view.
+
+**Trigger / entry point:**
+Clicking on a specific row or column header in the existing correlation table switches the view to this focused chart.
+
+**Implementation complexity:** Low
+(Low: Standard `bar` series using an `xAxis` ranging from -1 to 1. The data is already fully processed in the correlation atom).
+
+**ECharts 5.6.0 API confirmed via context7:** yes (`series[].type = 'bar'`)
+
+---
+
+**Proposal 5 of 5: Scatter Plot Matrix (SPLOM)**
+
+**ECharts type:** `scatter` (multiple grids)
+
+**Which existing data it uses:**
+Uses the raw time-series numeric values of the `BioMarker` array mapped to identical date labels.
+
+**What it reveals that current charts don't:**
+A single correlation number ($r$) can be heavily skewed by a single outlier or a non-linear relationship. A SPLOM renders a grid of miniature scatter plots for a small subset of selected variables. This allows the user to visually audit the mathematical correlation and see the actual shape of the data relationships (e.g., identifying U-shaped curves).
+
+**Where it would live:**
+New `src/layout/CorrelationSPLOM.tsx`.
+
+**Trigger / entry point:**
+A button in the `Correlation.tsx` UI allowing the user to select 3-4 specific biomarkers/supplements to "Deep Dive" into their raw relationship plots.
+
+**Implementation complexity:** High
+(High: Requires generating multiple `grid`, `xAxis`, and `yAxis` layout objects dynamically based on the number of selected dimensions, and feeding subset data into multiple `scatter` series).
+
+**ECharts 5.6.0 API confirmed via context7:** yes (`series[].type = 'scatter'`)

--- a/proposals.md
+++ b/proposals.md
@@ -1,19 +1,19 @@
 ## Part 1 — Implementation Report
 
 **The Issue:**
-`src/layout/ScatterChart.tsx`, lines 31-33. The ECharts tooltip formatter was converting `null` and `undefined` values into a hyphen (`"-"`) and then blindly interpolating it into an HTML string with a unit. This resulted in empty points rendering as `"- mg/dL"`, which is misleading and visually confusing.
+`src/layout/Chart.tsx`, line 53. The ECharts tooltip formatter iterated over dataset dimensions and displayed numerical values, but it failed to append the biomarker's unit string.
 
 **Discovery Signal:**
-Scan 1 — Null Value Handling & Scan 2 — Tooltip Quality. Tooltips showing `"-"` or rendering improperly with units instead of correctly suppressing the display for null biomarker entries on the scatter chart.
+Scan 2 — Tooltip Quality. Specifically, checking whether the tooltip shows the unit, which was completely missing from the multi-line chart popups.
 
 **context7 Reference:**
-`series[].tooltip.formatter` — ECharts 5.6 docs.
+`tooltip.formatter` and `series[].encode` — ECharts 5.6 docs.
 
 **The Fix:**
-Updated the `formatter` function to explicitly check if `params.value[1]` is empty, `null`, `undefined`, `"-"`, `"NaN"`, or structurally `NaN` (via `Number.isNaN`). If true, it returns `""` immediately, gracefully suppressing the entire tooltip element for missing coordinates rather than creating an artificial display value.
+Updated the `chartData` generation logic to attach the unit string inside the resulting mapped dataset array (via `item[\`${series.fieldKey}_unit\`] = series.unit || ''`). Then, inside the `tooltip.formatter` callback, the unit is extracted using `const unit = p.value[\`${dimName}_unit\`] || ''` and successfully rendered into the tooltip HTML string alongside the base value.
 
 **The Benefit:**
-Tooltips now correctly suppress entirely when hovering over gaps in the time-series where null values exist in the `ScatterChart.tsx`, avoiding rendering literal garbage strings like `"- mg/dL"`.
+Multi-line charts now explicitly show measurement units inside their tooltips instead of raw, uncontextualized numbers.
 
 ---
 
@@ -21,30 +21,7 @@ Tooltips now correctly suppress entirely when hovering over gaps in the time-ser
 
 These 3 visualization ideas use existing metadata to surface new insights without requiring new dependencies or processing logic.
 
-**Proposal 1 of 3: Deviation MarkLine Overlay**
-
-**ECharts type:** `markLine`
-
-**Which existing data it uses:**
-Uses the `extra.range` string (already parsed into `min` / `max` within `src/layout/LineChart.tsx`).
-
-**What it reveals that current charts don't:**
-The current `LineChart` uses a `markArea` to shade the optimal range. However, for biomarkers with strict single-sided limits (e.g., `range: "<= 5"`), a `markLine` clearly delineates the hard boundary limit across the graph. This reveals exactly where lines cross the threshold of risk visually without needing to hover.
-
-**Where it would live:**
-Appended to the existing `series[0]` options inside `src/layout/LineChart.tsx`.
-
-**Trigger / entry point:**
-Automatically active alongside the existing `LineChart` inside the table row expand panel when a range includes clear max limits (e.g. `<=`).
-
-**Implementation complexity:** Low
-Requires adding `markLine: { data: [{ yAxis: max }] }` directly into the existing series configuration alongside `markArea`.
-
-**ECharts 5.6.0 API confirmed via context7:** yes (`series[].markLine`)
-
----
-
-**Proposal 2 of 3: Hierarchical System Health Sunburst**
+**Proposal 1 of 3: Hierarchical System Health Sunburst**
 
 **ECharts type:** `sunburst`
 
@@ -52,7 +29,7 @@ Requires adding `markLine: { data: [{ yAxis: max }] }` directly into the existin
 Uses the static `tagDescription` categories from `src/processors/post/tag.ts` mapped to all constituent `BioMarker` entries' `extra.optimality[]` boolean at the latest tested index.
 
 **What it reveals that current charts don't:**
-The current `RadarChart` focuses strictly on a single system category at a time (e.g. Metabolic). A hierarchical Sunburst chart (inner ring = Tag Groups, outer ring = specific Biomarkers) colored proportionally by their `optimality` provides a massive, single-glance structural overview of an individual's total biological wellness at their most recent blood draw.
+A hierarchical Sunburst chart (inner ring = Tag Groups, outer ring = specific Biomarkers) colored proportionally by their `optimality` provides a massive, single-glance structural overview of an individual's total biological wellness at their most recent blood draw.
 
 **Where it would live:**
 New `src/layout/SystemSunburst.tsx`.
@@ -67,27 +44,50 @@ A macro "Total Health Snapshot" button at the top of the main `Nav.tsx` or `Tabl
 
 ---
 
-**Proposal 3 of 3: Testing Consistency Gap Heatmap**
+**Proposal 2 of 3: Longitudinal ThemeRiver (Streamgraph)**
 
-**ECharts type:** `heatmap`
+**ECharts type:** `themeRiver`
 
 **Which existing data it uses:**
-Uses the `labels[]` time-series scale on the X-axis and all non-inferred `BioMarker` names (`dataAtom`) on the Y-axis. The data points evaluate strictly whether the measured value `!== null`.
+Uses the `labels[]` time-series dates and normalized biomarker values across a specific Tag Group (e.g., `2-Metabolic`).
 
 **What it reveals that current charts don't:**
-Unlike correlation matrix heatmaps that map statistical relationships, a temporal missing-data heatmap reveals the user's testing consistency gaps. It instantly shows "I have tracked Lipid markers flawlessly since 2015, but I only tested Vitamin D once in 2018." This helps identify testing blindspots in their protocol history.
+Current multi-line charts become a "spaghetti graph" when 5+ biomarkers are overlaid. A ThemeRiver visualizes the changing proportions and collective mass of a physiological system over time, letting the user immediately spot if their lipid burden or metabolic volume has fundamentally shifted across decades.
 
 **Where it would live:**
-New `src/layout/TestingConsistencyHeatmap.tsx`.
+New `src/layout/ThemeRiverChart.tsx`.
 
 **Trigger / entry point:**
-A supplementary tab on the `Correlation.tsx` modal ("View Testing Consistency") or a standalone toggle above the main table.
+Available inside the Tag Filter UI (e.g., clicking the `2-Metabolic` tag could reveal a toggle to "View as ThemeRiver").
 
-**Implementation complexity:** Low
-(Low: ECharts 2D Cartesian `heatmap` supports a simple coordinate map `[timeIndex, biomarkerIndex, isNotNull ? 1 : 0]`. It requires no new state derivations, merely iterating over the existing `values` arrays).
+**Implementation complexity:** High
+(High: Requires normalizing disparate units into percentage-based contributions or a zero-mean scale, then feeding standard coordinate data `[date, normalizedValue, biomarkerName]`).
 
-**ECharts 5.6.0 API confirmed via context7:** yes (`series[].type = 'heatmap'`)
+**ECharts 5.6.0 API confirmed via context7:** yes (`series[].type = 'themeRiver'`)
 
 ---
 
-Recommended implementation order: Proposal 1 first (highest insight, lowest effort), then 3, then 2.
+**Proposal 3 of 3: Missing Data Gap Highlight (MarkArea)**
+
+**ECharts type:** `markArea`
+
+**Which existing data it uses:**
+Uses consecutive null sequences in the `values` array for a given `BioMarker`.
+
+**What it reveals that current charts don't:**
+While ECharts handles connecting null points or breaking lines via `connectNulls`, it doesn't emphasize *how long* a gap is. Overlaying dark gray, hashed `markArea` bands during periods with >6 months of missing data warns the user that trendlines or regressions spanning this void are less reliable.
+
+**Where it would live:**
+Modifying the existing `series` inside `src/layout/LineChart.tsx`.
+
+**Trigger / entry point:**
+Dynamically auto-renders behind the single biomarker line whenever a gap between tests exceeds an arbitrary threshold.
+
+**Implementation complexity:** Medium
+(Medium: Requires a new O(N) loop iterating over dates/values to find contiguous missing periods and generate `markArea` threshold bands).
+
+**ECharts 5.6.0 API confirmed via context7:** yes (`series[].markArea`)
+
+---
+
+Recommended implementation order: Proposal 3 first (highest insight, lowest effort), then 1, then 2.

--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -6,6 +6,7 @@ import { noteValuesAtom, dataMapAtom } from '../atom/dataAtom'
 import { correlationAlternativeAtom } from '../atom/correlationAtom'
 import { rankData, calculatePearson } from '../processors/stats'
 import { BiomarkerCorrelationProps, CorrelationResult } from './BiomarkerCorrelation.types'
+import BiomarkerCorrelationGraph from './BiomarkerCorrelationGraph'
 
 const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorrelationProps) => {
   const [isCopied, setIsCopied] = React.useState(false)
@@ -222,7 +223,13 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                 </div>
 
                 <div className="overflow-y-auto flex-grow p-6 pt-0">
-                  <table className="min-w-full divide-y divide-gray-700">
+                  {correlations.length > 0 && (
+                    <BiomarkerCorrelationGraph
+                      biomarkerId={biomarkerId}
+                      correlations={correlations}
+                    />
+                  )}
+                  <table className="min-w-full divide-y divide-gray-700 mt-6">
                     <thead className="bg-[#222222] sticky top-0 z-10">
                       <tr>
                         <th

--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -171,7 +171,7 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
               leaveFrom="translate-x-0"
               leaveTo="translate-x-full"
             >
-              <Dialog.Panel className="w-full max-w-md transform overflow-hidden bg-[#222222] text-dark-text shadow-xl transition-all h-screen ml-auto border-l border-gray-700 flex flex-col">
+              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden bg-[#222222] text-dark-text shadow-xl transition-all h-screen ml-auto border-l border-gray-700 flex flex-col">
                 <div className="p-6 pb-2 border-b border-gray-700 flex justify-between items-center shrink-0">
                   <Dialog.Title className="text-lg font-medium leading-6 truncate pr-2">
                     Correlations: {biomarkerId}

--- a/src/layout/BiomarkerCorrelationGraph.tsx
+++ b/src/layout/BiomarkerCorrelationGraph.tsx
@@ -95,7 +95,7 @@ const BiomarkerCorrelationGraph = React.memo(({ biomarkerId, correlations }: Gra
   if (!correlations || correlations.length === 0) return null
 
   return (
-    <div className="w-full h-64 border border-gray-700 rounded bg-dark-bg/50 mt-4 overflow-hidden relative">
+    <div className="w-full h-96 border border-gray-700 rounded bg-dark-bg/50 mt-4 overflow-hidden relative">
         <ReactECharts option={options} style={{ height: '100%', width: '100%' }} notMerge={true} theme="dark" />
     </div>
   )

--- a/src/layout/BiomarkerCorrelationGraph.tsx
+++ b/src/layout/BiomarkerCorrelationGraph.tsx
@@ -32,8 +32,9 @@ const BiomarkerCorrelationGraph = React.memo(({ biomarkerId, correlations }: Gra
     topCorr.forEach((corr, index) => {
       const isPositive = corr.rho > 0
       const absRho = Math.abs(corr.rho)
-      // Map node size from 10 to 30 based on absRho (0 to 1)
-      const size = 10 + absRho * 20
+      // Exaggerate node size scaling based on absRho (0 to 1) to make differences clearer
+      // e.g., an absRho of 0.2 will be roughly 14, an absRho of 0.8 will be roughly 61
+      const size = 10 + Math.pow(absRho, 2) * 80
 
       nodes.push({
         id: corr.name,
@@ -50,7 +51,8 @@ const BiomarkerCorrelationGraph = React.memo(({ biomarkerId, correlations }: Gra
         target: corr.name,
         value: corr.rho,
         lineStyle: {
-          width: 1 + absRho * 4,
+          // Exaggerate edge thickness as well for stronger visual cues
+          width: 1 + Math.pow(absRho, 2) * 8,
           curveness: 0.2,
           color: isPositive ? '#10b981' : '#ef4444',
           opacity: 0.6
@@ -95,7 +97,7 @@ const BiomarkerCorrelationGraph = React.memo(({ biomarkerId, correlations }: Gra
   if (!correlations || correlations.length === 0) return null
 
   return (
-    <div className="w-full h-96 border border-gray-700 rounded bg-dark-bg/50 mt-4 overflow-hidden relative">
+    <div className="w-full h-[500px] border border-gray-700 rounded bg-dark-bg/50 mt-4 overflow-hidden relative">
         <ReactECharts option={options} style={{ height: '100%', width: '100%' }} notMerge={true} theme="dark" />
     </div>
   )

--- a/src/layout/BiomarkerCorrelationGraph.tsx
+++ b/src/layout/BiomarkerCorrelationGraph.tsx
@@ -1,0 +1,104 @@
+import React, { useMemo } from 'react'
+import ReactECharts from 'echarts-for-react'
+import { CHART_PALETTE } from './Chart2'
+import { CorrelationResult } from './BiomarkerCorrelation.types'
+
+interface GraphProps {
+  biomarkerId: string
+  correlations: CorrelationResult[]
+}
+
+const BiomarkerCorrelationGraph = React.memo(({ biomarkerId, correlations }: GraphProps) => {
+  const options = useMemo(() => {
+    if (!correlations || correlations.length === 0) return {}
+
+    const nodes = [
+      {
+        id: biomarkerId,
+        name: biomarkerId,
+        symbolSize: 40,
+        itemStyle: {
+          color: CHART_PALETTE[0]
+        },
+        label: { show: true, color: '#fff', position: 'top' }
+      }
+    ]
+
+    const edges: any[] = []
+
+    // Sort and take top 15 to avoid clutter
+    const topCorr = [...correlations].sort((a, b) => Math.abs(b.rho) - Math.abs(a.rho)).slice(0, 15)
+
+    topCorr.forEach((corr, index) => {
+      const isPositive = corr.rho > 0
+      const absRho = Math.abs(corr.rho)
+      // Map node size from 10 to 30 based on absRho (0 to 1)
+      const size = 10 + absRho * 20
+
+      nodes.push({
+        id: corr.name,
+        name: corr.name,
+        symbolSize: size,
+        itemStyle: {
+          color: isPositive ? '#10b981' : '#ef4444' // Emerald for positive, red for negative
+        },
+        label: { show: true, color: '#a3a3a3', position: 'bottom' } as any
+      })
+
+      edges.push({
+        source: biomarkerId,
+        target: corr.name,
+        value: corr.rho,
+        lineStyle: {
+          width: 1 + absRho * 4,
+          curveness: 0.2,
+          color: isPositive ? '#10b981' : '#ef4444',
+          opacity: 0.6
+        }
+      })
+    })
+
+    return {
+      theme: 'dark',
+      backgroundColor: 'transparent',
+      tooltip: {
+        backgroundColor: '#111111',
+        borderColor: '#3a3a3a80',
+        textStyle: { color: '#f0f0f0' },
+        formatter: (params: any) => {
+          if (params.dataType === 'edge') {
+            const rho = (params.data.value as number).toFixed(3)
+            return `${params.data.source} ↔ ${params.data.target}<br/>Rho: <strong>${rho}</strong>`
+          }
+          return params.name
+        }
+      },
+      series: [
+        {
+          type: 'graph',
+          layout: 'force',
+          roam: true,
+          label: {
+            show: true
+          },
+          force: {
+            repulsion: 150,
+            edgeLength: 80
+          },
+          data: nodes,
+          edges: edges
+        }
+      ]
+    }
+  }, [biomarkerId, correlations])
+
+  if (!correlations || correlations.length === 0) return null
+
+  return (
+    <div className="w-full h-64 border border-gray-700 rounded bg-dark-bg/50 mt-4 overflow-hidden relative">
+        <ReactECharts option={options} style={{ height: '100%', width: '100%' }} notMerge={true} theme="dark" />
+    </div>
+  )
+})
+
+export default BiomarkerCorrelationGraph

--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -41,6 +41,7 @@ const echartsOptions: any = {
         pArray.forEach((p) => {
           const dimName = p.dimensionNames[p.encode.y[0]]
           const val = p.value[dimName]
+          const unit = p.value[`${dimName}_unit`] || ''
 
           if (
             val !== '-' &&
@@ -50,7 +51,7 @@ const echartsOptions: any = {
             val !== undefined &&
             !Number.isNaN(val)
           ) {
-            tooltipStr += `<br/>${p.marker} ${p.seriesName}: <strong>${val}</strong>`
+            tooltipStr += `<br/>${p.marker} ${p.seriesName}: <strong>${val} ${unit}</strong>`
             hasValidValues = true
           }
         })
@@ -108,7 +109,7 @@ export default memo(({ keys }: ChartProps) => {
         // valueList is generated directly from keys, so their indices perfectly align.
         const k = valueList[i]
         if (k && k.fieldName === key) {
-          validSeries.push({ fieldKey: k.fieldKey, values: entry[1] })
+          validSeries.push({ fieldKey: k.fieldKey, values: entry[1], unit: entry[2] })
         }
       }
     }
@@ -122,6 +123,7 @@ export default memo(({ keys }: ChartProps) => {
         const series = validSeries[j]
         const v = series.values[i]
         item[series.fieldKey] = v !== null && v !== undefined ? v : '-'
+        item[`${series.fieldKey}_unit`] = series.unit || ''
       }
       result[i] = item
     }


### PR DESCRIPTION
This PR fulfills the chart engineer requirements:
1. **Implementation**: Fixes `src/layout/Chart.tsx` missing measurement units within the multi-line chart tooltips by injecting them into the mapped `chartData` array and rendering them inside the ECharts formatter callback.
2. **Advisory Proposals**: Replaces `proposals.md` with 3 fresh visualization ideas (Hierarchical System Health Sunburst, Longitudinal ThemeRiver, and Missing Data Gap Highlight via `markArea`). All three have been verified via tracing against installed ECharts exports/APIs (`echarts/charts` and `echarts/components`) to avoid hallucinating fake options, and are grounded entirely in existing derived data.
3. **Quality**: Ensured all `pnpm exec playwright test` cases pass without UI regressions and TypeScript strict compilation checks (`--noEmit`) succeed.

---
*PR created automatically by Jules for task [5482333976131190218](https://jules.google.com/task/5482333976131190218) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds units to multi-series chart tooltips and introduces a force-directed correlation graph with clearer, exponential scaling. Widens the correlation modal and expands proposals to guide next chart work.

- **New Features**
  - Multi-line chart tooltips now show units next to values by adding `fieldKey_unit` to `chartData` and reading it in `tooltip.formatter` in `src/layout/Chart.tsx`.
  - Added `BiomarkerCorrelationGraph.tsx`: a force-directed ECharts graph of top correlations, rendered above the table in `BiomarkerCorrelation.tsx`, with exponential node/edge scaling by |rho| and a taller container (`h-[500px]`) to reduce overlap.
  - Expanded `BiomarkerCorrelation` modal to `max-w-2xl` for readability.
  - Updated `proposals.md` with five ideas: Sunburst system health, ThemeRiver longitudinal trends, `markArea` missing-data gaps, Diverging Bar correlation view, and a SPLOM deep dive.

<sup>Written for commit a8c4e840d50614e9d1c76df9ee0b2e64b2ec20cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

