### PR TITLE
🎨 Palette: Improve Markdown Readability in Dialogs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -74,5 +74,6 @@
 **Action:** Reused the Markdown renderer component for displaying textual Gist data and formatted the timestamps accurately for improved user experience.
 
 ## 2025-07-28 - Optimize initial page load via React.lazy code-splitting
+
 **Learning:** The application imported heavy visual components (like DarkVeil and modals) synchronously in `App.tsx`, which increased the initial JavaScript bundle size. Attempting to replace idiomatic array methods with `for` loops in components without clear performance metrics is often an unmeasurable micro-optimization.
 **Action:** Focus on macro-optimizations like asset loading first. To speed up initial page render, use `React.lazy()` and `<React.Suspense fallback={null}>` to code-split secondary UI layers and modals out of the main bundle.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,6 @@
 
 **Learning:** Relying solely on `aria-label` for inputs can sometimes be less robust than explicit, visually hidden `<label>` elements linked via `htmlFor` and `id`, especially across older assistive technologies. Explicit labels are considered the most robust HTML pattern.
 **Action:** Prefer `htmlFor`/`id` linking with a `sr-only` class for accessible labels over `aria-label` when adding or auditing inputs, and ensure redundant `aria-label`s are removed when explicitly labeled.
+## 2026-04-14 - Improve Markdown Readability in Dialogs
+**Learning:** Default text styles in narrow dialogs make markdown difficult to read.
+**Action:** Use `@tailwindcss/typography` plugin with `prose prose-invert` classes to automatically style markdown, and increase Dialog container widths (`max-w-3xl`) to improve overall readability.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.2.2)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.8(@types/node@24.9.1)(jiti@2.6.1)(terser@5.44.0))
@@ -3078,6 +3081,11 @@ packages:
     resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
     engines: {node: '>= 20'}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tailwindcss/vite@4.2.2':
     resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
     peerDependencies:
@@ -3471,6 +3479,11 @@ packages:
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -4479,6 +4492,10 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
@@ -4941,6 +4958,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -8727,6 +8747,11 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.2.2)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.2.2
+
   '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@24.9.1)(jiti@2.6.1)(terser@5.44.0))':
     dependencies:
       '@tailwindcss/node': 4.2.2
@@ -9129,6 +9154,8 @@ snapshots:
       nth-check: 2.1.1
 
   css-what@6.2.2: {}
+
+  cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -10318,6 +10345,11 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss-value-parser@4.2.0: {}
 
   postcss@8.5.9:
@@ -10932,6 +10964,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  util-deprecate@1.0.2: {}
 
   vfile-message@4.0.3:
     dependencies:

--- a/src/index.css
+++ b/src/index.css
@@ -62,3 +62,4 @@ input[type='search']::-webkit-search-results-button,
 input[type='search']::-webkit-search-results-decoration {
   display: none;
 }
+@plugin '@tailwindcss/typography';

--- a/src/layout/GistViewer.tsx
+++ b/src/layout/GistViewer.tsx
@@ -107,7 +107,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
               leaveFrom="translate-x-0"
               leaveTo="translate-x-full"
             >
-              <Dialog.Panel className="flex flex-col w-full max-w-md transform overflow-hidden bg-[#222222] text-dark-text p-6 text-left align-middle shadow-xl transition-all h-screen ml-auto border-l border-gray-700">
+              <Dialog.Panel className="flex flex-col w-full max-w-3xl transform overflow-hidden bg-[#222222] text-dark-text p-6 text-left align-middle shadow-xl transition-all h-screen ml-auto border-l border-gray-700">
                 <Dialog.Title
                   as="div"
                   className="flex justify-between items-center text-lg font-medium leading-6 mb-4 pb-2 border-b border-gray-700"
@@ -151,7 +151,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                       </button>
                     </div>
                   ) : selectedFile ? (
-                    <div className="text-sm whitespace-pre-wrap">
+                    <div className="prose prose-invert max-w-none">
                       <Markdown>{selectedFile.content}</Markdown>
                     </div>
                   ) : files.length > 0 ? (

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -8,7 +8,6 @@ import {
   TrashIcon,
   ClipboardDocumentIcon,
   CheckIcon,
-
 } from '@heroicons/react/24/outline'
 import { tags } from '../processors'
 import { askBioMarkers } from '../service/askAI'
@@ -508,7 +507,7 @@ export default React.memo<NavProps>(
                   leaveFrom="translate-x-0"
                   leaveTo="translate-x-full"
                 >
-                  <Dialog.Panel className="flex flex-col w-full max-w-md transform overflow-hidden bg-[#222222] text-dark-text p-6 text-left align-middle shadow-xl transition-all h-screen ml-auto border-l border-gray-700">
+                  <Dialog.Panel className="flex flex-col w-full max-w-3xl transform overflow-hidden bg-[#222222] text-dark-text p-6 text-left align-middle shadow-xl transition-all h-screen ml-auto border-l border-gray-700">
                     <Dialog.Title
                       as="div"
                       className="flex justify-between items-center text-lg font-medium leading-6 mb-4"
@@ -523,7 +522,7 @@ export default React.memo<NavProps>(
                         <XMarkIcon className="h-6 w-6" />
                       </button>
                     </Dialog.Title>
-                    <div className="mt-2 text-sm whitespace-pre-wrap overflow-y-auto">
+                    <div className="mt-2 prose prose-invert max-w-none overflow-y-auto">
                       <Markdown>{canvasText}</Markdown>
                     </div>
 


### PR DESCRIPTION
💡 What:
- Increased width of 'AI History' and 'Biomarker' dialogs from max-w-md to max-w-3xl.
- Integrated @tailwindcss/typography plugin.
- Applied 'prose prose-invert' styles to markdown wrappers.

🎯 Why:
The default font sizes and narrow dialog width made dense Markdown data (especially AI-generated insights) difficult to read. The prose styling scales text cleanly, while the wider dialog gives the content room to breathe.

---
*PR created automatically by Jules for task [4369216828201721553](https://jules.google.com/task/4369216828201721553) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Markdown readability in the AI History and Biomarker dialogs by widening the panels and applying Tailwind Typography prose styles.

- **New Features**
  - Increased dialog width to `max-w-3xl` in `GistViewer` and `Nav`.
  - Render Markdown with `prose prose-invert max-w-none` for better typography.

- **Dependencies**
  - Added `@tailwindcss/typography` and registered the plugin in `src/index.css`.

<sup>Written for commit 1137e86090d648268231f5accd0d913a7525bafc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

