### PR TITLE
🎨 Palette: Add aria-hidden to decorative icons in text buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -117,6 +117,13 @@
 
 **Learning:** Using computed results (like `!!text`) instead of intentional state (like `!!comparedSourceTarget`) to control dialog visibility causes silent failures when the computation yields no result. The user receives no feedback that their action was processed.
 **Action:** Always bind dialog visibility to the intentional state triggering it, and handle empty/error states inside the dialog content.
+
 ## 2026-05-02 - Moved Origin Values Toggle to Table Header
+
 **Learning:** The 'Origin values' toggle switch in the top navigation bar was too far removed from the data it controlled, breaking proximity principles. Furthermore, placing table-specific toggles in global navigation clutters the UI.
 **Action:** Always place controls that toggle table columns (like 'Origin values') directly inside the table header itself (e.g., inside the 'Unit' column) using TanStack Table's `table.options.meta` pattern, preserving proximity and cleaning up global navigation.
+
+## 2025-05-24 - Screen Reader Double Announcements with Decorative Icons in Text Buttons
+
+**Learning:** Adding SVGs inside generic buttons (e.g., "Copy Analysis" with an adjacent `<ClipboardDocumentIcon />`) without `aria-hidden="true"` can cause screen readers to announce the SVG unhelpfully before or after the text. While `aria-label` mitigates this for icon-only buttons, text-containing buttons inherently rely on their text content for accessibility.
+**Action:** When creating a button with both text and a decorative/illustrative icon, always set `aria-hidden="true"` on the icon itself to prevent screen readers from reading out arbitrary SVG elements and focus solely on the button's explicit text node or label.

--- a/src/layout/BiomarkerCorrelation.tsx
+++ b/src/layout/BiomarkerCorrelation.tsx
@@ -214,11 +214,11 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                       >
                         {isCopied ? (
                           <>
-                            <CheckIcon className="h-4 w-4" /> Copied!
+                            <CheckIcon className="h-4 w-4" aria-hidden="true" /> Copied!
                           </>
                         ) : (
                           <>
-                            <ClipboardDocumentIcon className="h-4 w-4" /> Copy
+                            <ClipboardDocumentIcon className="h-4 w-4" aria-hidden="true" /> Copy
                           </>
                         )}
                       </button>
@@ -230,7 +230,7 @@ const BiomarkerCorrelation = React.memo(({ biomarkerId, onClose }: BiomarkerCorr
                       aria-label="Close dialog"
                       title="Close dialog"
                     >
-                      <XMarkIcon className="h-6 w-6" />
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                   </div>
                 </div>

--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -188,11 +188,12 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                             >
                               {isCopied ? (
                                 <>
-                                  <CheckIcon className="h-4 w-4" /> Copied!
+                                  <CheckIcon className="h-4 w-4" aria-hidden="true" /> Copied!
                                 </>
                               ) : (
                                 <>
-                                  <ClipboardDocumentIcon className="h-4 w-4" /> Copy
+                                  <ClipboardDocumentIcon className="h-4 w-4" aria-hidden="true" />{' '}
+                                  Copy
                                 </>
                               )}
                             </button>

--- a/src/layout/GistViewer.tsx
+++ b/src/layout/GistViewer.tsx
@@ -127,7 +127,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                         aria-label="Back to list"
                         title="Back to list"
                       >
-                        <ArrowLeftIcon className="h-5 w-5" />
+                        <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
                       </button>
                     )}
                     <span>{selectedFile ? 'Analysis Details' : 'AI History'}</span>
@@ -139,7 +139,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                     aria-label="Close dialog"
                     title="Close dialog"
                   >
-                    <XMarkIcon className="h-6 w-6" />
+                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                   </button>
                 </Dialog.Title>
 

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -372,7 +372,7 @@ export default React.memo<NavProps>(
                           aria-label={`Remove ${item} from selection`}
                           title={`Remove ${item} from selection`}
                         >
-                          <XMarkIcon className="h-3 w-3" />
+                          <XMarkIcon className="h-3 w-3" aria-hidden="true" />
                         </button>
                       </span>
                     ))}
