### PR TITLE
🎨 Palette: Expand clickable target area for table header checkbox

### DIFF
--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -401,10 +401,12 @@ const columns: ColumnDef<DisplayedEntry, any>[] = [
   }),
   columnHelper.accessor('unit', {
     header: ({ table }) => (
-      <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
-        <label htmlFor="toggle-origin" className="cursor-pointer">
-          Unit
-        </label>
+      <label
+        htmlFor="toggle-origin"
+        className="flex items-center gap-2 cursor-pointer"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <span>Unit</span>
         <div className="flex items-center gap-1.5 ml-1">
           <input
             id="toggle-origin"
@@ -420,7 +422,7 @@ const columns: ColumnDef<DisplayedEntry, any>[] = [
             }}
           />
         </div>
-      </div>
+      </label>
     ),
     meta: {
       ref: true,


### PR DESCRIPTION
💡 **What**: Refactored the `Unit` table header toggle in `Table.tsx` to wrap both the descriptive text and the `<input type="checkbox">` inside a unified `<label htmlFor="toggle-origin">` element. Added a UX learning entry to `.Jules/palette.md`.
🎯 **Why**: Previously, the checkbox and its label text ("Unit") were siblings inside a `<div onClick={(e) => e.stopPropagation()}>`. Clicking the wrapper div did not toggle the checkbox. Relying solely on the small checkbox or the exact text reduced the hit area, creating a subpar experience. By wrapping the entire flex container in a single `<label>`, any click within that area natively activates the input.
📸 **Before/After**: Visually identical, but the interactive area is now significantly larger. (See frontend verification screenshots).
♿ **Accessibility**: Expanded the hit area makes interaction easier for all users, particularly those with motor control issues or visual impairments who rely on larger target areas.

Also updated `.Jules/palette.md` to log this specific pattern for future standalone checkboxes.

---
*PR created automatically by Jules for task [8868685596690130602](https://jules.google.com/task/8868685596690130602) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the clickable target for the “Unit” table header checkbox by wrapping the text and input in a single label (`htmlFor="toggle-origin"`), so clicks anywhere in that header toggle the checkbox and improve accessibility.

<sup>Written for commit dff84f769a95f75be6ee5d0e0b636f2e0f48c865. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/344?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

