### PR TITLE
🎨 Palette: [UX improvement] Improve dark theme contrast

### DIFF
--- a/src/layout/GistViewer.tsx
+++ b/src/layout/GistViewer.tsx
@@ -191,12 +191,12 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                       aria-live="polite"
                     >
                       <div className="bg-gray-800/50 rounded-full p-4 mb-4">
-                        <ClipboardDocumentIcon className="h-8 w-8 text-gray-500" />
+                        <ClipboardDocumentIcon className="h-8 w-8 text-gray-400" />
                       </div>
                       <h3 className="text-lg font-medium text-gray-300 mb-2">
                         No AI history found
                       </h3>
-                      <p className="text-sm text-gray-500 max-w-sm mb-6">
+                      <p className="text-sm text-gray-400 max-w-sm mb-6">
                         You haven't saved any AI analyses to this Gist yet. Select biomarkers, ask
                         AI, and save the results to see them here.
                       </p>

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -256,7 +256,7 @@ export default React.memo<NavProps>(
                 />
                 {!filterText && !isFocused && (
                   <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                    <kbd className="hidden sm:inline-block border border-gray-600 rounded px-1.5 py-0.5 text-xs text-gray-500 font-sans">
+                    <kbd className="hidden sm:inline-block border border-gray-600 rounded px-1.5 py-0.5 text-xs text-gray-400 font-sans">
                       /
                     </kbd>
                   </div>

--- a/src/layout/PValue.tsx
+++ b/src/layout/PValue.tsx
@@ -126,7 +126,7 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                   {comparedSourceTarget && (
                     <div className="mb-4 font-bold text-base flex items-center justify-center bg-dark-bg p-3 rounded border border-gray-700">
                       <span className="text-blue-400">{comparedSourceTarget[0][0]}</span>
-                      <span className="mx-3 text-gray-500 font-normal text-xs uppercase tracking-widest">
+                      <span className="mx-3 text-gray-400 font-normal text-xs uppercase tracking-widest">
                         vs
                       </span>
                       <span className="text-blue-400">{comparedSourceTarget[1][0]}</span>

--- a/src/layout/SupplementsPopover.tsx
+++ b/src/layout/SupplementsPopover.tsx
@@ -50,7 +50,7 @@ export default function SupplementsPopover({ supps }: SupplementsPopoverProps) {
             <li key={idx} className="break-words flex justify-between items-center gap-2">
               <span>{supp}</span>
               <span
-                className="text-gray-500 font-mono text-xs"
+                className="text-gray-400 font-mono text-xs"
                 title="Frequency across all records"
               >
                 ({suppFrequencies.get(supp) || 0})


### PR DESCRIPTION
💡 **What:** Improved the contrast of informational text and icons across multiple components. Specifically changed Tailwind classes from `text-gray-500` to `text-gray-400` in `GistViewer`, `SupplementsPopover`, `PValue`, and `Nav`.

🎯 **Why:** `text-gray-500` fails WCAG AA contrast ratio standards when placed against the very dark backgrounds (`#222222` and similar) heavily used in modals and tables across this application. Lightening this text to `text-gray-400` ensures it is readable while maintaining the visual hierarchy of secondary information.

♿ **Accessibility:**
- Resolved contrast ratio failures for informational text and icons in dark-themed UI components.

---
*PR created automatically by Jules for task [12000337168843502359](https://jules.google.com/task/12000337168843502359) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved dark theme contrast for informational text and icons to meet WCAG AA on dark backgrounds. Changed Tailwind classes from text-gray-500 to text-gray-400 in GistViewer, SupplementsPopover, PValue, and Nav.

<sup>Written for commit ec73a12fb6e8b1fdcb0e988016d3a6e3ee081156. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