@@ -384,7 +384,7 @@ export default React.memo<NavProps>(
                         aria-label="Clear all selected items"
                         title="Clear All"
                       >
-                        <TrashIcon className="h-4 w-4" />
+                        <TrashIcon className="h-4 w-4" aria-hidden="true" />
                       </button>
                     )}
                   </div>
@@ -540,7 +540,6 @@ export default React.memo<NavProps>(
                     <option value="15">Last 15 records</option>
                   </select>
                 </div>
-
               </div>
             </div>
           </div>
@@ -590,7 +589,7 @@ export default React.memo<NavProps>(
                         aria-label="Close dialog"
                         title="Close dialog"
                       >
-                        <XMarkIcon className="h-6 w-6" />
+                        <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                       </button>
                     </Dialog.Title>
                     <div className="mt-2 prose prose-invert max-w-none overflow-y-auto">
@@ -615,11 +614,12 @@ export default React.memo<NavProps>(
                       >
                         {isCopied ? (
                           <>
-                            <CheckIcon className="h-5 w-5" /> Copied!
+                            <CheckIcon className="h-5 w-5" aria-hidden="true" /> Copied!
                           </>
                         ) : (
                           <>
-                            <ClipboardDocumentIcon className="h-5 w-5" /> Copy Analysis
+                            <ClipboardDocumentIcon className="h-5 w-5" aria-hidden="true" /> Copy
+                            Analysis
                           </>
                         )}
                       </button>

--- a/src/layout/PValue.tsx
+++ b/src/layout/PValue.tsx
@@ -115,13 +115,10 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                     aria-label="Close dialog"
                     title="Close dialog"
                   >
-                    <XMarkIcon className="h-6 w-6" />
+                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                   </button>
                 </Dialog.Title>
-                <div
-                  className="mt-2 text-sm whitespace-pre-wrap flex-1"
-                  style={{ fontSize: 14 }}
-                >
+                <div className="mt-2 text-sm whitespace-pre-wrap flex-1" style={{ fontSize: 14 }}>
                   {comparedSourceTarget && (
                     <div className="mb-4 font-bold text-base flex items-center justify-center bg-dark-bg p-3 rounded border border-gray-700">
                       <span className="text-blue-400">{comparedSourceTarget[0][0]}</span>
@@ -174,11 +171,12 @@ export default React.memo(({ comparedSourceTarget, onClose }: PValueProps) => {
                     >
                       {isCopied ? (
                         <>
-                          <CheckIcon className="h-5 w-5" /> Copied!
+                          <CheckIcon className="h-5 w-5" aria-hidden="true" /> Copied!
                         </>
                       ) : (
                         <>
-                          <ClipboardDocumentIcon className="h-5 w-5" /> Copy Analysis
+                          <ClipboardDocumentIcon className="h-5 w-5" aria-hidden="true" /> Copy
+                          Analysis
                         </>
                       )}
                     </button>

--- a/src/layout/SupplementCorrelation.tsx
+++ b/src/layout/SupplementCorrelation.tsx
@@ -204,9 +204,9 @@ const SupplementCorrelation = React.memo(
                           aria-live="polite"
                         >
                           {isCopied ? (
-                            <CheckIcon className="h-5 w-5 text-green-500" />
+                            <CheckIcon className="h-5 w-5 text-green-500" aria-hidden="true" />
                           ) : (
-                            <ClipboardDocumentIcon className="h-5 w-5" />
+                            <ClipboardDocumentIcon className="h-5 w-5" aria-hidden="true" />
                           )}
                         </button>
                       )}

--- a/src/layout/SupplementsPopover.tsx
+++ b/src/layout/SupplementsPopover.tsx
@@ -37,7 +37,7 @@ export default function SupplementsPopover({ supps, onSupplementClick }: Supplem
         title={`View ${supps.length} supplement${supps.length !== 1 ? 's' : ''} taken on this date`}
         className="w-full h-full cursor-pointer hover:bg-gray-800 hover:text-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded font-bold transition-colors flex justify-center items-center p-1"
       >
-        <BeakerIcon className="h-5 w-5" />
+        <BeakerIcon className="h-5 w-5" aria-hidden="true" />
       </PopoverButton>
       <PopoverPanel
         transition
@@ -60,7 +60,7 @@ export default function SupplementsPopover({ supps, onSupplementClick }: Supplem
                     title={`Correlate ${supp} with biomarkers`}
                     aria-label={`Correlate ${supp} with biomarkers`}
                   >
-                    <CalculatorIcon className="h-4 w-4" />
+                    <CalculatorIcon className="h-4 w-4" aria-hidden="true" />
                   </button>
                 )}
               </span>

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -188,9 +188,9 @@ const TableRow = React.memo(
                 aria-expanded={isExpanded}
               >
                 {isExpanded ? (
-                  <MinusIcon className="h-5 w-5" />
+                  <MinusIcon className="h-5 w-5" aria-hidden="true" />
                 ) : (
-                  <ChartBarIcon className="h-5 w-5" />
+                  <ChartBarIcon className="h-5 w-5" aria-hidden="true" />
                 )}
               </button>
               <button
@@ -209,7 +209,7 @@ const TableRow = React.memo(
                     : `Correlate ${name} with other biomarkers`
                 }
               >
-                <ArrowsRightLeftIcon className="h-5 w-5" />
+                <ArrowsRightLeftIcon className="h-5 w-5" aria-hidden="true" />
               </button>
               <button
                 type="button"
@@ -227,7 +227,7 @@ const TableRow = React.memo(
                     : `Correlate ${name} with supplements`
                 }
               >
-                <CalculatorIcon className="h-5 w-5" />
+                <CalculatorIcon className="h-5 w-5" aria-hidden="true" />
               </button>
             </div>
           </td>
@@ -736,9 +736,15 @@ export default React.memo(
                             title={`Toggle group ${row.original.displayTag}`}
                           >
                             {row.getIsExpanded() ? (
-                              <ChevronDownIcon className="h-4 w-4 text-gray-400" />
+                              <ChevronDownIcon
+                                className="h-4 w-4 text-gray-400"
+                                aria-hidden="true"
+                              />
                             ) : (
-                              <ChevronRightIcon className="h-4 w-4 text-gray-400" />
+                              <ChevronRightIcon
+                                className="h-4 w-4 text-gray-400"
+                                aria-hidden="true"
+                              />
                             )}
                             {row.original.displayTag} ({row.subRows.length})
                           </button>


### PR DESCRIPTION
🎨 Palette: Add `aria-hidden` to decorative icons in text buttons

💡 What: Added `aria-hidden="true"` to Heroicons (CheckIcon, ClipboardDocumentIcon, XMarkIcon, TrashIcon, ArrowLeftIcon, ChevronDownIcon, etc.) that are used alongside visible text within buttons.
🎯 Why: Prevents screen readers from incorrectly reading out decorative SVGs out of context when the button already has explicit text or an aria-label. This fixes double-announcements.
♿ Accessibility: Improved screen reader UX for dynamic copying, modals, sorting, and navigation toggle actions.

---
*PR created automatically by Jules for task [14893306651498578405](https://jules.google.com/task/14893306651498578405) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds aria-hidden="true" to decorative icons used alongside text in buttons to stop screen readers from reading icons. Improves accessibility for copy, close/back, expand/collapse, and correlate actions across dialogs, tables, and nav.

- **Bug Fixes**
  - Marked decorative `@heroicons/react` icons in text buttons with `aria-hidden="true"`.
  - Updated BiomarkerCorrelation, Correlation, PValue, GistViewer, Nav, Table, SupplementCorrelation, and SupplementsPopover.
  - Added accessibility guidance to `.Jules/palette.md`.

<sup>Written for commit 991927455f1dcaf587a09f4de2d81e098bb4ee60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

