### PR TITLE
⚡ Bolt: [performance improvement] Lazy-load GistViewer modal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -23,6 +23,7 @@
 **Action:** Always pair conditionally disabled action buttons with contextual tooltips to clarify the system state to the user.
 
 ## 2026-04-20 - [Add Empty State with Actionable CTA]
+
 **Learning:** Replaced plain text empty states with structured UI (Icon + Heading + Explanation + CTA Button) significantly improves the perceived quality of the application and guides users effectively when there is no data.
 **Action:** When encountering `files.length === 0` or similar conditions, always prefer a structured empty state over plain text, ensuring it includes a helpful call-to-action to resolve the empty state.
 **Learning:** When implementing tab-like views using custom buttons (e.g., swapping between Chart and Table views), screen reader users are unaware of the active selection if the visual active state (e.g., highlighted background color) isn't paired with an accessibility attribute.

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -26,8 +26,12 @@ import { calculateSpearmanRanked } from '../processors/stats'
 import { averageCountAtom } from '../atom/averageValueAtom'
 import Markdown from 'react-markdown'
 import { Spinner } from './Spinner'
-import GistViewer from './GistViewer'
 import { NavProps } from './Nav.types'
+
+// Optimization: Lazy load the GistViewer modal to reduce the initial JavaScript bundle size.
+// This modal is only needed when a user explicitly clicks "View History", so code-splitting it
+// significantly improves the initial page load speed without sacrificing readability.
+const GistViewer = React.lazy(() => import('./GistViewer'))
 
 export default React.memo<NavProps>(
   ({
@@ -191,6 +195,13 @@ export default React.memo<NavProps>(
     const [gistError, setGistError] = React.useState<string | null>(null)
     const [isGistLoading, setIsGistLoading] = React.useState(false)
     const [isGistViewerOpen, setIsGistViewerOpen] = React.useState(false)
+    const [hasGistViewerMounted, setHasGistViewerMounted] = React.useState(false)
+
+    React.useEffect(() => {
+      if (isGistViewerOpen && !hasGistViewerMounted) {
+        setHasGistViewerMounted(true)
+      }
+    }, [isGistViewerOpen, hasGistViewerMounted])
 
     const handleClose = React.useCallback(() => {
       setCanvasText(null)
@@ -492,7 +503,11 @@ export default React.memo<NavProps>(
           </div>
         </nav>
 
-        <GistViewer isOpen={isGistViewerOpen} onClose={() => setIsGistViewerOpen(false)} />
+        <React.Suspense fallback={null}>
+          {hasGistViewerMounted && (
+            <GistViewer isOpen={isGistViewerOpen} onClose={() => setIsGistViewerOpen(false)} />
+          )}
+        </React.Suspense>
 
         <Transition appear show={!!canvasText} as={Fragment}>
           <Dialog as="div" className="relative z-50" onClose={handleClose}>


### PR DESCRIPTION
💡 What: Code-splits the `GistViewer` modal in `src/layout/Nav.tsx` using `React.lazy` and `Suspense`, preventing it from eagerly downloading until it's first requested. We use a `hasGistViewerMounted` tracker to keep it in the DOM after the first load, preserving exit animations.
🎯 Why: The modal is hidden by default and only shown if a user selects "View History", so we save parsing time and bundle weight on initial page load without affecting visual fluidity.
📊 Impact: Reduces initial JavaScript bundle size significantly.
🔬 Measurement: Verify using `pnpm build` and observing the chunk sizes.

---
*PR created automatically by Jules for task [11932428552992374846](https://jules.google.com/task/11932428552992374846) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-loads the `GistViewer` modal so it downloads only when users click View History, reducing the initial JS bundle and improving initial load time.

- **Refactors**
  - Code-splits `GistViewer` with `React.lazy` + `Suspense` and uses `fallback={null}` to avoid blocking UI.
  - Keeps it mounted after first open via `hasGistViewerMounted` to preserve exit animations; verify reduction via `pnpm build` and chunk sizes.

<sup>Written for commit 2695d52d46c9ed8de7674da55bcf6904a0765245. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

