### PR TITLE
🎨 Palette: Hide decorative SVGs in labeled buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -120,3 +120,6 @@
 ## 2026-05-02 - Moved Origin Values Toggle to Table Header
 **Learning:** The 'Origin values' toggle switch in the top navigation bar was too far removed from the data it controlled, breaking proximity principles. Furthermore, placing table-specific toggles in global navigation clutters the UI.
 **Action:** Always place controls that toggle table columns (like 'Origin values') directly inside the table header itself (e.g., inside the 'Unit' column) using TanStack Table's `table.options.meta` pattern, preserving proximity and cleaning up global navigation.
+## 2024-05-08 - Redundant Screen Reader Announcements for Decorative SVG Icons
+**Learning:** Decorative icons (like `<CheckIcon />` or `<MinusIcon />` from `@heroicons/react`) placed inside buttons that already have an explicit `aria-label` or `title` can cause double announcements by screen readers. While `<Spinner />` had `aria-hidden="true"`, many other action-button icons in components like `Table.tsx` and `Correlation.tsx` were missing this attribute.
+**Action:** Always add `aria-hidden="true"` to generic/decorative SVGs when they are placed alongside explicit descriptive text or when wrapped in interactive elements with a clear `aria-label`.

--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -215,11 +215,11 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                       >
                         {isCopied ? (
                           <>
-                            <CheckIcon className="h-4 w-4" /> Copied!
+                            <CheckIcon className="h-4 w-4" aria-hidden="true" /> Copied!
                           </>
                         ) : (
                           <>
-                            <ClipboardDocumentIcon className="h-4 w-4" /> Copy
+                            <ClipboardDocumentIcon className="h-4 w-4" aria-hidden="true" /> Copy
                           </>
                         )}
                       </button>
@@ -231,7 +231,7 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                       aria-label="Close dialog"
                       title="Close dialog"
                     >
-                      <XMarkIcon className="h-6 w-6" />
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                   </div>
                 </div>

--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -188,11 +188,11 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                             >
                               {isCopied ? (
                                 <>
-                                  <CheckIcon className="h-4 w-4" /> Copied!
+                                  <CheckIcon className="h-4 w-4" aria-hidden="true" /> Copied!
                                 </>
                               ) : (
                                 <>
-                                  <ClipboardDocumentIcon className="h-4 w-4" /> Copy
+                                  <ClipboardDocumentIcon className="h-4 w-4" aria-hidden="true" /> Copy
                                 </>
                               )}
                             </button>

--- a/src/layout/PValue.tsx
+++ b/src/layout/PValue.tsx
@@ -115,7 +115,7 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                     aria-label="Close dialog"
                     title="Close dialog"
                   >
-                    <XMarkIcon className="h-6 w-6" />
+                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                   </button>
                 </Dialog.Title>
                 <div
@@ -174,11 +174,11 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                     >
                       {isCopied ? (
                         <>
-                          <CheckIcon className="h-5 w-5" /> Copied!
+                          <CheckIcon className="h-5 w-5" aria-hidden="true" /> Copied!
                         </>
                       ) : (
                         <>
-                          <ClipboardDocumentIcon className="h-5 w-5" /> Copy Analysis
+                          <ClipboardDocumentIcon className="h-5 w-5" aria-hidden="true" /> Copy Analysis
                         </>
                       )}
                     </button>

--- a/src/layout/SupplementCorrelation.tsx
+++ b/src/layout/SupplementCorrelation.tsx
@@ -204,9 +204,9 @@ const SupplementCorrelation = React.memo(
                           aria-live="polite"
                         >
                           {isCopied ? (
-                            <CheckIcon className="h-5 w-5 text-green-500" />
+                            <CheckIcon className="h-5 w-5 text-green-500" aria-hidden="true" />
                           ) : (
-                            <ClipboardDocumentIcon className="h-5 w-5" />
+                            <ClipboardDocumentIcon className="h-5 w-5" aria-hidden="true" />
                           )}
                         </button>
                       )}

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -188,9 +188,9 @@ const TableRow = React.memo(
                 aria-expanded={isExpanded}
               >
                 {isExpanded ? (
-                  <MinusIcon className="h-5 w-5" />
+                  <MinusIcon className="h-5 w-5" aria-hidden="true" />
                 ) : (
-                  <ChartBarIcon className="h-5 w-5" />
+                  <ChartBarIcon className="h-5 w-5" aria-hidden="true" />
                 )}
               </button>
               <button
@@ -209,7 +209,7 @@ const TableRow = React.memo(
                     : `Correlate ${name} with other biomarkers`
                 }
               >
-                <ArrowsRightLeftIcon className="h-5 w-5" />
+                <ArrowsRightLeftIcon className="h-5 w-5" aria-hidden="true" />
               </button>
               <button
                 type="button"
@@ -227,7 +227,7 @@ const TableRow = React.memo(
                     : `Correlate ${name} with supplements`
                 }
               >
-                <CalculatorIcon className="h-5 w-5" />
+                <CalculatorIcon className="h-5 w-5" aria-hidden="true" />
               </button>
             </div>
           </td>
@@ -736,9 +736,9 @@ export default React.memo(
                             title={`Toggle group ${row.original.displayTag}`}
                           >
                             {row.getIsExpanded() ? (
-                              <ChevronDownIcon className="h-4 w-4 text-gray-400" />
+                              <ChevronDownIcon className="h-4 w-4 text-gray-400" aria-hidden="true" />
                             ) : (
-                              <ChevronRightIcon className="h-4 w-4 text-gray-400" />
+                              <ChevronRightIcon className="h-4 w-4 text-gray-400" aria-hidden="true" />
                             )}
                             {row.original.displayTag} ({row.subRows.length})
                           </button>


### PR DESCRIPTION
## 💡 What
Added `aria-hidden="true"` to decorative SVG icons (`@heroicons/react`) that are located inside icon-only buttons across multiple components (`Table`, `Correlation`, `BiomarkerCorrelation`, `PValue`, `SupplementCorrelation`).

## 🎯 Why
When an icon is placed inside an interactive element (like a button) that already has an explicit `aria-label` or `title`, screen readers might announce both the label and the generic icon representation, leading to redundant and confusing "double announcements." Hiding the decorative SVG ensures a clean, single announcement.

## 📸 Before/After
*(Visuals remain unchanged. Screen reader experience is improved.)*

## ♿ Accessibility
- Prevents redundant double-announcements for screen reader users by properly hiding decorative SVG elements.
- Ensures focus remains on the explicit, descriptive `aria-label` of interactive buttons.

---
*PR created automatically by Jules for task [15193890785709303726](https://jules.google.com/task/15193890785709303726) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide decorative `@heroicons/react` SVGs in labeled buttons by adding aria-hidden="true`. This prevents double announcements by screen readers with no visual changes.

- **Bug Fixes**
  - Applied to icon-only buttons that already have an aria-label or title.
  - Covers expand/collapse, correlate, copy, and close actions across layouts.
  - Added guidance to `.Jules/palette.md` for future use.

<sup>Written for commit 8d79fdfaffc9a44233fd2f54c706783e1ba85b60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

