### PR TITLE
🎨 Palette: [UX improvement] Fix nested interactive elements and empty states in Table Cells

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -50,3 +50,8 @@
 
 **Learning:** Generic icon components (like `@heroicons/react`) can cause redundant screen reader announcements if used decoratively without `aria-hidden="true"`.
 **Action:** Always add `aria-hidden="true"` to SVG/icon components that do not convey meaningful unique information (e.g., when wrapped in a button with a clear `aria-label`).
+
+## 2026-05-24 - Avoiding Nested Interactive Elements in Data Cells
+
+**Learning:** Data table cells (`<td>`) that map to diverse data types often mistakenly apply global interactive attributes (like `role="button"` or `tabIndex=0` for a "click-to-copy" feature) even when the inner content is already interactive (like an `<a>` tag for an external URL). This creates a "nested interactive element" accessibility violation, confusing screen readers.
+**Action:** When a table cell renders an interactive element (like a link), conditionally strip the outer `<td>` of its interactive ARIA roles, keyboard focus attributes, and click handlers, delegating interaction entirely to the inner element. Additionally, if the cell is completely empty, it should simply return a semantic `<td>` with no interactive attributes whatsoever.

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -70,26 +70,33 @@ const DataCell = React.memo(
       setTimeout(() => setCopied(false), 1500)
     }, [onCopy, rawValue])
 
+    if (displayValue === null || displayValue === undefined || displayValue === '') {
+      return <td className={className}></td>
+    }
+
     const isUrlUnit =
       typeof unit === 'object' && unit !== null && 'url' in unit && typeof unit.url === 'string'
-    const content = isUrlUnit ? (
-      <a
-        href={isUrlUnit ? (unit as { url: string }).url : ''}
-        target="_blank"
-        rel="noreferrer"
-        className="text-blue-400 hover:underline"
-      >
-        {displayValue}
-      </a>
-    ) : (
-      displayValue
-    )
+
+    if (isUrlUnit) {
+      return (
+        <td className={className}>
+          <a
+            href={(unit as { url: string }).url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm"
+          >
+            {displayValue}
+          </a>
+        </td>
+      )
+    }
 
     return (
       <td
         className={cn(
           className,
-          'relative group focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm',
+          'relative group focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm hover:bg-gray-600/30 transition-colors',
         )}
         onClick={handleInteraction}
         tabIndex={0}
@@ -107,7 +114,7 @@ const DataCell = React.memo(
         }
         title="Copy to clipboard"
       >
-        {content}
+        {displayValue}
         {copied && (
           <span
             className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-1 px-2 py-1 text-xs text-white bg-blue-600 rounded shadow-lg z-50 animate-fade-in-out pointer-events-none whitespace-nowrap"
@@ -299,7 +306,10 @@ const TableRow = React.memo(
             <td colSpan={visibleLeafColumnsCount} className="border border-gray-700">
               <React.Suspense
                 fallback={
-                  <div className="p-8 flex flex-col items-center justify-center gap-3 text-gray-400" aria-busy="true">
+                  <div
+                    className="p-8 flex flex-col items-center justify-center gap-3 text-gray-400"
+                    aria-busy="true"
+                  >
                     <Spinner />
                     <span role="status" aria-live="polite">
                       Loading charts...
@@ -649,7 +659,10 @@ export default React.memo(
     return (
       <React.Suspense
         fallback={
-          <div className="p-12 flex flex-col items-center justify-center gap-3 text-gray-400" aria-busy="true">
+          <div
+            className="p-12 flex flex-col items-center justify-center gap-3 text-gray-400"
+            aria-busy="true"
+          >
             <Spinner />
             <span role="status" aria-live="polite">
               Loading table...


### PR DESCRIPTION
💡 What:
- Updated the `DataCell` component to return a clean, non-interactive `<td>` when the `displayValue` is empty (`null`, `undefined`, or `''`).
- Conditionally removed global interactive attributes (like `role="button"`, `tabIndex`, and keyboard handlers) when the cell renders an external URL (`isUrlUnit`), delegating interaction solely to the inner `<a>` element.
- Added a subtle hover state (`hover:bg-gray-600/30 transition-colors`) to copyable cells for better visual feedback.

🎯 Why:
- Previous behavior rendered interactive attributes on empty cells, confusing screen readers.
- Placing an interactive `<a>` element inside a `<td>` with `role="button"` creates a severe nested interactive element accessibility violation.
- It was visually unclear to sighted users that non-link data cells could be clicked to copy.

♿ Accessibility:
- Prevented screen reader double-announcements and nested interaction confusion.
- Ensured empty states are semantically inert.

---
*PR created automatically by Jules for task [12509734169924485804](https://jules.google.com/task/12509734169924485804) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `DataCell` to avoid nested interactive elements and ensure empty cells are inert, improving accessibility and clarity. Adds a subtle hover background for copyable cells.

- **Bug Fixes**
  - Empty `displayValue` now renders a plain, non-interactive td.
  - For URL units, removed outer `role`, `tabIndex`, and keyboard/click handlers; interaction is delegated to the inner link with proper focus styles.
  - Added a light hover state to copyable cells for clearer visual feedback.

<sup>Written for commit 22ffd4e12fb83173de19ad568f8c0cfebc86b70d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

