### PR TITLE
Fix weak typing for note aggregation in visualisations

### DIFF
--- a/src/layout/BiomarkerCorrelationBumpChart.tsx
+++ b/src/layout/BiomarkerCorrelationBumpChart.tsx
@@ -11,7 +11,7 @@ import { calculatePearson } from '../processors/stats'
 interface BumpChartProps {
   targetBiomarker: string
   correlations: CorrelationResult[]
-  noteValues: any[]
+  noteValues: NoteItem[]
 }
 
 export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartProps) => {

--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -200,7 +200,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
         const m2Score = (m2Optimal / m2Valid) * 100
 
         // Ensure we properly map notes depending on the type
-        const rawNote: any = noteValues[t]
+        const rawNote: NoteItem | undefined = noteValues[t]
         const supps =
           rawNote && rawNote.supps && rawNote.supps.length > 0 ? rawNote.supps.join(', ') : 'None'
 


### PR DESCRIPTION
**The Issue:**
`src/layout/SystemClustering.tsx` (line 203) and `src/layout/BiomarkerCorrelationBumpChart.tsx` (line 14) had weak type annotations using `any` for `noteValues` arrays and object references, causing a loss of type safety in the note aggregation loops.

**The Discovery Signal:**
Scan C (Weak or Missing Type Annotations) flagged:
- `src/layout/SystemClustering.tsx` line 203 — `const rawNote: any = noteValues[t]`
- `src/layout/BiomarkerCorrelationBumpChart.tsx` line 14 — `noteValues: any[]`

**The Fix:**
Replaced the `any` annotations with `NoteItem` (from `src/vite-env.d.ts`):
- `SystemClustering.tsx`: `const rawNote: NoteItem | undefined = noteValues[t]`
- `BiomarkerCorrelationBumpChart.tsx`: `noteValues: NoteItem[]`
No new imports were needed because `NoteItem` is declared in the global `vite-env.d.ts`.

**The Benefit:**
Eliminates unsafe `any` types while mapping over note items in the clustering and correlation visualizations. Helps ensure property access on notes (such as `.supps` and `.date`) are checked by the compiler, avoiding runtime errors when reading optional properties. Ensures the code adheres strictly to TypeScript without generating implicit `any` warnings or lint regressions.

---
*PR created automatically by Jules for task [3962528809958722304](https://jules.google.com/task/3962528809958722304) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced weak `any` types with `NoteItem` in note aggregation for `SystemClustering` and `BiomarkerCorrelationBumpChart` to improve type safety. This prevents unsafe property access on optional fields like `supps` and `date`.

- **Refactors**
  - `BiomarkerCorrelationBumpChart.tsx`: `noteValues: NoteItem[]`
  - `SystemClustering.tsx`: `const rawNote: NoteItem | undefined = noteValues[t]`
  - Uses global `NoteItem` from `vite-env.d.ts` (no new imports) and removes implicit `any` warnings.

<sup>Written for commit 69fced39cd5ca5cc1291942a65c9a7d52180877c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

