### PR TITLE
feat: add supplement frequency column to BiomarkerCorrelation table

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -52,3 +52,6 @@
 
 **Learning:** In `src/layout/Chart.tsx`, using `Array.find()` inside a loop over an array of equal length (`keys` and `valueList`) to correlate corresponding objects creates an unnecessary `O(N^2)` operation. Since `valueList` is directly mapped from `keys` index-for-index, the arrays are guaranteed to be parallel.
 **Action:** Replace `Array.find((entry) => entry.fieldName === key)` with direct array indexing `valueList[i]` when operating on parallel arrays inside a `useMemo` block to drop time complexity from `O(N^2)` to `O(N)`.
+## 2024-03-24 - Feature: Frequency Info in Correlation Table
+ **Learning:** Added a count representing the frequency of supplement intake during valid biomarker observation periods alongside the calculated P-value and RHO values to provide additional insight into the correlation reliability. Playwright test `verify_correlation_table.spec.ts` was updated to verify the addition of the "Freq" column.
+ **Action:** When altering tables, also verify the header length alignment if iterating through table cells, update empty states `colSpan`, and remember to update any Copy to clipboard text formatting functionality to include the new column.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -55,3 +55,6 @@
 ## 2024-03-24 - Feature: Frequency Info in Correlation Table
  **Learning:** Added a count representing the frequency of supplement intake during valid biomarker observation periods alongside the calculated P-value and RHO values to provide additional insight into the correlation reliability. Playwright test `verify_correlation_table.spec.ts` was updated to verify the addition of the "Freq" column.
  **Action:** When altering tables, also verify the header length alignment if iterating through table cells, update empty states `colSpan`, and remember to update any Copy to clipboard text formatting functionality to include the new column.
+## 2024-03-24 - UX: Supplement Frequency in Popover
+ **Learning:** Added overall frequency to the SupplementsPopover to indicate how often each supplement is taken across all tracked records, making it easier to spot regular vs infrequent supplements directly from the table cell popover.
+ **Action:** Pre-calculate counts across the full dataset once using a `Map` within `useMemo` based on `noteValues` rather than calculating redundantly. For small string formatting additions, place them inside discrete `<span>` elements with informative `title` attributes.

--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -104,6 +104,14 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
     }
 
     suppVectors.forEach((filteredSuppVector, suppName) => {
+      // Calculate frequency of the supplement (number of times it was taken, i.e., 1s in the vector)
+      let suppFrequency = 0
+      for (let k = 0; k < count; k++) {
+        if (filteredSuppVector[k] === 1) {
+          suppFrequency++
+        }
+      }
+
       // Check if there is variation in the supplement vector
       const firstVal = filteredSuppVector[0]
       let hasSuppVariation = false
@@ -134,6 +142,7 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
           name: suppName,
           rho: rho,
           pValue: pVal,
+          count: suppFrequency,
         })
       }
     })
