### PR TITLE
Fix multi-axis overlap in Chart.tsx

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -92,11 +92,22 @@ export default memo(({ keys }: ChartProps) => {
     const numKeys = keys.length
     const result = Array<any>(numKeys)
     for (let i = 0; i < numKeys; i++) {
+      const isEven = i % 2 === 0
+      const sideOffset = Math.floor(i / 2) * 80
+
       result[i] = {
         scale: true,
         name: keys[i],
+        position: isEven ? 'left' : 'right',
+        offset: sideOffset,
         nameLocation: 'middle',
         nameGap: 50,
+        axisLine: {
+          show: true,
+          lineStyle: {
+            color: CHART_PALETTE[i % CHART_PALETTE.length],
+          },
+        },
       }
     }
     return result
@@ -156,10 +167,15 @@ export default memo(({ keys }: ChartProps) => {
         instance.setOption(
           {
             yAxis,
-            grid: { top: 40, bottom: 20 },
+            grid: {
+              top: 40,
+              bottom: 20,
+              left: Math.ceil(keys.length / 2) * 80,
+              right: Math.max(Math.floor(keys.length / 2) * 80, 40),
+            },
             series,
           },
-          { replaceMerge: ['series', 'yAxis'], notMerge: true },
+          { replaceMerge: ['series', 'yAxis'] },
         )
       }
     }


### PR DESCRIPTION
Fixes an issue in `Chart.tsx` where adding multiple series would stack the Y-axes over each other. This implements the left/right switching and progressive offsets.

---
*PR created automatically by Jules for task [13424602239965319456](https://jules.google.com/task/13424602239965319456) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Y‑axis overlap in multi‑series charts in `Chart.tsx` by alternating axis sides and applying step offsets, with grid auto‑spacing. Also removes `notMerge: true` from `setOption` to align with the wrapper’s merge behavior.

- **Bug Fixes**
  - Alternate axis side per series (left/right) with 80px incremental offsets.
  - Color each axis line using `CHART_PALETTE` to match its series.
  - Auto‑compute grid padding (`left`/`right`) based on axis count.
  - Use `replaceMerge: ['series', 'yAxis']` and drop `notMerge: true`.

<sup>Written for commit e6230fee8120e3d09f527126172e4147b9d48161. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

