### PR TITLE
feat(charts): update ScatterChart tooltip to support cross-series comparison

### DIFF
--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -20,29 +20,38 @@ const echartsOptions = {
   yAxis: [] as any[],
   series: [] as any[],
   tooltip: {
-    trigger: 'item',
+    trigger: 'axis',
     backgroundColor: '#111111',
     borderColor: '#3a3a3a80',
     textStyle: {
       color: '#f0f0f0',
     },
     formatter: (params: any) => {
-      const date = params.value[0]
-      const val = params.value[1]
+      const pArray = Array.isArray(params) ? params : [params]
+      if (pArray.length === 0) return ''
 
-      if (
-        val === null ||
-        val === undefined ||
-        val === '-' ||
-        val === '' ||
-        val === 'NaN' ||
-        Number.isNaN(val)
-      ) {
-        return ''
+      let tooltipStr = `${pArray[0].value[0]}`
+      let hasValidValues = false
+
+      for (let i = 0; i < pArray.length; i++) {
+        const p = pArray[i]
+        const val = p.value[1]
+
+        if (
+          val !== null &&
+          val !== undefined &&
+          val !== '-' &&
+          val !== '' &&
+          val !== 'NaN' &&
+          !Number.isNaN(val)
+        ) {
+          const unit = p.value[2] ? ` ${p.value[2]}` : ''
+          tooltipStr += `<br/>${p.marker} ${p.seriesName}: <strong>${val}${unit}</strong>`
+          hasValidValues = true
+        }
       }
 
-      const unit = params.value[2] ? ` ${params.value[2]}` : ''
-      return `${params.marker} ${params.seriesName}<br/>${date}<br/><strong>${val}${unit}</strong>`
+      return hasValidValues ? tooltipStr : ''
     },
   },
   legend: {


### PR DESCRIPTION
This change improves the `ScatterChart.tsx` tooltip by enabling cross-series comparison. Previously, `trigger: 'item'` only showed the value of a single hovered point. Now, `trigger: 'axis'` displays all valid biomarker measurements for the corresponding date.

The formatter iterates over the `params` array, gracefully handling single objects and filtering out missing data points (`null`, `NaN`, `'-'`). It also correctly appends units when available.

**Note:** `context7` was unavailable during execution.

**Visualization Proposals:**
No new visualization proposals are being made because all candidate chart types evaluated (radar, heatmap, boxplot, calendar, gauge, parallel, bar, visualMap, histogram, clustering) have either been previously implemented or rejected according to repository constraints and memory.

---
*PR created automatically by Jules for task [16550025534223900544](https://jules.google.com/task/16550025534223900544) started by @fantasia949*