### PR TITLE
🎨 Palette: Accessible loading states for lazy-loaded modals

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -130,3 +130,8 @@
 ## 2026-05-17 - Suspense Loading Fallbacks
 **Learning:** When using loading states like React Suspense fallbacks that contain both text and a generic spinner icon, applying `aria-live="polite"` and `role="status"` to the container wrapper alongside `aria-busy="true"` improves screen reader announcements instead of isolating the announcement to a single inner span while leaving the spinner and container attributes unassociated.
 **Action:** Always group loading indicators and their descriptive text holistically at the container level by putting `aria-busy`, `role="status"`, and `aria-live` on the wrapper element to provide clear, unified context to assistive technologies.
+
+## 2026-12-18 - Jarring Modals and Suspense Overlays
+
+**Learning:** When using `React.Suspense` for lazy-loaded modals, utilizing a full-screen, semi-transparent background overlay as the fallback loading state causes a jarring screen flash for the user because the loading state often appears for only a fraction of a second.
+**Action:** Always use a subtle, localized loading indicator (e.g., a floating bottom-right notification) instead of a full-screen overlay for `React.Suspense` fallbacks on modals. This ensures an accessible loading state is communicated to screen readers (via `aria-busy="true"`, `role="status"`, `aria-live="polite"`) without causing visual disruption.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -297,7 +297,19 @@ export default function App() {
         </div>
       </React.Suspense>
       <Nav {...navProps} />
-      <React.Suspense fallback={null}>
+      <React.Suspense
+        fallback={
+          <div
+            className="fixed bottom-4 right-4 z-50 flex items-center justify-center px-4 py-3 bg-gray-800 text-gray-300 rounded-md shadow-xl border border-gray-700 gap-3 animate-pulse"
+            aria-busy="true"
+            role="status"
+            aria-live="polite"
+          >
+            <Spinner />
+            <span className="text-sm font-medium">Loading module...</span>
+          </div>
+        }
+      >
         <PValue comparedSourceTarget={comparedSourceTarget} onClose={onPValueClose} />
         <Correlation target={corrlationKey} onClose={onCorrelationClose} />
         <SupplementCorrelation

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -545,7 +545,19 @@ export default React.memo<NavProps>(
           </div>
         </nav>
 
-        <React.Suspense fallback={null}>
+        <React.Suspense
+          fallback={
+            <div
+              className="fixed bottom-4 right-4 z-50 flex items-center justify-center px-4 py-3 bg-gray-800 text-gray-300 rounded-md shadow-xl border border-gray-700 gap-3 animate-pulse"
+              aria-busy="true"
+              role="status"
+              aria-live="polite"
+            >
+              <Spinner />
+              <span className="text-sm font-medium">Loading module...</span>
+            </div>
+          }
+        >
           {hasGistViewerMounted && (
             <GistViewer isOpen={isGistViewerOpen} onClose={() => setIsGistViewerOpen(false)} />
           )}


### PR DESCRIPTION
💡 **What**: Added an accessible, non-intrusive `React.Suspense` fallback for lazy-loaded modals (`PValue`, `Correlation`, `SystemClustering`, `GistViewer`).
🎯 **Why**: Previously, these lazy-loaded modals used `fallback={null}`, meaning screen reader users received no auditory feedback that a chunk was downloading after clicking a button. The new approach provides an accessible loading indicator via a subtle bottom-right toast-style notification, avoiding jarring full-screen flashes.
♿ **Accessibility**: Added `aria-busy="true"`, `role="status"`, and `aria-live="polite"` directly to the Suspense loading container alongside an `aria-hidden` `<Spinner />` to perfectly sync state announcements.

---
*PR created automatically by Jules for task [14011966192310923823](https://jules.google.com/task/14011966192310923823) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an accessible, non-intrusive `React.Suspense` loading fallback for lazy-loaded modals. Screen reader users now get polite loading feedback without a full-screen flash.

- **New Features**
  - Replaced `fallback={null}` with a subtle bottom-right toast showing a spinner and “Loading module…”.
  - Added `aria-busy="true"`, `role="status"`, and `aria-live="polite"` on the fallback container for proper announcements.
  - Applied to `PValue`, `Correlation`, `SupplementCorrelation`, and `GistViewer` modals.

<sup>Written for commit e597c2935ec24c492476a1cf6210584135eeca7a. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/350?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

