### PR TITLE
fix: resolve oxlint no-new-array violations in inferData

### DIFF
--- a/src/processors/enrich/inferData.ts
+++ b/src/processors/enrich/inferData.ts
@@ -61,7 +61,7 @@ export default (entries: BioMarker[]): BioMarker[] => {
 
     // Optimization: Avoid chaining Array.from({ length }).map() and inner array.map().some()
     // inside hot loops to reduce multiple array allocations and closure overheads per period.
-    const values = new Array(periods)
+    const values = Array.from({ length: periods }) as (string | null)[]
     if (hasMissingField) {
       for (let i = 0; i < periods; i++) {
         values[i] = null
@@ -69,7 +69,7 @@ export default (entries: BioMarker[]): BioMarker[] => {
     } else {
       for (let i = 0; i < periods; i++) {
         let missing = false
-        const fieldValues = new Array(numFields)
+        const fieldValues = Array.from({ length: numFields }) as number[]
         for (let j = 0; j < numFields; j++) {
           const v = fieldArrays[j]![i]
           if (!v) {


### PR DESCRIPTION
**The Issue:**
`src/processors/enrich/inferData.ts` around line 64 and 72 contained `new Array(singleArgument)` which triggers the `unicorn/no-new-array` rule in oxlint.

**The Discovery Signal:**
Scan G (oxlint violations) flagged 6 instances of this rule violation across the repository. This is an unsafe runtime pattern because `new Array(singleArgument)` is confusing when a single integer creates an array of that length with empty slots.

**The Fix:**
Replaced `new Array(periods)` and `new Array(numFields)` in `src/processors/enrich/inferData.ts` with `Array.from({ length: periods }) as (string | null)[]` and `Array.from({ length: numFields }) as number[]` respectively, explicitly inferring the correct types from the surrounding code.

**The Benefit:**
Resolves the active oxlint error while maintaining memory optimization through proper length pre-allocation and preserving TypeScript type safety without inventing new interfaces.

---
*PR created automatically by Jules for task [12188033213901916388](https://jules.google.com/task/12188033213901916388) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `oxlint` `unicorn/no-new-array` violations in `inferData.ts` by replacing `new Array(periods)` and `new Array(numFields)` with `Array.from({ length })`. This removes empty-slot array pitfalls while keeping pre-allocation and correct types for `(string | null)[]` and `number[]`.

<sup>Written for commit 2c82ecfdb8e159335711b9853af2785a22688eca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

