### PR TITLE
⚡ Bolt: Extract RadarChart data filtering into useMemo to prevent re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -82,3 +82,8 @@
 
 **Learning:** Combining a raw `<ReactECharts>` component with a third-party wrapper (like `@echarts-readymade/scatter` or `@echarts-readymade/line`) inside the same `<ChartProvider>` container can inadvertently instantiate two conflicting, overlapping ECharts canvas instances for the same dataset. This introduces hidden performance overhead and visual collision bugs.
 **Action:** When a raw `ReactECharts` configuration object inherently contains all necessary series and datasets (e.g., standard scatter plotting plus `ecStat:regression` transforms), completely remove any supplementary third-party wrapper components, their layout context providers, and associated DOM refs or manual `setOption` overrides to ensure a single, clean render cycle.
+
+## 2026-05-18 - Stable array references for memoized child components
+
+**Learning:** Inline array allocations like `data.filter(...)` inside the render function of a parent component (e.g. `App.tsx`) create a new array reference on every re-render. If this component re-renders frequently—such as responding to an active `searchText` state from user keystrokes—these inline allocations invalidate the `React.memo` prop checks for heavy child components (like `RadarChart`), causing them to re-render synchronously and block the main thread, resulting in severe typing lag.
+**Action:** Always pre-filter data intended for heavy memoized components inside a dedicated `React.useMemo` block, using a single-pass `for` loop to avoid closure overhead. This ensures the array reference remains stable during unrelated state updates, preserving the performance of `React.memo` and preventing input blocking.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -225,6 +225,22 @@ export default function App() {
     ],
   )
 
+  // Optimization: Pre-filter radar chart data in a memoized hook with a single-pass loop.
+  // Previously, inline `data.filter()` created a new array reference on every keystroke
+  // when `searchText` changed, invalidating the memoized RadarChart and causing severe
+  // lag during typing.
+  const radarChartData = React.useMemo(() => {
+    if (!filterTag || !data) return []
+    const result: typeof data = []
+    for (let i = 0; i < data.length; i++) {
+      const entry = data[i]
+      if (entry[3]?.tag?.includes(filterTag)) {
+        result.push(entry)
+      }
+    }
+    return result
+  }, [data, filterTag])
+
   // Optimization: tableProps does NOT include searchText. It only includes state relevant to the table.
   // This prevents the heavy Table component from re-rendering on every keystroke in the search input,
   // since Table relies on the debounced filterTextAtom, not the immediate searchText.
@@ -275,10 +291,7 @@ export default function App() {
           }
         >
           {filterTag && (!chartKeys || chartKeys.length === 0) && (
-            <RadarChart
-              data={data.filter(([_, __, ___, extra]) => extra?.tag?.includes(filterTag))}
-              tag={filterTag}
-            />
+            <RadarChart data={radarChartData} tag={filterTag} />
           )}
           {chartKeys && chartKeys.length > 0 && chartType === 'scatter' && (
             <ScatterChart keys={chartKeys} />


### PR DESCRIPTION
💡 **What:** Extracted the inline `data.filter(...)` call passed to `RadarChart` into a `React.useMemo` block that utilizes a traditional, single-pass `for` loop.
🎯 **Why:** Because `App.tsx` re-renders constantly when typing in the search bar (as `searchText` updates state rapidly), the inline `data.filter` created a new array reference on every render. This invalidated the shallow equality check on `RadarChart`'s `React.memo` prop, forcing the heavy ECharts `<canvas>` component to synchronously re-render on the main thread, leading to significant typing lag when a tag filter was active.
📊 **Impact:** Provides a stable array reference to `RadarChart`, completely eliminating ECharts re-renders while typing in the search bar. Drastically improves input latency. Also eliminates the minor garbage collection overhead of the `.filter()` closure by using a classic `for` loop.
🔬 **Measurement:** Click a tag in the navigation bar to filter and display the Radar Chart. Then, type rapidly in the search bar. Previously, typing would stutter and drop frames. With this fix, typing is smooth and instantaneous, as the `RadarChart` does not re-render.

---
*PR created automatically by Jules for task [16566423200316598625](https://jules.google.com/task/16566423200316598625) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized RadarChart data filtering to keep a stable array reference and stop unnecessary re-renders while typing. This removes input lag by preventing the ECharts canvas from repainting on each keystroke.

- **Performance**
  - Moved inline `data.filter(...)` in `App.tsx` into `React.useMemo` with a single-pass loop.
  - `RadarChart` now gets a stable `data` prop, so `React.memo` holds and the chart does not re-render as `searchText` changes.

<sup>Written for commit 6e34554781b760bc034f4eaa4898e01cd8d284f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

