### PR TITLE
Fix react-hooks/exhaustive-deps violation in SystemClustering.tsx

### DIFF
--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -280,7 +280,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
         },
       ],
     }
-  }, [data, noteValues, xAxisTag, yAxisTag, availableTags])
+  }, [data, noteValues, xAxisTag, yAxisTag])
 
   return (
     <Transition appear show={isOpen} as={Fragment}>


### PR DESCRIPTION
**The Issue:**
`src/layout/SystemClustering.tsx` line 283 contained an unnecessary dependency (`availableTags`) in the dependency array of a `useMemo` hook, causing a structural React Hook correctness violation.

**The Discovery Signal:**
Scan B: `src/layout/SystemClustering.tsx` line 283 — oxlint rule `correctness/exhaustive-deps` reported `React Hook useMemo has unnecessary dependency: availableTags`.

**The Fix:**
Removed `availableTags` from the `useMemo` dependency array on line 283, as it was not used within the hook's callback.

**The Benefit:**
Eliminates a potentially problematic structural linting violation, leading to a cleaner build output without using any suppression comments and avoiding unnecessary React renders.

---
*PR created automatically by Jules for task [5703574482319608643](https://jules.google.com/task/5703574482319608643) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a react-hooks/exhaustive-deps violation in `src/layout/SystemClustering.tsx` by removing the unused `availableTags` from a `useMemo` dependency array. This avoids unnecessary re-computes and keeps lint output clean.

<sup>Written for commit 22fa8e52d979aefc61d3c06fd698ec22829d6bf7. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/346?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

