### PR TITLE
fix: add missing `noteValues` dependency in BiomarkerCorrelationBumpChart useMemo

### DIFF
--- a/src/layout/BiomarkerCorrelationBumpChart.tsx
+++ b/src/layout/BiomarkerCorrelationBumpChart.tsx
@@ -257,7 +257,7 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
       },
       series: series,
     }
-  }, [targetBiomarker, correlations, rankedDataMap])
+  }, [targetBiomarker, correlations, noteValues, rankedDataMap])
 
   if (Object.keys(options).length === 0) {
     return (


### PR DESCRIPTION
**The Issue:**
`src/layout/BiomarkerCorrelationBumpChart.tsx` lines 21-257 — The `useMemo` hook that computes the `options` object was using the `noteValues` prop (line 52) but failing to declare it in its dependency array. This is a structural correctness bug that can lead to stale closures, where the chart fails to re-render if `noteValues` change.

**The Discovery Signal:**
Scan B: `src/layout/BiomarkerCorrelationBumpChart.tsx` line 52 — oxlint rule `react-hooks(exhaustive-deps)` reports: `React Hook useMemo has a missing dependency: 'noteValues'`.

**The Fix:**
Added `noteValues` to the dependency array of the `useMemo` hook at line 257. No logic was altered.

**The Benefit:**
Eliminates a `correctness` level bug flagged by oxlint, preventing potential stale UI states when note data changes. This cleans up the `oxlint src/` output and adheres strictly to React's data-flow principles.

---
*PR created automatically by Jules for task [11511953007769046935](https://jules.google.com/task/11511953007769046935) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stale-render bug in the biomarker correlation bump chart by adding the missing `noteValues` dependency to the `useMemo` that builds `options`. The chart now updates correctly when note data changes.

<sup>Written for commit 30f1f893697b3cebc449d684f1ab6e2dd5abebc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

