### PR TITLE
fix: remove unused index parameter from BiomarkerCorrelationGraph

### DIFF
--- a/src/layout/BiomarkerCorrelationGraph.tsx
+++ b/src/layout/BiomarkerCorrelationGraph.tsx
@@ -29,7 +29,7 @@ const BiomarkerCorrelationGraph = React.memo(({ biomarkerId, correlations }: Gra
     // Sort and take top 15 to avoid clutter
     const topCorr = [...correlations].sort((a, b) => Math.abs(b.rho) - Math.abs(a.rho)).slice(0, 15)
 
-    topCorr.forEach((corr, index) => {
+    topCorr.forEach((corr) => {
       const isPositive = corr.rho > 0
       const absRho = Math.abs(corr.rho)
       // Exaggerate node size scaling based on absRho (0 to 1) to make differences clearer


### PR DESCRIPTION
**The Issue:**
`src/layout/BiomarkerCorrelationGraph.tsx` line 32 — a structural problem identified where an `index` parameter was declared in a `forEach` loop callback but never used.

**The Discovery Signal:**
Scan G: `npx oxlint src/` reported an `eslint(no-unused-vars)` violation: "Parameter 'index' is declared but never used. Unused parameters should start with a '_'".

**The Fix:**
Removed the unused `index` parameter from the `topCorr.forEach` callback in `src/layout/BiomarkerCorrelationGraph.tsx`.

**The Benefit:**
Eliminates a lingering oxlint warning in the correctness/style category, improving overall codebase health, cleaning up the linter output, and preventing confusion for future agents working in this file.

---
*PR created automatically by Jules for task [4203483177359516133](https://jules.google.com/task/4203483177359516133) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused index parameter from the topCorr.forEach callback in `src/layout/BiomarkerCorrelationGraph.tsx`. This clears the `eslint(no-unused-vars)` warning and keeps linter output clean.

<sup>Written for commit 449f4efca0c82bb0a920a2fb5123d25177cee326. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

