### PR TITLE
🎨 Palette: Add dynamic accessibility feedback to icon-only copy button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,3 +28,7 @@
 **Action:** When encountering `files.length === 0` or similar conditions, always prefer a structured empty state over plain text, ensuring it includes a helpful call-to-action to resolve the empty state.
 **Learning:** When implementing tab-like views using custom buttons (e.g., swapping between Chart and Table views), screen reader users are unaware of the active selection if the visual active state (e.g., highlighted background color) isn't paired with an accessibility attribute.
 **Action:** Always add `aria-pressed={isActive}` or `aria-selected={isActive}` to toggle buttons to correctly communicate their state to assistive technologies.
+## 2026-05-01 - Add missing accessibility feedback to icon-only state buttons
+
+**Learning:** When icon-only buttons change state (e.g., from a "Copy" icon to a "Check" icon upon successful copy) without triggering a route change, screen readers receive no feedback unless explicitly provided. While visual users see the icon swap, assistive technologies need dynamic accessible labels and live regions to announce the action's success.
+**Action:** Always ensure that icon-only buttons which perform stateful actions dynamically update their `aria-label` (and `title` for visual hover consistency) and apply `aria-live="polite"` so state changes are properly announced.

--- a/src/layout/SupplementCorrelation.tsx
+++ b/src/layout/SupplementCorrelation.tsx
@@ -199,8 +199,9 @@ const SupplementCorrelation = React.memo(
                             })
                           }}
                           className="text-gray-400 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded p-1"
-                          title="Copy to clipboard"
-                          aria-label="Copy to clipboard"
+                          title={isCopied ? 'Copied to clipboard' : 'Copy to clipboard'}
+                          aria-label={isCopied ? 'Copied to clipboard' : 'Copy to clipboard'}
+                          aria-live="polite"
                         >
                           {isCopied ? (
                             <CheckIcon className="h-5 w-5 text-green-500" />


### PR DESCRIPTION
💡 What:
Added dynamic `aria-label`, `title`, and `aria-live="polite"` to the icon-only "Copy" button in `SupplementCorrelation.tsx`.
Updated the Palette journal with this insight.

🎯 Why:
When icon-only buttons change state (like from "Copy to clipboard" to "Copied!") without triggering a route change, assistive technologies need dynamic accessible labels and live regions to announce the action's success. The existing implementation gave zero feedback to screen readers and the visual hover text (`title`) remained "Copy to clipboard" even after copying.

♿ Accessibility:
- The `aria-label` correctly updates to 'Copied to clipboard' upon success.
- `aria-live="polite"` announces the text change smoothly.
- The native visual `title` updates to match, ensuring visual mouse users aren't confused.

---
*PR created automatically by Jules for task [1856983952597724521](https://jules.google.com/task/1856983952597724521) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add dynamic accessibility feedback to the icon-only “Copy” button so screen readers announce success and the hover title updates. Also updated the Palette journal with the pattern.

- **Bug Fixes**
  - Update `aria-label` and `title` based on copy state.
  - Add `aria-live="polite"` to announce “Copied to clipboard”.
  - Document the pattern in `.jules/palette.md`.

<sup>Written for commit 922d08e70130f6a9eb3ed7f8339f1143904e09d6. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/282?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