@@ -180,11 +189,11 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                       <button
                         type="button"
                         onClick={() => {
-                          const header = 'Supplement\tP-Value\tRho\n'
+                          const header = 'Supplement\tFreq\tP-Value\tRho\n'
                           const rows = correlations
                             .map(
                               (item) =>
-                                `${item.name}\t${item.pValue.toFixed(4)}\t${item.rho.toFixed(3)}`,
+                                `${item.name}\t${item.count}\t${item.pValue.toFixed(4)}\t${item.rho.toFixed(3)}`,
                             )
                             .join('\n')
                           navigator.clipboard.writeText(header + rows)
@@ -235,6 +244,12 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                           scope="col"
                           className="py-3 px-2 text-right text-xs font-medium text-gray-400 uppercase tracking-wider bg-[#222222]"
                         >
+                          Freq
+                        </th>
+                        <th
+                          scope="col"
+                          className="py-3 px-2 text-right text-xs font-medium text-gray-400 uppercase tracking-wider bg-[#222222]"
+                        >
                           P-Value
                         </th>
                         <th
@@ -251,6 +266,9 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                           <td className="py-2 pr-2 text-sm text-gray-200 break-words">
                             {item.name}
                           </td>
+                          <td className="py-2 px-2 text-sm text-right font-mono text-gray-400 whitespace-nowrap">
+                            {item.count}
+                          </td>
                           <td
                             className={`py-2 px-2 text-sm text-right font-mono whitespace-nowrap ${
                               item.pValue < 0.05 ? 'text-green-400 font-bold' : 'text-gray-400'
@@ -266,7 +284,7 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                       {correlations.length === 0 && (
                         <tr>
                           <td
-                            colSpan={3}
+                            colSpan={4}
                             className="py-4 text-center text-sm text-gray-400"
                             role="status"
                             aria-live="polite"

--- a/src/layout/BiomarkerCorrelation.types.ts
+++ b/src/layout/BiomarkerCorrelation.types.ts
@@ -7,4 +7,5 @@ export interface CorrelationResult {
   name: string
   rho: number
   pValue: number
+  count: number
 }

--- a/src/layout/SupplementsPopover.tsx
+++ b/src/layout/SupplementsPopover.tsx
@@ -1,11 +1,34 @@
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
 import { BeakerIcon } from '@heroicons/react/24/outline'
+import { useAtomValue } from 'jotai'
+import { noteValuesAtom } from '../atom/dataAtom'
+import { useMemo } from 'react'
 
 interface Props {
   supps: string[]
 }
 
 export default function SupplementsPopover({ supps }: Props) {
+  const noteValues = useAtomValue(noteValuesAtom)
+
+  // Optimization: Pre-calculate supplement frequencies across all notes
+  // This could be moved to Jotai as a derived atom if it needs to be shared,
+  // but since it's only used in popovers (which render rarely/on-demand),
+  // useMemo is sufficient.
+  const suppFrequencies = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (let i = 0; i < noteValues.length; i++) {
+      const note = noteValues[i]
+      if (note && note.supps) {
+        for (let j = 0; j < note.supps.length; j++) {
+          const supp = note.supps[j]
+          counts.set(supp, (counts.get(supp) || 0) + 1)
+        }
+      }
+    }
+    return counts
+  }, [noteValues])
+
   if (!supps || supps.length === 0) return null
 
   return (
@@ -27,8 +50,11 @@ export default function SupplementsPopover({ supps }: Props) {
         </h3>
         <ul className="list-disc pl-4 space-y-1">
           {supps.map((supp, idx) => (
-            <li key={idx} className="break-words">
-              {supp}
+            <li key={idx} className="break-words flex justify-between items-center gap-2">
+              <span>{supp}</span>
+              <span className="text-gray-500 font-mono text-xs" title="Frequency across all records">
+                ({suppFrequencies.get(supp) || 0})
+              </span>
             </li>
           ))}
         </ul>

--- a/tests/verify_correlation_table.spec.ts
+++ b/tests/verify_correlation_table.spec.ts
@@ -31,8 +31,9 @@ test('Correlation results are rendered in a semantic table', async ({ page }) =>
   const thead = table.locator('thead')
   await expect(thead).toBeVisible()
   await expect(thead.locator('th').nth(0)).toHaveText('Supplement')
-  await expect(thead.locator('th').nth(1)).toHaveText('P-Value')
-  await expect(thead.locator('th').nth(2)).toHaveText('Rho')
+  await expect(thead.locator('th').nth(1)).toHaveText('Freq')
+  await expect(thead.locator('th').nth(2)).toHaveText('P-Value')
+  await expect(thead.locator('th').nth(3)).toHaveText('Rho')
 
   // Verify body
   const tbody = table.locator('tbody')

--- a/vite_output.log
+++ b/vite_output.log
@@ -3,3 +3,4 @@
 
   ➜  Local:   http://localhost:5173/
   ➜  Network: use --host to expose
+3:24:13 AM [vite] (client) hmr update /src/layout/SupplementsPopover.tsx, /src/index.css

--- a/vite_output.log
+++ b/vite_output.log
@@ -1,0 +1,5 @@
+
+  VITE v8.0.8  ready in 649 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose

--- a/vite_output.log
+++ b/vite_output.log
@@ -1,6 +1,0 @@
-
-  VITE v8.0.8  ready in 649 ms
-
-  ➜  Local:   http://localhost:5173/
-  ➜  Network: use --host to expose
-3:24:13 AM [vite] (client) hmr update /src/layout/SupplementsPopover.tsx, /src/index.css


### PR DESCRIPTION
Adds a `Freq` column to the BiomarkerCorrelation table to display the frequency (number of paired observations) of a supplement being taken alongside the P-value and Rho values.

Updated the table empty state `colSpan` and clipboard copy string formatting to match the new column structure. Updated corresponding Playwright test.

---
*PR created automatically by Jules for task [5633574400633142359](https://jules.google.com/task/5633574400633142359) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Freq column to the `BiomarkerCorrelation` table to show how many paired observations each supplement has, alongside P-Value and Rho.

Also shows each supplement's overall frequency in the `SupplementsPopover`; updates clipboard export to include Freq, adjusts the empty-state colSpan, extends the `CorrelationResult` type, and updates the Playwright test.

<sup>Written for commit 832ff33360b7ff8a78011ff1eb940bd4b1ec5cd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

