### PR TITLE
🎨 Palette: Ensure aria-hidden="true" on decorative icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -38,3 +38,7 @@
 
 **Learning:** Adding `role="status"` and `aria-label` directly to generic Spinner SVGs causes double announcements when the spinner is embedded alongside actual loading text that already has `aria-live="polite"` or `role="status"`.
 **Action:** Keep visual-only indicators like SVGs hidden from screen readers using `aria-hidden="true"`, and manage the accessible loading state purely through the surrounding text/container.
+
+## 2025-02-20 - Ensure Aria-Hidden on Decorative Icons
+**Learning:** Generic icon components (like `@heroicons/react`) can cause redundant screen reader announcements if used decoratively without `aria-hidden="true"`.
+**Action:** Always add `aria-hidden="true"` to SVG/icon components that do not convey meaningful unique information (e.g., when wrapped in a button with a clear `aria-label`).

--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -215,11 +215,11 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                       >
                         {isCopied ? (
                           <>
-                            <CheckIcon className="h-4 w-4" /> Copied!
+                            <CheckIcon className="h-4 w-4" aria-hidden="true" /> Copied!
                           </>
                         ) : (
                           <>
-                            <ClipboardDocumentIcon className="h-4 w-4" /> Copy
+                            <ClipboardDocumentIcon className="h-4 w-4" aria-hidden="true" /> Copy
                           </>
                         )}
                       </button>
@@ -231,7 +231,7 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                       aria-label="Close dialog"
                       title="Close dialog"
                     >
-                      <XMarkIcon className="h-6 w-6" />
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                   </div>
                 </div>

--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -188,11 +188,11 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                             >
                               {isCopied ? (
                                 <>
-                                  <CheckIcon className="h-4 w-4" /> Copied!
+                                  <CheckIcon className="h-4 w-4" aria-hidden="true" /> Copied!
                                 </>
                               ) : (
                                 <>
-                                  <ClipboardDocumentIcon className="h-4 w-4" /> Copy
+                                  <ClipboardDocumentIcon className="h-4 w-4" aria-hidden="true" /> Copy
                                 </>
                               )}
                             </button>

--- a/src/layout/GistViewer.tsx
+++ b/src/layout/GistViewer.tsx
@@ -127,7 +127,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                         aria-label="Back to list"
                         title="Back to list"
                       >
-                        <ArrowLeftIcon className="h-5 w-5" />
+                        <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
                       </button>
                     )}
                     <span>{selectedFile ? 'Analysis Details' : 'AI History'}</span>
@@ -139,7 +139,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                     aria-label="Close dialog"
                     title="Close dialog"
                   >
-                    <XMarkIcon className="h-6 w-6" />
+                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                   </button>
                 </Dialog.Title>
 

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -372,7 +372,7 @@ export default React.memo<NavProps>(
                           aria-label={`Remove ${item} from selection`}
                           title={`Remove ${item} from selection`}
                         >
-                          <XMarkIcon className="h-3 w-3" />
+                          <XMarkIcon className="h-3 w-3" aria-hidden="true" />
                         </button>
                       </span>
                     ))}
@@ -384,7 +384,7 @@ export default React.memo<NavProps>(
                         aria-label="Clear all selected items"
                         title="Clear All"
                       >
-                        <TrashIcon className="h-4 w-4" />
+                        <TrashIcon className="h-4 w-4" aria-hidden="true" />
                       </button>
                     )}
                   </div>
