### PR TITLE
🎨 Palette: Enhance Suspense fallbacks with wrapper-level ARIA attributes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -127,3 +127,6 @@
 
 **Learning:** Decorative icons (like `<CheckIcon />` or `<MinusIcon />` from `@heroicons/react`) placed inside buttons that already have an explicit `aria-label` or `title` can cause double announcements by screen readers. While `<Spinner />` had `aria-hidden="true"`, many other action-button icons in components like `Table.tsx` and `Correlation.tsx` were missing this attribute.
 **Action:** Always add `aria-hidden="true"` to generic/decorative SVGs when they are placed alongside explicit descriptive text or when wrapped in interactive elements with a clear `aria-label`.
+## 2026-05-17 - Suspense Loading Fallbacks
+**Learning:** When using loading states like React Suspense fallbacks that contain both text and a generic spinner icon, applying `aria-live="polite"` and `role="status"` to the container wrapper alongside `aria-busy="true"` improves screen reader announcements instead of isolating the announcement to a single inner span while leaving the spinner and container attributes unassociated.
+**Action:** Always group loading indicators and their descriptive text holistically at the container level by putting `aria-busy`, `role="status"`, and `aria-live` on the wrapper element to provide clear, unified context to assistive technologies.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -309,11 +309,14 @@ export default function App() {
       <main id="main-content" tabIndex={-1}>
         <React.Suspense
           fallback={
-            <div className="flex flex-col items-center justify-center p-12 gap-3 text-gray-400" aria-busy="true">
+            <div
+              className="flex flex-col items-center justify-center p-12 gap-3 text-gray-400"
+              aria-busy="true"
+              role="status"
+              aria-live="polite"
+            >
               <Spinner />
-              <span role="status" aria-live="polite">
-                Loading chart...
-              </span>
+              <span>Loading chart...</span>
             </div>
           }
         >

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -309,11 +309,11 @@ const TableRow = React.memo(
                   <div
                     className="p-8 flex flex-col items-center justify-center gap-3 text-gray-400"
                     aria-busy="true"
+                    role="status"
+                    aria-live="polite"
                   >
                     <Spinner />
-                    <span role="status" aria-live="polite">
-                      Loading charts...
-                    </span>
+                    <span>Loading charts...</span>
                   </div>
                 }
               >
@@ -664,11 +664,11 @@ export default React.memo(
           <div
             className="p-12 flex flex-col items-center justify-center gap-3 text-gray-400"
             aria-busy="true"
+            role="status"
+            aria-live="polite"
           >
             <Spinner />
-            <span role="status" aria-live="polite">
-              Loading table...
-            </span>
+            <span>Loading table...</span>
           </div>
         }
       >


### PR DESCRIPTION
💡 **What**
Moved `role="status"` and `aria-live="polite"` from the isolated inner `<span>` to the wrapper `<div>` containing `aria-busy="true"` in Suspense loading fallbacks across `src/App.tsx` and `src/layout/Table.tsx`.

🎯 **Why**
When `aria-busy`, `role="status"`, and `aria-live` are applied across disparate parent and child elements, screen readers may announce the text inconsistently or miss the fact that the entire block is the loading status container. Grouping these semantic attributes holistically at the wrapper level ensures consistent and correct announcements by assistive technologies.

📸 **Before/After**
*Visuals remain identical since this is purely a semantic HTML/ARIA accessibility fix.*

♿ **Accessibility**
Improves screen reader interpretation of Suspense fallbacks by unifying `aria-busy`, `role="status"`, and `aria-live` at the wrapper container level, ensuring clear and complete context.

---
*PR created automatically by Jules for task [17926633456644112488](https://jules.google.com/task/17926633456644112488) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved accessibility of Suspense loading fallbacks by moving role="status" and aria-live="polite" to the wrapper div that already has aria-busy="true" in src/App.tsx and src/layout/Table.tsx. Screen readers now announce the entire loading block consistently; visuals unchanged.

<sup>Written for commit d2e83f210081ef6382923663f5f421d2c2ce247a. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/345?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

