### PR TITLE
refactor: extract GistFile type to match repository conventions

### DIFF
--- a/src/layout/GistViewer.tsx
+++ b/src/layout/GistViewer.tsx
@@ -7,7 +7,8 @@ import {
   ClipboardDocumentIcon,
 } from '@heroicons/react/24/outline'
 import Markdown from 'react-markdown'
-import { getGistFiles, GistFile } from '../service/gist'
+import { getGistFiles } from '../service/gist'
+import { GistFile } from '../service/gist.types'
 import { Spinner } from './Spinner'
 import { GistViewerProps } from './GistViewer.types'
 

--- a/src/service/gist.ts
+++ b/src/service/gist.ts
@@ -1,3 +1,5 @@
+import { GistFile } from './gist.types'
+
 export async function createGist(content: string, token: string, keys: string): Promise<string> {
   const prefix = 'biomarker'
   const now = new Date()
@@ -28,11 +30,6 @@ export async function createGist(content: string, token: string, keys: string): 
 
   const data = await response.json()
   return data.html_url
-}
-
-export interface GistFile {
-  filename: string
-  content: string
 }
 
 export async function getGistFiles(): Promise<GistFile[]> {

--- a/src/service/gist.types.ts
+++ b/src/service/gist.types.ts
@@ -1,0 +1,4 @@
+export interface GistFile {
+  filename: string
+  content: string
+}


### PR DESCRIPTION
**The Issue:**
`src/service/gist.ts` lines 33-36 contained the `GistFile` interface definition, which was being exported and then imported by an entirely different component (`src/layout/GistViewer.tsx`). This violates the separation of concerns and the repository's convention of placing shared complex types in a `.types.ts` sibling file or `src/types/`.

**The Discovery Signal:**
Scan D (Misplaced Shared Types) triggered this. `GistFile` was declared in a logic file (`gist.ts`) and imported elsewhere.

**The Fix:**
- Created `src/service/gist.types.ts` containing the `GistFile` interface.
- Removed the `GistFile` declaration from `src/service/gist.ts` and updated its return type to use the new import.
- Updated `src/layout/GistViewer.tsx` to import `GistFile` from `../service/gist.types`.

**The Benefit:**
Cleaner structural separation. Future agents won't be confused by implementation logic files exporting complex types, and the codebase follows a more uniform convention matching the existing `.types.ts` pattern. Verified that `tsc --noEmit` passes cleanly.

---
*PR created automatically by Jules for task [1210058581229925156](https://jules.google.com/task/1210058581229925156) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the `GistFile` interface from `src/service/gist.ts` to `src/service/gist.types.ts` to follow the `.types.ts` convention and keep logic files free of shared types. Updated imports in `gist.ts` and `src/layout/GistViewer.tsx`; no functional changes.

<sup>Written for commit 83855fc5307a113bfda969e0912597291978ebee. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/284?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

