### PR TITLE
🎨 Palette: [UX improvement] Dynamic button tooltips for empty selections

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -14,3 +14,6 @@
 ## 2026-04-14 - Improve Markdown Readability in Dialogs
 **Learning:** Default text styles in narrow dialogs make markdown difficult to read.
 **Action:** Use `@tailwindcss/typography` plugin with `prose prose-invert` classes to automatically style markdown, and increase Dialog container widths (`max-w-3xl`) to improve overall readability.
+## 2026-04-18 - Improve Dynamic Button Tooltips
+**Learning:** Action buttons dependent on UI state (e.g., table selections) must utilize explicit `disabled` attributes alongside dynamic `title` tooltips that inform the user why the action is disabled when conditions aren't met (e.g., 'Select at least one item to visualize').
+**Action:** Always pair conditionally disabled action buttons with contextual tooltips to clarify the system state to the user.

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -372,8 +372,14 @@ export default React.memo<NavProps>(
                     <button
                       type="button"
                       onClick={onAskAI}
-                      disabled={isAsking}
-                      title={isAsking ? 'Asking AI...' : 'Ask AI'}
+                      disabled={isAsking || selected.length === 0}
+                      title={
+                        isAsking
+                          ? 'Asking AI...'
+                          : selected.length === 0
+                            ? 'Select biomarkers to ask AI'
+                            : 'Ask AI'
+                      }
                       className="px-3 py-1 text-xs font-medium bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 transition-colors flex items-center justify-center gap-1 min-w-[70px]"
                       aria-busy={isAsking}
                       aria-live="polite"
@@ -396,8 +402,13 @@ export default React.memo<NavProps>(
                     <button
                       type="button"
                       onClick={onVisualize}
-                      title="Visualize selected biomarkers"
-                      className="px-3 py-1 text-xs font-medium bg-blue-600 text-white rounded hover:bg-blue-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 transition-colors"
+                      disabled={selected.length === 0}
+                      title={
+                        selected.length === 0
+                          ? 'Select biomarkers to visualize'
+                          : 'Visualize selected biomarkers'
+                      }
+                      className="px-3 py-1 text-xs font-medium bg-blue-600 text-white rounded hover:bg-blue-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       Visualize
                     </button>


### PR DESCRIPTION
💡 **What**: Added explicit `disabled` states and dynamic context-aware `title` tooltips to the "Ask AI" and "Visualize" buttons in `Nav.tsx` when no table biomarkers are selected.
🎯 **Why**: When the selection is empty, these buttons simply did nothing but remained active or provided generic titles. This improves the UX by visually disabling them and explaining what the user needs to do ('Select biomarkers to ask AI').
📸 **Before/After**: See recorded verification screenshots showing the initial disabled state vs the active state.
♿ **Accessibility**: Replaced static action labels with conditional labels reflecting the precise system state, and properly utilizing native `<button disabled>` attributes preventing keyboard activation while in an invalid state.

---
*PR created automatically by Jules for task [12305498337366950268](https://jules.google.com/task/12305498337366950268) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled the 'Ask AI' and 'Visualize' buttons in `Nav.tsx` when no biomarkers are selected and added contextual tooltips explaining why. This prevents no‑op clicks, uses native `disabled` for accessibility, and guides users with titles like "Select biomarkers to visualize."

<sup>Written for commit c0bc36fb8aadffea3a679396cf828e49e9342f32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

