### PR TITLE
🎨 Palette: Add aria-hidden to decorative icons

### DIFF
--- a/src/layout/GistViewer.tsx
+++ b/src/layout/GistViewer.tsx
@@ -182,7 +182,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                               {keys}
                             </div>
                             <div className="text-xs text-gray-400 flex items-center gap-1">
-                              <ClockIcon className="h-3 w-3" />
+                              <ClockIcon className="h-3 w-3" aria-hidden="true" />
                               {isParsed ? dateStr : file.filename}
                             </div>
                           </button>
@@ -196,7 +196,10 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                       aria-live="polite"
                     >
                       <div className="bg-gray-800/50 rounded-full p-4 mb-4">
-                        <ClipboardDocumentIcon className="h-8 w-8 text-gray-400" />
+                        <ClipboardDocumentIcon
+                          className="h-8 w-8 text-gray-400"
+                          aria-hidden="true"
+                        />
                       </div>
                       <h3 className="text-lg font-medium text-gray-300 mb-2">
                         No AI history found

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -253,7 +253,11 @@ export default React.memo<NavProps>(
               title={show ? 'Close menu' : 'Open menu'}
               aria-expanded={show}
             >
-              {show ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
+              {show ? (
+                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+              ) : (
+                <Bars3Icon className="h-6 w-6" aria-hidden="true" />
+              )}
             </button>
             <div className="w-full min-w-40 lg:w-auto flex-1 lg:flex-none">
               <div className="relative text-gray-400 focus-within:text-gray-200">

--- a/vite_output.log
+++ b/vite_output.log
@@ -1,0 +1,10 @@
+
+> myhealth@1.0.0 dev /app
+> vite
+
+Port 5173 is in use, trying another one...
+
+  VITE v8.0.8  ready in 462 ms
+
+  ➜  Local:   http://localhost:5174/
+  ➜  Network: use --host to expose


### PR DESCRIPTION
💡 **What:** Added `aria-hidden="true"` to decorative icons across the application. Specifically:
- `ClockIcon` and `ClipboardDocumentIcon` in `src/layout/GistViewer.tsx`.
- `XMarkIcon` and `Bars3Icon` inside the mobile menu toggle button in `src/layout/Nav.tsx`.

🎯 **Why:** To improve accessibility by preventing screen readers from redundantly announcing purely decorative SVG icons, especially when they are already accompanied by text or placed inside elements with explicit `aria-label` or `aria-live` attributes.

♿ **Accessibility:** Prevents double announcements and cleans up the accessibility tree for screen reader users.

---
*PR created automatically by Jules for task [2400552010042809560](https://jules.google.com/task/2400552010042809560) started by @fantasia949*