### PR TITLE
🛠️ Code Quality: Fix exhaustive-deps in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,17 +73,17 @@ export default function App() {
 
   const onAiKeyChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => setAiKey(e.target.value),
-    [],
+    [setAiKey],
   )
 
   const onAiModelChange = React.useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => setAiModel(e.target.value),
-    [],
+    [setAiModel],
   )
 
   const onGistTokenChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => setGistToken(e.target.value),
-    [],
+    [setGistToken],
   )
 
   const onFilterByTag = React.useCallback(


### PR DESCRIPTION
**The Issue:**
`src/App.tsx` (lines 74-86) triggered linting warnings because `React.useCallback` hooks omitted their state setter dependencies. While Jotai setters are referentially stable, structural lint rules expect them to be declared.

**The Discovery Signal:**
Scan B (oxlint):
```
! react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'setAiKey'
,-[src/App.tsx:76:5]
! react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'setAiModel'
,-[src/App.tsx:81:5]
! react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'setGistToken'
,-[src/App.tsx:86:5]
```

**The Fix:**
Updated the `useCallback` dependency arrays in `src/App.tsx` for `onAiKeyChange`, `onAiModelChange`, and `onGistTokenChange` to correctly include `setAiKey`, `setAiModel`, and `setGistToken`, respectively.

**The Benefit:**
Resolves the top-priority `correctness` warning reported by `oxlint`, maintaining strict adherence to React Hook rules without relying on inline suppression comments or changing runtime behavior.

---
*PR created automatically by Jules for task [3799098121077915016](https://jules.google.com/task/3799098121077915016) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed `react-hooks/exhaustive-deps` warnings in `src/App.tsx` by adding missing state setters to `useCallback` dependency arrays. Updated `onAiKeyChange`, `onAiModelChange`, and `onGistTokenChange` to include `setAiKey`, `setAiModel`, and `setGistToken`, removing lint noise without changing behavior.

<sup>Written for commit eb95a8b6de2885a9e7623bb437c8f8bcf8844d0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

