### PR TITLE
fix: remove unused dependency from navProps useMemo in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -225,7 +225,6 @@ export default function App() {
       onClearSelection,
       searchText,
       filterTag,
-      showOrigColumns,
       showRecords,
       onShowRecordsChange,
       onTextChange,


### PR DESCRIPTION
**The Issue:**
`src/App.tsx` line 228 — The `showOrigColumns` state variable was included in the dependency array of the `useMemo` hook that constructs `navProps`, even though it is not referenced inside the factory function. This is a structural linting violation and causes unnecessary recalculation.

**The Discovery Signal:**
Scan B: `src/App.tsx` line 220 — oxlint rule `correctness/exhaustive-deps` reported `React Hook useMemo has unnecessary dependency: showOrigColumns`.

**The Fix:**
Removed `showOrigColumns` from the dependency array of the `navProps` `useMemo` hook in `src/App.tsx`.

**The Benefit:**
Eliminates a noisy `oxlint` error, preventing potential confusion. It also slightly optimizes render performance by preventing `navProps` from being needlessly re-calculated when `showOrigColumns` changes, since that state does not impact the returned props object.

---
*PR created automatically by Jules for task [16187405915103573901](https://jules.google.com/task/16187405915103573901) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused dependency `showOrigColumns` from the `useMemo` that builds `navProps` in `src/App.tsx`, fixing an `oxlint` exhaustive-deps warning and avoiding unnecessary recalculation when `showOrigColumns` changes.

<sup>Written for commit 38499bff7d8167a8683ce32cfef01db12d3ff3db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

