### PR TITLE
fix: resolve missing dependencies in Nav.tsx

### DIFF
--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -205,7 +205,7 @@ export default React.memo<NavProps>(
       } finally {
         setIsAsking(false)
       }
-    }, [selected, data, filterTag, key, model, fullData, nonInferredData])
+    }, [selected, data, filterTag, key, model, fullData, nonInferredData, rankedDataMap])
 
     const [canvasText, setCanvasText] = React.useState<string | null>(null)
     const [gistUrl, setGistUrl] = React.useState<string | null>(null)
@@ -229,7 +229,7 @@ export default React.memo<NavProps>(
 
     const onAverageCount = React.useCallback(
       (e: React.ChangeEvent<HTMLSelectElement>) => setAverageCount(e.target.value),
-      [],
+      [setAverageCount],
     )
     return (
       <>


### PR DESCRIPTION
Resolves missing dependency violations in `src/layout/Nav.tsx`.

Added `rankedDataMap` and `setAverageCount` to their respective `useCallback` dependency arrays, ensuring up-to-date closures.

Validated against `oxlint`, `tsc`, and playwright tests.

---
*PR created automatically by Jules for task [3895882238686060986](https://jules.google.com/task/3895882238686060986) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix missing `useCallback` dependencies in `src/layout/Nav.tsx` to prevent stale closures and clear `react-hooks/exhaustive-deps` warnings.

- **Bug Fixes**
  - Added `rankedDataMap` to the ask handler’s `useCallback` deps.
  - Added `setAverageCount` to the average count handler’s `useCallback` deps.
  - Verified with `oxlint`, `tsc`, and `Playwright` tests.

<sup>Written for commit 8459871c8c2c24d8f4bb753c94aa34d394415126. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

