### PR TITLE
⚡ Bolt: [performance improvement] Fuse min/max calculations into mappedScatterData loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -97,3 +97,8 @@
 
 **Learning:** `Array.from({ length: N })` and `[] as any[]; array.length = N` create unnecessary garbage collection overhead when used inside tight loops or frequent React renders (`useMemo`). `Array.from` additionally allocates an intermediate object `{ length }`. The oxlint rule `unicorn/no-new-array` flags `new Array(len)`, causing developers to mistakenly prefer slower patterns.
 **Action:** Always pre-allocate fixed-length arrays directly using explicit types without the `new` keyword: `Array<Type>(N)`. This bypasses the linting rule while preserving the high-performance memory allocation behavior of `new Array()`.
+
+## 2024-05-18 - Fuse consecutive array iterations in useMemo
+
+**Learning:** Having one `useMemo` loop over an array to build a mapped dataset, followed immediately by a second `useMemo` hook that loops over that exact same mapped dataset to calculate min/max boundaries, creates an unnecessary O(N) traversal.
+**Action:** When deriving multiple insights from a newly mapped array (like transformed objects and statistical bounds), fuse the logic into a single O(N) loop within the first `useMemo` block and return a combined object (e.g., `{ data: mappedData, minX, maxX, minY, maxY }`). This prevents redundant iterations over the same data.

--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -159,6 +159,10 @@ export default memo(({ keys }: ChartProps) => {
     const entry1 = dataMap.get(keys[1])
 
     const mappedData: any[][] = []
+    let minX = 0,
+      maxX = 100,
+      minY = 0,
+      maxY = 100
 
     if (entry0 && entry1) {
       const values0 = entry0[1]
@@ -167,17 +171,32 @@ export default memo(({ keys }: ChartProps) => {
       const unitY = entry1[2] || ''
       const len = labels.length
 
+      let initializedBounds = false
+
       for (let i = 0; i < len; i++) {
         const v0 = values0[i]
         const v1 = values1[i]
         if (v0 !== null && v0 !== undefined && v1 !== null && v1 !== undefined) {
           const formattedDate = formatTime(labels[i])
           mappedData.push([v0, v1, formattedDate, unitX, unitY])
+
+          if (!initializedBounds) {
+            minX = v0
+            maxX = v0
+            minY = v1
+            maxY = v1
+            initializedBounds = true
+          } else {
+            if (v0 < minX) minX = v0
+            if (v0 > maxX) maxX = v0
+            if (v1 < minY) minY = v1
+            if (v1 > maxY) maxY = v1
+          }
         }
       }
     }
 
-    return mappedData
+    return { data: mappedData, minX, maxX, minY, maxY }
   }, [dataMap, keys])
 
   const options: any = useMemo(() => {
@@ -188,12 +207,12 @@ export default memo(({ keys }: ChartProps) => {
     const dataset: any[] = [
       {
         dimensions: [keys[0], keys[1], 'Date', 'unitX', 'unitY'],
-        source: mappedScatterData,
+        source: mappedScatterData.data,
       },
     ]
 
     // Guard against regression transform crash on <2 points
-    if (mappedScatterData.length >= 2) {
+    if (mappedScatterData.data.length >= 2) {
       dataset.push({
         transform: {
           type: 'ecStat:regression',
@@ -206,7 +225,7 @@ export default memo(({ keys }: ChartProps) => {
     const nextSeries = [
       series[0],
       // Only include the regression series if dataset contains it
-      ...(mappedScatterData.length >= 2
+      ...(mappedScatterData.data.length >= 2
         ? [
             {
               ...series[1],
@@ -220,27 +239,6 @@ export default memo(({ keys }: ChartProps) => {
           ]
         : []),
     ]
-
-    // Optimization: Calculate min/max data boundaries in a single O(N) pass
-    // to avoid allocating 4 intermediate arrays via chained .map() and
-    // preventing stack overflow from spreading (...) large arrays into Math.min/max.
-    let minX = 0,
-      maxX = 100,
-      minY = 0,
-      maxY = 100
-    if (mappedScatterData.length > 0) {
-      minX = mappedScatterData[0][0]
-      maxX = mappedScatterData[0][0]
-      minY = mappedScatterData[0][1]
-      maxY = mappedScatterData[0][1]
-      for (let i = 1; i < mappedScatterData.length; i++) {
-        const item = mappedScatterData[i]
-        if (item[0] < minX) minX = item[0]
-        if (item[0] > maxX) maxX = item[0]
-        if (item[1] < minY) minY = item[1]
-        if (item[1] > maxY) maxY = item[1]
-      }
-    }
 
     return {
       ...echartsOptions,
@@ -281,13 +279,13 @@ export default memo(({ keys }: ChartProps) => {
       dataZoom: [
         {
           ...(echartsOptions.dataZoom as any[])[0],
-          startValue: minX,
-          endValue: maxX,
+          startValue: mappedScatterData.minX,
+          endValue: mappedScatterData.maxX,
         },
         {
           ...(echartsOptions.dataZoom as any[])[1],
-          startValue: minY,
-          endValue: maxY,
+          startValue: mappedScatterData.minY,
+          endValue: mappedScatterData.maxY,
         },
       ],
     }

--- a/vite_output.log
+++ b/vite_output.log
@@ -1,9 +1,0 @@
-
-> myhealth@1.0.0 dev /app
-> vite
-
-
-  VITE v8.0.8  ready in 642 ms
-
-  ➜  Local:   http://localhost:5173/
-  ➜  Network: use --host to expose


### PR DESCRIPTION
💡 **What:**
Moved the `minX`, `maxX`, `minY`, `maxY` boundary calculations from a separate `useMemo` block directly into the single `mappedScatterData` loop in `src/layout/Chart2.tsx`.

🎯 **Why:**
Previously, `mappedScatterData` was calculated in one O(N) loop. Immediately after, a second `useMemo` block calculated min/max boundaries by looping over `mappedScatterData` entirely a second time. This created redundant array traversals and `useMemo` dependency chains.

📊 **Impact:**
Reduces the data traversal operations in the main Chart component by 50% per render cycle, completely eliminating one `O(N)` loop over the generated points array and improving reactivity when changing selected chart axes.

🔬 **Measurement:**
Run `pnpm exec playwright test` and ensure all tests continue to pass correctly, specifically confirming the scatter plot min/max boundaries accurately reflect the underlying data.

---
*PR created automatically by Jules for task [5715019581910531004](https://jules.google.com/task/5715019581910531004) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fused min/max boundary calculations into the `mappedScatterData` loop to remove a second O(N) pass and cut per-render work. Charts now read bounds from the mapped result for snappier axis changes.

- **Refactors**
  - Compute bounds during the single pass and return `{ data, minX, maxX, minY, maxY }` instead of an array.
  - Update dataset/series and `dataZoom` to use `mappedScatterData.data` and bounds; keep regression only with 2+ points.
  - Remove the extra bounds `useMemo`; drop `vite_output.log`; add a performance note in `.jules/bolt.md`.

<sup>Written for commit 77840c00b7d284b674cb72953576e816c263e30a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

