### PR TITLE
⚡ Bolt: [performance improvement] Pre-calculate formatted chart labels at load time

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,1 +1,1 @@
-export { labels, loadData } from './loader'
+export { labels, formattedLabels, loadData } from './loader'

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -5,6 +5,14 @@ const addLabels = ['251015', '251120', '251228', '260129', '260305', '260411']
 
 export const labels = [...data.map((item) => item.time), ...addLabels]
 
+// ⚡ Bolt Optimization: Pre-calculate formatted date strings once at load time.
+// This prevents redundant string manipulations and object allocations inside
+// chart component render loops or useMemo hooks, reducing garbage collection overhead.
+export const formattedLabels = labels.map(label => {
+  if (!label || label.length < 6) return label
+  return `20${label.slice(0, 2)}/${label.slice(2, 4)}/${label.slice(4, 6)}`
+})
+
 const mergeNotes = (inputs: Array<RawEntry>): Notes =>
   Object.fromEntries(
     inputs.map((entry, index) => [

--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -3,7 +3,7 @@ import { useAtomValue } from 'jotai'
 import { dataMapAtom } from '../atom/dataAtom'
 import { ChartProvider, ChartContext } from '@echarts-readymade/core'
 import { Line } from '@echarts-readymade/line'
-import { labels } from '../data'
+import { labels, formattedLabels } from '../data'
 import { CHART_PALETTE } from './Chart2'
 
 interface ChartProps {
@@ -66,11 +66,6 @@ const echartsOptions: any = {
   },
 }
 
-const formatTime = (label: string) => {
-  if (!label || label.length < 6) return label
-  return `20${label.slice(0, 2)}/${label.slice(2, 4)}/${label.slice(4, 6)}`
-}
-
 export default memo(({ keys }: ChartProps) => {
   const dataMap = useAtomValue(dataMapAtom)
 
@@ -128,7 +123,7 @@ export default memo(({ keys }: ChartProps) => {
     const len = labels.length
     const result = Array<Record<string, any>>(len)
     for (let i = 0; i < len; i++) {
-      const item: Record<string, any> = { d1: formatTime(labels[i]) }
+      const item: Record<string, any> = { d1: formattedLabels[i] }
       for (let j = 0; j < validSeries.length; j++) {
         const series = validSeries[j]
         const v = series.values[i]

--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo } from 'react'
 import { useAtomValue } from 'jotai'
 import { dataMapAtom } from '../atom/dataAtom'
 
-import { labels } from '../data'
+import { labels, formattedLabels } from '../data'
 import ReactECharts from 'echarts-for-react'
 import * as echarts from 'echarts'
 import * as ecStat from 'echarts-stat'
@@ -147,11 +147,6 @@ const echartsOptions: any = {
 export default memo(({ keys }: ChartProps) => {
   const dataMap = useAtomValue(dataMapAtom)
 
-  const formatTime = (label: string) => {
-    if (!label || label.length < 6) return label
-    return `20${label.slice(0, 2)}/${label.slice(2, 4)}/${label.slice(4, 6)}`
-  }
-
   const mappedScatterData = useMemo(() => {
     // Optimization: Replace O(K*N) chained .map(), .reduce(), and .filter() array allocations
     // with a single-pass O(N) loop to eliminate closure creation and garbage collection overhead.
@@ -177,7 +172,7 @@ export default memo(({ keys }: ChartProps) => {
         const v0 = values0[i]
         const v1 = values1[i]
         if (v0 !== null && v0 !== undefined && v1 !== null && v1 !== undefined) {
-          const formattedDate = formatTime(labels[i])
+          const formattedDate = formattedLabels[i]
           mappedData.push([v0, v1, formattedDate, unitX, unitY])
 
           if (!initializedBounds) {

--- a/src/layout/LineChart.tsx
+++ b/src/layout/LineChart.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react'
 import ReactECharts from 'echarts-for-react'
-import { labels } from '../data'
+import { labels, formattedLabels } from '../data'
 import { CHART_PALETTE } from './Chart2'
 
 interface LineChartProps {
@@ -55,11 +55,6 @@ const echartsOptions = {
   },
 }
 
-const formatTime = (label: string) => {
-  if (!label || label.length < 6) return label
-  return `20${label.slice(0, 2)}/${label.slice(2, 4)}/${label.slice(4, 6)}`
-}
-
 import { useMemo } from 'react'
 
 export default memo(({ name, values, rangeStr }: LineChartProps) => {
@@ -74,7 +69,7 @@ export default memo(({ name, values, rangeStr }: LineChartProps) => {
     const result = new Array(numLabels)
     for (let i = 0; i < numLabels; i++) {
       const value = values[i]
-      result[i] = [formatTime(labels[i]), value !== null && value !== undefined ? value : '-']
+      result[i] = [formattedLabels[i], value !== null && value !== undefined ? value : '-']
     }
     return result
   }, [values])

--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo } from 'react'
 import { useAtomValue } from 'jotai'
 import { dataMapAtom } from '../atom/dataAtom'
 import ReactECharts from 'echarts-for-react'
-import { labels } from '../data'
+import { labels, formattedLabels } from '../data'
 import { CHART_PALETTE } from './Chart2'
 
 interface ScatterChartProps {
@@ -80,10 +80,6 @@ export default memo(({ keys }: ScatterChartProps) => {
     }
   })
 
-  const formatTime = (label: string) => {
-    return `20${label.slice(0, 2)}/${label.slice(2, 4)}/${label.slice(4, 6)}`
-  }
-
   const chartData = useMemo(() => {
     // Optimization: Replace chained Array.map() with a classic for-loop and pre-allocated array.
     // This eliminates the closure allocation and avoids garbage collection spikes in component render paths.
@@ -113,7 +109,7 @@ export default memo(({ keys }: ScatterChartProps) => {
       for (let i = 0; i < numLabels; i++) {
         const val = values[i]
         if (val !== null && val !== undefined) {
-          validData.push([formatTime(labels[i]), val, unit])
+          validData.push([formattedLabels[i], val, unit])
         }
       }
 


### PR DESCRIPTION
💡 What: Extracted `formatTime` string manipulation into a pre-calculated `formattedLabels` array inside `src/data/loader.ts`. All chart components (`Chart.tsx`, `Chart2.tsx`, `LineChart.tsx`, `ScatterChart.tsx`) now use O(1) array lookups instead of computing string slices dynamically on every render or inside `useMemo` hooks.

🎯 Why: The `formatTime` function was being executed continuously inside hot loops and `useMemo` dependencies across all four chart views, causing unnecessary string memory allocations and garbage collection overhead on every application re-render or data change.

📊 Impact: Significantly reduces string allocations and garbage collection pauses when rendering multiple charts or typing in the search bar, making the UI noticeably smoother.

🔬 Measurement: Verify by loading charts and interacting with the app (e.g. typing in search); profile the heap allocation in DevTools to observe the elimination of string allocations from `formatTime` during React re-renders.

---
*PR created automatically by Jules for task [2055774245680188395](https://jules.google.com/task/2055774245680188395) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-calculated formatted chart labels at load time and switched charts to O(1) lookups, removing per-render string formatting. This reduces allocations and GC pauses, making chart interactions smoother.

- **Refactors**
  - Added `formattedLabels` in `src/data/loader.ts` and exported via `src/data/index.ts`.
  - Replaced local `formatTime` calls in `Chart.tsx`, `Chart2.tsx`, `LineChart.tsx`, and `ScatterChart.tsx` with `formattedLabels[i]`.

<sup>Written for commit 56da4f4917636e0b209b7f432e5ed9dce0338f78. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/283?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

