### PR TITLE
⚡ Bolt: [performance improvement] Hoist loop-invariant array allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -87,3 +87,8 @@
 
 **Learning:** Inline array allocations like `data.filter(...)` inside the render function of a parent component (e.g. `App.tsx`) create a new array reference on every re-render. If this component re-renders frequently—such as responding to an active `searchText` state from user keystrokes—these inline allocations invalidate the `React.memo` prop checks for heavy child components (like `RadarChart`), causing them to re-render synchronously and block the main thread, resulting in severe typing lag.
 **Action:** Always pre-filter data intended for heavy memoized components inside a dedicated `React.useMemo` block, using a single-pass `for` loop to avoid closure overhead. This ensures the array reference remains stable during unrelated state updates, preserving the performance of `React.memo` and preventing input blocking.
+
+## 2024-04-17 - Hoist Loop-Invariant Array Allocations
+
+**Learning:** Allocating fallback arrays using `Array.from` inside a hot loop (e.g., iterating over data timepoints) causes significant unnecessary garbage collection and object allocation overhead, even when the underlying dependencies of the array don't change per iteration.
+**Action:** Always identify loop-invariant array allocations and hoist them outside the loop. This converts O(N) allocations into O(1) allocations.

--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -122,24 +122,21 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
       if (yAxisTag && tags.includes(yAxisTag)) m2Indices.push(m)
     }
 
+    // Fallback: If we don't have enough markers in tags, just use the first half vs second half
+    const useTags =
+      xAxisTag !== '' && yAxisTag !== '' && m1Indices.length > 0 && m2Indices.length > 0
+    // Bolt Optimization: Hoist fallback array calculations outside the inner loop to
+    // eliminate redundant object allocations and garbage collection per timepoint.
+    const g1 = useTags ? m1Indices : Array.from({ length: Math.floor(numMarkers / 2) }, (_, i) => i)
+    const g2 = useTags
+      ? m2Indices
+      : Array.from({ length: Math.ceil(numMarkers / 2) }, (_, i) => i + Math.floor(numMarkers / 2))
+
     for (let t = 0; t < numTimepoints; t++) {
       let m1Valid = 0
       let m1Optimal = 0
       let m2Valid = 0
       let m2Optimal = 0
-
-      // Fallback: If we don't have enough markers in tags, just use the first half vs second half
-      const useTags =
-        xAxisTag !== '' && yAxisTag !== '' && m1Indices.length > 0 && m2Indices.length > 0
-      const g1 = useTags
-        ? m1Indices
-        : Array.from({ length: Math.floor(numMarkers / 2) }, (_, i) => i)
-      const g2 = useTags
-        ? m2Indices
-        : Array.from(
-            { length: Math.ceil(numMarkers / 2) },
-            (_, i) => i + Math.floor(numMarkers / 2),
-          )
 
       for (const m of g1) {
         const val = data[m][1][t]


### PR DESCRIPTION
💡 What: Hoisted the fallback logic (e.g., `useTags`, `g1`, `g2` array allocations) outside of the `for (let t = 0; t < numTimepoints; t++)` loop in `src/layout/SystemClustering.tsx`.

🎯 Why: The variables and arrays were derived from `numMarkers`, `m1Indices`, and `m2Indices`, which are loop-invariant relative to the timepoints loop. Re-allocating them on every timepoint iteration caused unnecessary object creation and continuous garbage collection pressure.

📊 Impact: Converts O(N) array allocations (where N is the number of timepoints) into an O(1) allocation during the clustering data matrix preparation. This reduces memory pressure and execution time when generating the scatter plot matrix.

🔬 Measurement: Verified that tests pass (`pnpm exec playwright test`). There is no visual or functional change to the clustering feature; it purely prevents redundant work in the `useMemo` calculation block.

---
*PR created automatically by Jules for task [17662775844550800034](https://jules.google.com/task/17662775844550800034) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hoisted loop-invariant array allocations in `SystemClustering.tsx` to remove per-timepoint object creation and reduce GC. This speeds up clustering matrix preparation with no UI or behavior changes.

- **Refactors**
  - Moved `useTags`, `g1`, and `g2` fallback computations outside the `for (t)` loop.
  - Replaced O(N timepoints) array allocations with O(1), reducing GC and CPU during scatter plot matrix generation.

<sup>Written for commit e5db101f44415c6121dca3bf9c21e4dae4b2da8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

