### PR TITLE
fix: enforce dark theme constants on Chart2 regression styles

### DIFF
--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -44,7 +44,7 @@ const echartsOptions: any = {
     {
       show: true,
       type: 'value',
-      splitLine: { lineStyle: { color: '#E7EAEF', type: 'dashed', width: 1 } },
+      splitLine: { lineStyle: { color: '#3a3a3a80', type: 'dashed', width: 1 } },
     },
     {
       show: false,
@@ -131,7 +131,7 @@ const echartsOptions: any = {
           normal: {
             show: true,
             textStyle: {
-              color: '#333',
+              color: '#f0f0f0',
               fontSize: 14,
             },
           },


### PR DESCRIPTION
# Part 1 — Implementation Report

**The Issue:**
In `src/layout/Chart2.tsx` (lines 44-50 and 130-140), the regression chart styling contains hardcoded light-theme colors that severely violate the application's strict dark theme requirements, making elements unreadable against the `#111111` background. Specifically:
```tsx
  yAxis: [
    {
      show: true,
      type: 'value',
      splitLine: { lineStyle: { color: '#E7EAEF', type: 'dashed', width: 1 } },
    },
```
and
```tsx
      markPoint: {
        itemStyle: { normal: { color: 'transparent' } },
        label: {
          normal: {
            show: true,
            textStyle: {
              color: '#333',
              fontSize: 14,
            },
```

**Discovery Signal:**
Scan 7 — Visual Consistency. While all charts define `backgroundColor: 'transparent'` and `theme: "dark"`, `Chart2.tsx` explicitly hardcoded a light grey background line (`#E7EAEF`) and dark text (`#333`) for its regression annotations, violating the MyHealth theme constants.

**context7 Reference:**
Unable to verify via context7 directly due to network isolation/missing tool, but `yAxis.splitLine.lineStyle.color` and `series.markPoint.label.textStyle.color` are universally standard and stable properties in Apache ECharts 6.0.0 and already functionally present in the file under edit.

**The Fix:**
Changed `yAxis[0].splitLine.lineStyle.color` from `"#E7EAEF"` to the mandated MyHealth accent constant `"#3a3a3a80"`.
Changed `series[1].markPoint.label.normal.textStyle.color` from `"#333"` to the mandated MyHealth text constant `"#f0f0f0"`.

**The Benefit:**
Fixes severe contrast and readability issues in the regression grid layout. The visual design now explicitly respects the MyHealth dashboard's strict dark mode theme constraints.

**TypeScript result:**
`npx tsc --noEmit` output: 0 errors. E2E Playwright tests also passed cleanly for modified code paths.

---

# Part 2 — Proposals

**Proposal 1 of 5: System Group Range Status Parallel Coordinates**
**ECharts type:** `parallel`
**Codebase citation:** `extra.optimality[]` pre-computed by `src/processors/post/range.ts` and tag groups defined in `src/processors/post/tag.ts` (e.g. `2-Metabolic`).
**Which existing data it uses:** Iterates over `visibleDataAtom` (or specific `dataAtom` subset) based on `tagAtom`. Reads the latest time index value from `BioMarker[1]`, the bounds from `extra.range`, and uses the boolean array `extra.optimality[]`.
**What it reveals that current charts don't:** At a single point in time, it maps every biomarker within a specific physiological system (e.g., Kidney or Liver) as parallel axes. By coloring lines based on `extra.optimality`, users can instantly identify which specific members of a subsystem are drifting simultaneously at the most recent snapshot, giving an immediate multivariate snapshot impossible to see in 2D scatter plots.
**Where it would live:** New `src/layout/ParallelSystemChart.tsx`, embedded within `Table.tsx` headers or as a standalone top-level view.
**Trigger / entry point:** Activating a tag via `tagAtom` from `Nav.tsx` would switch the view.
**Implementation complexity:** Medium. ECharts parallel coordinates require custom min/max bounds alignment mapping the soft limits of `extra.range`.
**ECharts 6 API confirmed:** no / unavailable (ECharts `parallel` and `parallelAxis` are standard, but tool was inaccessible).

---

**Proposal 2 of 5: Daily Protocol Optmality Heatmap**
**ECharts type:** `heatmap`
**Codebase citation:** The pre-computed `extra.optimality[]` boolean array index-aligned with the `labels[]` from `src/data/index.ts`.
**Which existing data it uses:** Feeds the `visibleDataAtom` through an ECharts Cartesian heatmap where the Y-axis is biomarker display names (`BioMarker[0]`), the X-axis is `labels[]`, and the color mapping checks `extra.optimality[index]`.
**What it reveals that current charts don't:** Exposes chronological clusters of out-of-range biomarkers. Instead of looking at lines, a user can instantly see if a whole group of metrics (like `1-RBC` markers) turned "red" at a specific test date, potentially linking systemic stress to a lifestyle event without manual cross-referencing.
**Where it would live:** New `src/layout/OptimalityHeatmap.tsx` rendered alongside or above the main Table component.
**Trigger / entry point:** Rendered automatically whenever `visibleDataAtom` resolves (showing all visible filtered data).
**Implementation complexity:** Low. The data structure maps cleanly to `[xIndex, yIndex, value]` required by ECharts `heatmap` series.
**ECharts 6 API confirmed:** no / unavailable (ECharts `heatmap` is standard).

---

**Proposal 3 of 5: Protocol Consistency Gauge**
**ECharts type:** `gauge`
**Codebase citation:** `extra.optimality[]` from `src/processors/post/range.ts` combined with `nonInferredDataAtom`.
**Which existing data it uses:** Aggregates a ratio of `true` (out of range) to `false` (optimal) across all `nonInferredDataAtom` markers at the most recent time step (`labels.length - 1`).
**What it reveals that current charts don't:** Gives a single, immediate "Health Score" or "Optimality Ratio" summarizing the most recent blood panel in one glance, showing how close the entire system is to 100% optimal.
**Where it would live:** Integrated into `Nav.tsx` or a new dashboard header.
**Trigger / entry point:** Always visible, recalculates when global data changes.
**Implementation complexity:** Low. Straightforward percentage aggregation pushed into a single ECharts `gauge` series.
**ECharts 6 API confirmed:** no / unavailable (ECharts `gauge` is standard).

---

**Proposal 4 of 5: Biomarker Variance Boxplot**
**ECharts type:** `boxplot`
**Codebase citation:** Uses the raw numeric history array `BioMarker[1]` excluding nulls.
**Which existing data it uses:** Reads `BioMarker[1]` arrays directly from `visibleDataAtom` for up to 5-10 biomarkers simultaneously.
**What it reveals that current charts don't:** Visualizes the lifetime volatility of specific biomarkers (e.g. Glucose vs. TSH). While `LineChart` shows the path, a boxplot clearly identifies the median stabilization point and extreme outliers over the entire dataset history without time-axis clutter.
**Where it would live:** New `src/layout/VarianceBoxplot.tsx`, accessed via a new tab or expanded table row detail.
**Trigger / entry point:** Toggled via a new button near the "Show Chart" line controls.
**Implementation complexity:** High. Requires data transformation into `[min, Q1, median, Q3, max]` either manually or by importing the `echarts-stat` data processing transformer.
**ECharts 6 API confirmed:** no / unavailable (ECharts `boxplot` is standard).

---

**Proposal 5 of 5: Outlier Significance Bar + MarkLine**
**ECharts type:** `bar` + `markLine`
**Codebase citation:** Reads `extra.range` boundaries and the latest `BioMarker[1]` value from `src/processors/post/range.ts`.
**Which existing data it uses:** Filters `visibleDataAtom` for markers with `extra.range` defined. Normalizes the distance of the latest reading from the range's midpoint as a Z-score or percentage deviation.
**What it reveals that current charts don't:** Provides a ranked "Triage" view showing exactly which biomarkers are furthest away from their optimal center, prioritizing the user's attention. Instead of scrolling a table to find what's wrong, the largest bars immediately highlight the most severe deviations.
**Where it would live:** A dedicated "Deviations" modal or side-panel component.
**Trigger / entry point:** A new "Show Triage" action button.
**Implementation complexity:** Medium. Requires computing normalized deviation ratios to ensure markers with different units (e.g. 5 ng/mL vs 200 mg/dL) can be plotted on the same relative axis.
**ECharts 6 API confirmed:** no / unavailable (ECharts `bar` and `markLine` are standard).

---

Recommended implementation order: Proposal 2 first (highest insight, lowest effort), then 5, then 1, then 3, then 4.

---
*PR created automatically by Jules for task [6785621798300617604](https://jules.google.com/task/6785621798300617604) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces dark theme colors in the Chart2 regression chart to fix poor contrast on the dark dashboard background. Updated the Y-axis split line to #3a3a3a80 and the markPoint label text to #f0f0f0 for better readability.

<sup>Written for commit 021c0761fc885675359cc5ee07b8eb7370bb3dd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

