### PR TITLE
🎨 Palette: Add type="button" to action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,6 +11,8 @@
 
 **Learning:** Relying solely on `aria-label` for inputs can sometimes be less robust than explicit, visually hidden `<label>` elements linked via `htmlFor` and `id`, especially across older assistive technologies. Explicit labels are considered the most robust HTML pattern.
 **Action:** Prefer `htmlFor`/`id` linking with a `sr-only` class for accessible labels over `aria-label` when adding or auditing inputs, and ensure redundant `aria-label`s are removed when explicitly labeled.
+
 ## 2026-04-14 - Improve Markdown Readability in Dialogs
+
 **Learning:** Default text styles in narrow dialogs make markdown difficult to read.
 **Action:** Use `@tailwindcss/typography` plugin with `prose prose-invert` classes to automatically style markdown, and increase Dialog container widths (`max-w-3xl`) to improve overall readability.

--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -221,6 +221,7 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                       </button>
                     )}
                     <button
+                      type="button"
                       onClick={onClose}
                       className="text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded shrink-0"
                       aria-label="Close dialog"

--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -147,7 +147,6 @@ const echartsOptions: any = {
 export default memo(({ keys }: ChartProps) => {
   const dataMap = useAtomValue(dataMapAtom)
 
-
   const formatTime = (label: string) => {
     if (!label || label.length < 6) return label
     return `20${label.slice(0, 2)}/${label.slice(2, 4)}/${label.slice(4, 6)}`
@@ -180,8 +179,6 @@ export default memo(({ keys }: ChartProps) => {
 
     return mappedData
   }, [dataMap, keys])
-
-
 
   const options: any = useMemo(() => {
     let { series, yAxis, xAxis } = echartsOptions
@@ -295,8 +292,6 @@ export default memo(({ keys }: ChartProps) => {
       ],
     }
   }, [mappedScatterData, keys])
-
-
 
   // console.log("ch2", options.series[0].data, options.series[1].data);
 

--- a/src/layout/GistViewer.tsx
+++ b/src/layout/GistViewer.tsx
@@ -115,6 +115,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                   <div className="flex items-center gap-2">
                     {selectedFile && (
                       <button
+                        type="button"
                         onClick={() => setSelectedFile(null)}
                         className="text-gray-400 hover:text-white mr-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                         aria-label="Back to list"
@@ -126,6 +127,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                     <span>{selectedFile ? 'Analysis Details' : 'AI History'}</span>
                   </div>
                   <button
+                    type="button"
                     onClick={onClose}
                     className="text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                     aria-label="Close dialog"
@@ -144,6 +146,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                     <div className="text-red-400 p-4 bg-red-900/20 rounded">
                       <p>Error: {error}</p>
                       <button
+                        type="button"
                         onClick={loadFiles}
                         className="mt-2 text-sm text-blue-400 hover:text-blue-300 underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                       >
@@ -160,6 +163,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                         const { keys, dateStr, isParsed } = formatFilename(file.filename)
                         return (
                           <button
+                            type="button"
                             key={file.filename}
                             onClick={() => setSelectedFile(file)}
                             className="text-left p-3 rounded bg-[#333333] hover:bg-[#444444] transition-colors border border-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -216,6 +216,7 @@ export default React.memo<NavProps>(
         >
           <div className="flex flex-wrap lg:flex-nowrap w-full items-center justify-between px-3 gap-3">
             <button
+              type="button"
               className="lg:hidden p-2 text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
               type="button"
               onClick={onToggle}
@@ -514,6 +515,7 @@ export default React.memo<NavProps>(
                     >
                       <span>Biomarker</span>
                       <button
+                        type="button"
                         onClick={handleClose}
                         className="text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                         aria-label="Close dialog"

--- a/src/layout/PValue.tsx
+++ b/src/layout/PValue.tsx
@@ -109,6 +109,7 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                 >
                   <span>{method === 'pearson' ? 'Pearson' : 'Spearman Rank'} Correlation</span>
                   <button
+                    type="button"
                     onClick={onClose}
                     className="text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                     aria-label="Close dialog"

--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -288,6 +288,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                 >
                   <span>Biological System Clustering</span>
                   <button
+                    type="button"
                     onClick={onClose}
                     className="text-gray-400 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                     aria-label="Close dialog"

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -493,8 +493,10 @@ export default React.memo(
 
       // Optimization: use standard comparison instead of localeCompare for ASCII keys
       return {
-        displayedEntries: result.sort((a, b) => (a.sortKey < b.sortKey ? -1 : a.sortKey > b.sortKey ? 1 : 0)),
-        hiddenCountPerGroup: hiddenCounts
+        displayedEntries: result.sort((a, b) =>
+          a.sortKey < b.sortKey ? -1 : a.sortKey > b.sortKey ? 1 : 0,
+        ),
+        hiddenCountPerGroup: hiddenCounts,
       }
     }, [convertedEntries, showRecords, showHiddenPerGroup])
 


### PR DESCRIPTION
💡 What: Added `type="button"` to all standalone `<button>` elements across the layout components.
🎯 Why: Buttons without an explicit type default to `type="submit"`. Adding an explicit type ensures these buttons will not accidentally trigger form submissions if they are later wrapped in `<form>` elements, making the application more robust and improving accessibility compliance.
📸 Before/After: Code structure change only. Functionality remains identical, but forms are safer.
♿ Accessibility: Ensures clearer semantics for screen readers and better general HTML robustness.

---
*PR created automatically by Jules for task [7624562848104244764](https://jules.google.com/task/7624562848104244764) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit type="button" to standalone buttons to prevent accidental form submissions and improve accessibility. No visual or behavioral changes; forms are safer.

- **Bug Fixes**
  - Set type="button" on action buttons in BiomarkerCorrelation, GistViewer, Nav, PValue, and SystemClustering.

<sup>Written for commit f5ed84fda91981e07e4ca78253b89c9783f17c00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

