### PR TITLE
Update gist suffix to use YYYYMMDD format

### DIFF
--- a/src/layout/SupplementCorrelation.tsx
+++ b/src/layout/SupplementCorrelation.tsx
@@ -18,7 +18,6 @@ const SupplementCorrelation = React.memo(
     const dataMap = useAtomValue(dataMapAtom)
     const alpha = 0.05
 
-
     const correlations = useMemo(() => {
       if (!supplementName) return []
 

--- a/src/service/gist.ts
+++ b/src/service/gist.ts
@@ -1,6 +1,7 @@
 export async function createGist(content: string, token: string, keys: string): Promise<string> {
   const prefix = 'biomarker'
-  const suffix = Date.now()
+  const now = new Date()
+  const suffix = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`
   const fileName = `${prefix}_${keys}_${suffix}.md`
   const response = await fetch('https://api.github.com/gists/f0423911a4f974338132d2a160b6c638', {
     method: 'PATCH',


### PR DESCRIPTION
Updated `createGist` in `src/service/gist.ts` to replace `Date.now()` with a string in `YYYYMMDD` format using local time (`Date.getFullYear()`, `Date.getMonth()`, `Date.getDate()`), correctly padding month and date values with leading zeroes. This satisfies the requirement to use the YYYYMMDD suffix instead of timestamp.

---
*PR created automatically by Jules for task [1206628154204120310](https://jules.google.com/task/1206628154204120310) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use local YYYYMMDD suffix for gist filenames (replaces `Date.now()`) to meet the naming requirement and improve readability. Also removes a stray blank line in `SupplementCorrelation.tsx`.

<sup>Written for commit 57b3eaf14af60accbc43131f9eeb1189a5566493. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

