### PR TITLE
Extract BumpChartProps to dedicated types file

### DIFF
--- a/src/layout/BiomarkerCorrelationBumpChart.tsx
+++ b/src/layout/BiomarkerCorrelationBumpChart.tsx
@@ -5,14 +5,8 @@ import { rankedDataMapAtom } from '../atom/dataAtom'
 import { correlationMethodAtom } from '../atom/correlationAtom'
 import { CHART_PALETTE } from './Chart2'
 import { formattedLabels } from '../data'
-import { CorrelationResult } from './BiomarkerCorrelation.types'
+import { BumpChartProps } from './BiomarkerCorrelationBumpChart.types'
 import { calculatePearson } from '../processors/stats'
-
-interface BumpChartProps {
-  targetBiomarker: string
-  correlations: CorrelationResult[]
-  noteValues: NoteItem[]
-}
 
 export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartProps) => {
   const rankedDataMap = useAtomValue(rankedDataMapAtom)

--- a/src/layout/BiomarkerCorrelationBumpChart.types.ts
+++ b/src/layout/BiomarkerCorrelationBumpChart.types.ts
@@ -1,0 +1,7 @@
+import { CorrelationResult } from './BiomarkerCorrelation.types'
+
+export interface BumpChartProps {
+  targetBiomarker: string
+  correlations: CorrelationResult[]
+  noteValues: NoteItem[]
+}


### PR DESCRIPTION
**The Issue:**
`src/layout/BiomarkerCorrelationBumpChart.tsx` at line 11 contained an inline `interface BumpChartProps` which broke the established structural convention of separating component types into sibling `.types.ts` files.

**The Discovery Signal:**
Scan A found that several files had misplaced shared types, with `BiomarkerCorrelationBumpChart.tsx` being one of the more prominent components needing correction.

**The Fix:**
I extracted `BumpChartProps` to a newly created file `src/layout/BiomarkerCorrelationBumpChart.types.ts`, and updated `src/layout/BiomarkerCorrelationBumpChart.tsx` to import the interface instead.

**The Benefit:**
This improves maintainability and consistency by enforcing the rule that "components with complex props have a sibling `.types.ts` file", reducing the surface area for confusion and keeping component files focused on implementation.

---
*PR created automatically by Jules for task [13460131461579983266](https://jules.google.com/task/13460131461579983266) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the inline `BumpChartProps` from `src/layout/BiomarkerCorrelationBumpChart.tsx` into `src/layout/BiomarkerCorrelationBumpChart.types.ts` to match our sibling `.types.ts` pattern and keep the component focused. No runtime changes; this is a type organization cleanup.

<sup>Written for commit 2e35bf49b22e0304c61e44e1d07c3725e74e513c. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/354?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

