### PR TITLE
🎨 Palette: Improve P-Value Dialog Empty State & Tooltip

### DIFF
--- a/src/layout/PValue.tsx
+++ b/src/layout/PValue.tsx
@@ -120,7 +120,6 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                 </Dialog.Title>
                 <div
                   className="mt-2 text-sm whitespace-pre-wrap flex-1"
-                  title={text?.[1]}
                   style={{ fontSize: 14 }}
                 >
                   {comparedSourceTarget && (
@@ -137,7 +136,8 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                   ) : (
                     <div
                       className="text-gray-400 p-6 text-center border border-dashed border-gray-700 rounded bg-white/5 my-4 flex flex-col gap-2"
-                      role="alert"
+                      role="status"
+                      aria-live="polite"
                     >
                       <span className="font-semibold text-gray-300">
                         Not enough overlapping data points


### PR DESCRIPTION
💡 What:
- Updated the "Not enough overlapping data points" message in `PValue.tsx` to use `role="status"` and `aria-live="polite"`.
- Removed a confusing `title={text?.[1]}` attribute from the text container which showed raw JSON data on hover.

🎯 Why:
- The `role="alert"` was inconsistent with standard empty states in the application and could be disruptive to screen readers.
- Raw JSON tooltips are a poor experience for visual users.

📸 Before/After:
Before: The text container had a `title` showing raw JSON, and the empty state used `role="alert"`.
After: The JSON tooltip is gone, and the empty state uses the accessible standard `role="status"` and `aria-live="polite"`.

♿ Accessibility:
- Screen readers now announce the missing data state smoothly using `role="status"`, rather than as a jarring `role="alert"`.

---
*PR created automatically by Jules for task [1086939988480823078](https://jules.google.com/task/1086939988480823078) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve the P-Value dialog empty state for better accessibility and UX. The message now uses role="status" with aria-live="polite", and the text container no longer shows a raw JSON tooltip on hover.

<sup>Written for commit 96ca998cdf06ae0ca613224795944b8e4b720986. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

