### PR TITLE
🎨 Palette: Add keyboard focus ring to clustering modal close button

### DIFF
--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -289,7 +289,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                   <span>Biological System Clustering</span>
                   <button
                     onClick={onClose}
-                    className="text-gray-400 hover:text-white transition-colors"
+                    className="text-gray-400 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                     aria-label="Close dialog"
                     title="Close dialog"
                   >


### PR DESCRIPTION
💡 **What**: Added standard Tailwind focus ring classes (`focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded`) to the close dialog `<button>` in `SystemClustering.tsx`.

🎯 **Why**: Previously, the close button in the System Clustering modal had hover states but no visible focus indicator when navigating via keyboard. This makes it difficult for keyboard-only or screen-reader users to know when they have focused the element to dismiss the dialog. 

📸 **Before/After**: Visually identical on hover/idle, but now displays a clear blue focus ring when navigating via `Tab`.

♿ **Accessibility**: Improves WCAG compliance (Focus Visible) and provides consistent keyboard navigation feedback matching the rest of the application's dialogs.

---
*PR created automatically by Jules for task [13704896510135005864](https://jules.google.com/task/13704896510135005864) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a visible keyboard focus ring to the System Clustering modal close button to improve keyboard navigation and accessibility. Applies Tailwind focus-visible ring classes so the button shows a clear blue ring when focused via Tab.

<sup>Written for commit 2b9abd34ac64e1b7e1c0ccf9469c6b5aeddb4b9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

