### PR TITLE
refactor: extract SupplementsPopoverProps into separate file

### DIFF
--- a/src/layout/SupplementsPopover.tsx
+++ b/src/layout/SupplementsPopover.tsx
@@ -3,12 +3,9 @@ import { BeakerIcon } from '@heroicons/react/24/outline'
 import { useAtomValue } from 'jotai'
 import { noteValuesAtom } from '../atom/dataAtom'
 import { useMemo } from 'react'
+import { SupplementsPopoverProps } from './SupplementsPopover.types'
 
-interface Props {
-  supps: string[]
-}
-
-export default function SupplementsPopover({ supps }: Props) {
+export default function SupplementsPopover({ supps }: SupplementsPopoverProps) {
   const noteValues = useAtomValue(noteValuesAtom)
 
   // Optimization: Pre-calculate supplement frequencies across all notes

--- a/src/layout/SupplementsPopover.types.ts
+++ b/src/layout/SupplementsPopover.types.ts
@@ -1,0 +1,3 @@
+export interface SupplementsPopoverProps {
+  supps: string[]
+}


### PR DESCRIPTION
**The Issue:**
`src/layout/SupplementsPopover.tsx` lines 7-9. It is a structural problem because it contains a complex inline prop interface (`interface Props`), which violates the codebase pattern "Each component with complex props has a sibling `.types.ts` file".

**The Discovery Signal:**
Scan D: Misplaced Shared Types. Several `.tsx` files in `src/layout/` contained inline interfaces (`HistogramChartProps`, `RadarChartProps`, `Props`, etc.), and I chose to extract `interface Props` from `src/layout/SupplementsPopover.tsx`.

**The Fix:**
I extracted `interface Props` into a new file `src/layout/SupplementsPopover.types.ts`, renamed it to `export interface SupplementsPopoverProps`, and updated `src/layout/SupplementsPopover.tsx` to import and use the extracted type.

**The Benefit:**
Aligns the component with the established repository architecture, reducing confusion for future developers and agents by maintaining a consistent placement for type definitions.

---
*PR created automatically by Jules for task [12951650701001934958](https://jules.google.com/task/12951650701001934958) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the inline `Props` interface from `src/layout/SupplementsPopover.tsx` into `src/layout/SupplementsPopover.types.ts` as `SupplementsPopoverProps`, and updated the component to import it. This aligns with our pattern of keeping prop types in sibling `.types.ts` files and reduces noise in the component.

<sup>Written for commit 97439410aeb1dbfc38fb46fdff605f29cf8f6a7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

