### PR TITLE
fix(chart): resolve stale ref dependency and lifecycle crashes

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useEffect, useMemo } from 'react'
+import { memo, useRef, useEffect, useMemo, useState, useCallback } from 'react'
 import { useAtomValue } from 'jotai'
 import { dataMapAtom } from '../atom/dataAtom'
 import { ChartProvider, ChartContext } from '@echarts-readymade/core'
@@ -148,12 +148,19 @@ export default memo(({ keys }: ChartProps) => {
   }, [dataMap, keys, valueList, labels])
 
   const ref = useRef<any>(null)
+  const [isChartReady, setIsChartReady] = useState(false)
+
+  const handleRef = useCallback((node: any) => {
+    ref.current = node
+    if (node) {
+      setIsChartReady(true)
+    }
+  }, [])
 
   useEffect(() => {
-    let instance: any = null
-    if (ref.current) {
-      instance = ref.current.getEchartsInstance()
-      if (instance) {
+    if (isChartReady && ref.current) {
+      const instance = ref.current.getEchartsInstance()
+      if (instance && !instance.isDisposed()) {
         // Optimization: Replace array map in the render loop with a classic for-loop
         // and pre-allocated array to avoid closure and garbage collection overhead.
         const len = keys.length
@@ -179,17 +186,12 @@ export default memo(({ keys }: ChartProps) => {
         )
       }
     }
-    return () => {
-      if (instance) {
-        instance.destroy()
-      }
-    }
-  }, [keys, yAxis])
+  }, [keys, yAxis, isChartReady])
 
   return (
     <ChartProvider data={chartData} echartsOptions={echartsOptions}>
       <Line
-        ref={ref}
+        ref={handleRef}
         // Note: here you need pass context down
         context={ChartContext}
         dimension={dimension}


### PR DESCRIPTION
Fixes issue where Chart.tsx fails to update axes properly due to stale refs and improper instance destruction.

---
*PR created automatically by Jules for task [15230639372469867930](https://jules.google.com/task/15230639372469867930) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chart axis updates failing due to stale refs and destructive cleanup, preventing blank/crashed charts on `keys`/`yAxis` changes. Ensures ECharts options apply only when the instance is ready.

- **Bug Fixes**
  - Use a callback ref (`handleRef`) with `isChartReady` to avoid stale ref updates.
  - Guard against disposed instances with `!instance.isDisposed()` before applying options.
  - Remove `instance.destroy()` from effect cleanup to prevent crashes during reactive updates.

<sup>Written for commit d9c8a166b844b24f1353cbc3c7e6edc2fe1088d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

