### PR TITLE
🎨 Palette: Inferred vs Measured Value Divergence Line Chart

### DIFF
--- a/src/layout/InferredValidationChart.tsx
+++ b/src/layout/InferredValidationChart.tsx
@@ -1,0 +1,131 @@
+import React, { memo, useMemo } from 'react'
+import ReactECharts from 'echarts-for-react'
+import { labels, formattedLabels } from '../data'
+import { CHART_PALETTE } from './Chart2'
+
+interface InferredValidationChartProps {
+  name: string
+  values: number[]
+  originValues?: (string | number | null)[]
+}
+
+const echartsOptions = {
+  style: { height: 350, width: '100%' },
+  theme: 'dark',
+  backgroundColor: 'transparent',
+  color: [CHART_PALETTE[0], CHART_PALETTE[1]], // primary and secondary colors
+  animation: false,
+  tooltip: {
+    trigger: 'axis',
+    backgroundColor: '#111111',
+    borderColor: '#3a3a3a80',
+    textStyle: {
+      color: '#f0f0f0',
+    },
+    formatter: (params: any) => {
+      let result = ''
+      for (const p of params) {
+        if (
+          !p ||
+          p.value[1] === '-' ||
+          p.value[1] === '' ||
+          p.value[1] === 'NaN' ||
+          p.value[1] === null ||
+          p.value[1] === undefined ||
+          Number.isNaN(p.value[1])
+        ) {
+          continue
+        }
+        if (!result) result = `${p.value[0]}<br/>`
+        result += `${p.marker} ${p.seriesName}: <strong>${p.value[1]}</strong><br/>`
+      }
+      return result
+    },
+  },
+  grid: {
+    left: '3%',
+    right: '4%',
+    bottom: '3%',
+    containLabel: true,
+  },
+  legend: {
+    data: ['Inferred (Formula)', 'Measured (Raw)'],
+    textStyle: {
+      color: '#ccc',
+    },
+  },
+  xAxis: {
+    type: 'time',
+    boundaryGap: false,
+  },
+  yAxis: {
+    type: 'value',
+    scale: true,
+  },
+}
+
+export default memo(({ name, values, originValues }: InferredValidationChartProps) => {
+  const [inferredData, measuredData] = useMemo(() => {
+    const numLabels = labels.length
+    const inferred = Array<[string, number | string]>(numLabels)
+    const measured = Array<[string, number | string]>(numLabels)
+
+    for (let i = 0; i < numLabels; i++) {
+      const val = values[i]
+      const originVal = originValues?.[i]
+
+      inferred[i] = [formattedLabels[i], val !== null && val !== undefined ? val : '-']
+
+      let finalOriginVal: number | string = '-'
+      if (originVal !== null && originVal !== undefined) {
+        const parsed = typeof originVal === 'string' ? parseFloat(originVal.replace(/[^0-9.-]/g, '')) : originVal
+        if (!Number.isNaN(parsed)) {
+          finalOriginVal = parsed
+        }
+      }
+      measured[i] = [formattedLabels[i], finalOriginVal]
+    }
+
+    return [inferred, measured]
+  }, [values, originValues])
+
+  const options = useMemo(() => {
+    return {
+      ...echartsOptions,
+      title: {
+        text: `${name} Divergence: Measured vs Inferred`,
+        left: 'center',
+        textStyle: {
+          color: '#ccc',
+        },
+      },
+      series: [
+        {
+          name: 'Inferred (Formula)',
+          type: 'line',
+          data: inferredData,
+          smooth: true,
+          symbol: 'circle',
+          symbolSize: 6,
+          lineStyle: {
+            width: 3,
+            type: 'dashed'
+          }
+        },
+        {
+          name: 'Measured (Raw)',
+          type: 'line',
+          data: measuredData,
+          smooth: true,
+          symbol: 'circle',
+          symbolSize: 6,
+          lineStyle: {
+            width: 3
+          }
+        },
+      ],
+    }
+  }, [name, inferredData, measuredData])
+
+  return <ReactECharts option={options} style={echartsOptions.style} notMerge={true} theme="dark" />
+})

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -38,6 +38,7 @@ import { Spinner } from './Spinner'
 const LineChart = React.lazy(() => import('./LineChart'))
 const BoxplotChart = React.lazy(() => import('./BoxplotChart'))
 const HistogramChart = React.lazy(() => import('./HistogramChart'))
+const InferredValidationChart = React.lazy(() => import('./InferredValidationChart'))
 
 const columnHelper = createColumnHelper<DisplayedEntry>()
 
@@ -326,6 +327,15 @@ const TableRow = React.memo(
                   <BoxplotChart name={name} values={values} />
                   <HistogramChart name={name} values={values} />
                 </div>
+                {extra.inferred && (
+                  <div className="p-3 w-full">
+                    <InferredValidationChart
+                      name={name}
+                      values={values}
+                      originValues={extra.originValues}
+                    />
+                  </div>
+                )}
               </React.Suspense>
             </td>
           </tr>


### PR DESCRIPTION
Creates a new `InferredValidationChart` and renders it beneath the normal chart grid in `Table.tsx` for rows with `extra.inferred === true`. It receives `values` and `extra.originValues` from the `BioMarker` tuple and displays them as a dual-series EChart using `scale: true`.

---
*PR created automatically by Jules for task [10458722186017015701](https://jules.google.com/task/10458722186017015701) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a divergence line chart that compares inferred vs measured biomarker values, rendered under rows flagged as inferred. This helps validate inference quality over time with a clear dual-series view.

- **New Features**
  - New `InferredValidationChart` showing Inferred (Formula) vs Measured (Raw) as smoothed lines (inferred dashed).
  - Rendered in `Table.tsx` only when `extra.inferred === true`, using `values` and `extra.originValues`.
  - Time x-axis with existing labels; scaled y-axis; tooltip skips invalid points; parses numeric values from strings.
  - Lazy-loaded to avoid impacting initial render.

<sup>Written for commit 100b1e9abc9f2e74d05b781099f866efcb0015fd. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/351?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

