### PR TITLE
Fix chart bug

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -152,6 +152,8 @@ export default memo(({ keys }: ChartProps) => {
     ref.current = node
     if (node) {
       setIsChartReady(true)
+    } else {
+      setIsChartReady(false)
     }
   }, [])
 


### PR DESCRIPTION
Fix chart bug in Chart.tsx.

---
*PR created automatically by Jules for task [1361243307352380947](https://jules.google.com/task/1361243307352380947) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a bug where the chart stayed “ready” after unmount. The ref callback in `src/layout/Chart.tsx` now sets isChartReady to false when the node is null, preventing stale state and rendering glitches.

<sup>Written for commit c9a5ef67d90a53f6a25ad98a68b87a5acfffb5d9. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/347?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

