### PR TITLE
Refactor: Extract SystemClusteringProps to sibling types file

### DIFF
--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -7,17 +7,13 @@ import * as ecStat from 'echarts-stat'
 import { useAtomValue } from 'jotai'
 import { noteValuesAtom, nonInferredDataAtom } from '../atom/dataAtom'
 import { Fragment } from 'react'
+import { SystemClusteringProps } from './SystemClustering.types'
 
 echarts.registerTransform(
   (ecStat as any).transform?.clustering ||
     (ecStat as any).default?.transform?.clustering ||
     (ecStat as any).clustering,
 )
-
-interface SystemClusteringProps {
-  isOpen: boolean
-  onClose: () => void
-}
 
 export const CHART_PALETTE = [
   '#c23531',

--- a/src/layout/SystemClustering.types.ts
+++ b/src/layout/SystemClustering.types.ts
@@ -1,0 +1,4 @@
+export interface SystemClusteringProps {
+  isOpen: boolean
+  onClose: () => void
+}


### PR DESCRIPTION
Extracted `SystemClusteringProps` to a dedicated `SystemClustering.types.ts` sibling file to comply with the project pattern where complex component props should have their own extracted type files.

---
*PR created automatically by Jules for task [10951370177812170261](https://jules.google.com/task/10951370177812170261) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved SystemClusteringProps to a new sibling file, src/layout/SystemClustering.types.ts, to match our prop-types pattern and enable reuse. No functional changes.

<sup>Written for commit 7f433c4707d805cec0e2fd9960bff3b05c1fafd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

