### PR TITLE
🎨 Palette: Add aria-busy to loading states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -310,7 +310,7 @@ export default function App() {
       <main id="main-content" tabIndex={-1}>
         <React.Suspense
           fallback={
-            <div className="flex flex-col items-center justify-center p-12 gap-3 text-gray-400">
+            <div className="flex flex-col items-center justify-center p-12 gap-3 text-gray-400" aria-busy="true">
               <Spinner />
               <span role="status" aria-live="polite">
                 Loading chart...

--- a/src/layout/GistViewer.tsx
+++ b/src/layout/GistViewer.tsx
@@ -149,6 +149,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
                       className="flex items-center justify-center h-32"
                       role="status"
                       aria-live="polite"
+                      aria-busy="true"
                     >
                       <Spinner /> <span className="ml-2 text-gray-400">Loading history...</span>
                     </div>

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -299,7 +299,7 @@ const TableRow = React.memo(
             <td colSpan={visibleLeafColumnsCount} className="border border-gray-700">
               <React.Suspense
                 fallback={
-                  <div className="p-8 flex flex-col items-center justify-center gap-3 text-gray-400">
+                  <div className="p-8 flex flex-col items-center justify-center gap-3 text-gray-400" aria-busy="true">
                     <Spinner />
                     <span role="status" aria-live="polite">
                       Loading charts...
@@ -646,7 +646,7 @@ export default React.memo(
     return (
       <React.Suspense
         fallback={
-          <div className="p-12 flex flex-col items-center justify-center gap-3 text-gray-400">
+          <div className="p-12 flex flex-col items-center justify-center gap-3 text-gray-400" aria-busy="true">
             <Spinner />
             <span role="status" aria-live="polite">
               Loading table...


### PR DESCRIPTION
💡 What: Added `aria-busy="true"` to `Suspense` fallback loading containers and `GistViewer` loading states.
🎯 Why: To properly communicate to screen readers that the component is in an active loading or updating state.
📸 Before/After: Not a visual change.
♿ Accessibility: Improves accessibility by making screen readers announce the loading states naturally.

---
*PR created automatically by Jules for task [101997824627624323](https://jules.google.com/task/101997824627624323) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `aria-busy="true"` to loading containers in `React.Suspense` fallbacks and `GistViewer` so screen readers announce active loading states. No visual changes; improves accessibility for assistive tech users.

<sup>Written for commit 36099d73afef9139762a4a9ac06e6d796af24777. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