@@ -590,7 +590,7 @@ export default React.memo<NavProps>(
                         aria-label="Close dialog"
                         title="Close dialog"
                       >
-                        <XMarkIcon className="h-6 w-6" />
+                        <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                       </button>
                     </Dialog.Title>
                     <div className="mt-2 prose prose-invert max-w-none overflow-y-auto">
@@ -615,11 +615,11 @@ export default React.memo<NavProps>(
                       >
                         {isCopied ? (
                           <>
-                            <CheckIcon className="h-5 w-5" /> Copied!
+                            <CheckIcon className="h-5 w-5" aria-hidden="true" /> Copied!
                           </>
                         ) : (
                           <>
-                            <ClipboardDocumentIcon className="h-5 w-5" /> Copy Analysis
+                            <ClipboardDocumentIcon className="h-5 w-5" aria-hidden="true" /> Copy Analysis
                           </>
                         )}
                       </button>

--- a/src/layout/PValue.tsx
+++ b/src/layout/PValue.tsx
@@ -115,7 +115,7 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                     aria-label="Close dialog"
                     title="Close dialog"
                   >
-                    <XMarkIcon className="h-6 w-6" />
+                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                   </button>
                 </Dialog.Title>
                 <div
@@ -174,11 +174,11 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                     >
                       {isCopied ? (
                         <>
-                          <CheckIcon className="h-5 w-5" /> Copied!
+                          <CheckIcon className="h-5 w-5" aria-hidden="true" /> Copied!
                         </>
                       ) : (
                         <>
-                          <ClipboardDocumentIcon className="h-5 w-5" /> Copy Analysis
+                          <ClipboardDocumentIcon className="h-5 w-5" aria-hidden="true" /> Copy Analysis
                         </>
                       )}
                     </button>

--- a/src/layout/PasswordInput.tsx
+++ b/src/layout/PasswordInput.tsx
@@ -23,7 +23,7 @@ export const PasswordInput = React.memo(
         aria-label={show ? 'Hide password' : 'Show password'}
         title={show ? 'Hide password' : 'Show password'}
       >
-        {show ? <EyeSlashIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
+        {show ? <EyeSlashIcon className="h-5 w-5" aria-hidden="true" /> : <EyeIcon className="h-5 w-5" aria-hidden="true" />}
       </button>
     </div>
   ),

--- a/src/layout/SupplementCorrelation.tsx
+++ b/src/layout/SupplementCorrelation.tsx
@@ -204,9 +204,9 @@ const SupplementCorrelation = React.memo(
                           aria-live="polite"
                         >
                           {isCopied ? (
-                            <CheckIcon className="h-5 w-5 text-green-500" />
+                            <CheckIcon className="h-5 w-5 text-green-500" aria-hidden="true" />
                           ) : (
-                            <ClipboardDocumentIcon className="h-5 w-5" />
+                            <ClipboardDocumentIcon className="h-5 w-5" aria-hidden="true" />
                           )}
                         </button>
                       )}

--- a/src/layout/SupplementsPopover.tsx
+++ b/src/layout/SupplementsPopover.tsx
@@ -37,7 +37,7 @@ export default function SupplementsPopover({ supps, onSupplementClick }: Supplem
         title={`View ${supps.length} supplement${supps.length !== 1 ? 's' : ''} taken on this date`}
         className="w-full h-full cursor-pointer hover:bg-gray-800 hover:text-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded font-bold transition-colors flex justify-center items-center p-1"
       >
-        <BeakerIcon className="h-5 w-5" />
+        <BeakerIcon className="h-5 w-5" aria-hidden="true" />
       </PopoverButton>
       <PopoverPanel
         transition
@@ -60,7 +60,7 @@ export default function SupplementsPopover({ supps, onSupplementClick }: Supplem
                     title={`Correlate ${supp} with biomarkers`}
                     aria-label={`Correlate ${supp} with biomarkers`}
                   >
-                    <CalculatorIcon className="h-4 w-4" />
+                    <CalculatorIcon className="h-4 w-4" aria-hidden="true" />
                   </button>
                 )}
               </span>

--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -302,7 +302,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                     aria-label="Close dialog"
                     title="Close dialog"
                   >
-                    <XMarkIcon className="h-6 w-6" />
+                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                   </button>
                 </Dialog.Title>
 

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -188,9 +188,9 @@ const TableRow = React.memo(
                 aria-expanded={isExpanded}
               >
                 {isExpanded ? (
-                  <MinusIcon className="h-5 w-5" />
+                  <MinusIcon className="h-5 w-5" aria-hidden="true" />
                 ) : (
-                  <ChartBarIcon className="h-5 w-5" />
+                  <ChartBarIcon className="h-5 w-5" aria-hidden="true" />
                 )}
               </button>
               <button
@@ -209,7 +209,7 @@ const TableRow = React.memo(
                     : `Correlate ${name} with other biomarkers`
                 }
               >
-                <ArrowsRightLeftIcon className="h-5 w-5" />
+                <ArrowsRightLeftIcon className="h-5 w-5" aria-hidden="true" />
               </button>
               <button
                 type="button"
@@ -227,7 +227,7 @@ const TableRow = React.memo(
                     : `Correlate ${name} with supplements`
                 }
               >
-                <CalculatorIcon className="h-5 w-5" />
+                <CalculatorIcon className="h-5 w-5" aria-hidden="true" />
               </button>
             </div>
           </td>
@@ -736,9 +736,9 @@ export default React.memo(
                             title={`Toggle group ${row.original.displayTag}`}
                           >
                             {row.getIsExpanded() ? (
-                              <ChevronDownIcon className="h-4 w-4 text-gray-400" />
+                              <ChevronDownIcon className="h-4 w-4 text-gray-400" aria-hidden="true" />
                             ) : (
-                              <ChevronRightIcon className="h-4 w-4 text-gray-400" />
+                              <ChevronRightIcon className="h-4 w-4 text-gray-400" aria-hidden="true" />
                             )}
                             {row.original.displayTag} ({row.subRows.length})
                           </button>


### PR DESCRIPTION
💡 What: Appended `aria-hidden="true"` to SVG components like `<XMarkIcon>`, `<ClipboardDocumentIcon>`, `<CheckIcon>`, and others throughout the layout components.

🎯 Why: Generic icons were causing redundant and confusing announcements for screen reader users when nested inside buttons that already carried a clear `aria-label`.

♿ Accessibility: Prevents double announcements and clears up the accessibility tree for assistive tech users.

---
*PR created automatically by Jules for task [14091250353941058015](https://jules.google.com/task/14091250353941058015) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure decorative SVG icons are hidden from screen readers by adding aria-hidden="true" across the app to prevent duplicate announcements. Improves accessibility with no visual or logic changes.

- **Bug Fixes**
  - Applied `aria-hidden="true"` to decorative icons from `@heroicons/react` in buttons, toggles, and dialog titles (e.g., X, Clipboard, Check, Arrow, Chevron, Chart/Calculator).
  - Added guidance to `.jules/palette.md` on keeping decorative icons hidden from assistive tech.

<sup>Written for commit e13b290ad7da8585bc0d814a35d2c52930b1aaa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

