### PR TITLE
fix: resolve exhaustive-deps correctness warning in BiomarkerCorrelationBumpChart

### DIFF
--- a/src/layout/BiomarkerCorrelationBumpChart.tsx
+++ b/src/layout/BiomarkerCorrelationBumpChart.tsx
@@ -257,7 +257,7 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
       },
       series: series,
     }
-  }, [targetBiomarker, correlations, rankedDataMap])
+  }, [targetBiomarker, correlations, rankedDataMap, noteValues])
 
   if (Object.keys(options).length === 0) {
     return (


### PR DESCRIPTION
**The Issue:**
`src/layout/BiomarkerCorrelationBumpChart.tsx` at line 260. The `useMemo` hook creating the ECharts options omitted `noteValues` from its dependency array. This is a structural bug where the chart could potentially render stale data if the underlying supplement notes changed without the other dependencies updating.

**The Discovery Signal:**
Scan B: `src/layout/BiomarkerCorrelationBumpChart.tsx` line 52 — oxlint rule `react-hooks/exhaustive-deps` reports `React Hook useMemo has a missing dependency: 'noteValues'`.

**The Fix:**
Added `noteValues` to the `useMemo` dependency array at the end of the hook in `src/layout/BiomarkerCorrelationBumpChart.tsx`.

**The Benefit:**
Eliminated a silent runtime bug where the chart would fail to re-render when note data changed, ensuring reactive state consistency. It also reduces the noise in the `oxlint` output, bringing the codebase closer to a clean state.

---
*PR created automatically by Jules for task [13249727482981201157](https://jules.google.com/task/13249727482981201157) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stale render in `src/layout/BiomarkerCorrelationBumpChart.tsx` by adding the missing `noteValues` to the `useMemo` dependency array. The chart now updates when notes change and the oxlint `react-hooks/exhaustive-deps` warning is cleared.

<sup>Written for commit c120c61b7804cf109ea06eff711ecc820a3b621b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

