### PR TITLE
feat: Add Biomarker Correlation Network Graph

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -138,3 +138,6 @@
 ## 2024-05-20 - Correlation Network Graph Edges
 **Learning:** Dense correlation network graphs in ECharts can render edges weirdly (as chunky polygons instead of distinct lines) if thickness scales excessively and `type: 'solid'` is omitted on curved connections.
 **Action:** When visualizing network edges mapping to weight/value, explicitly set `lineStyle.type: 'solid'`, increase `force.repulsion`, and constrain edge widths (e.g. `0.5 + Math.pow(rho, 2) * 2`) to ensure visually clean distinct paths rather than massive overlapping visual artifacts.
+## 2024-05-20 - Correlation Network Node Spacing
+**Learning:** ECharts force graph nodes tend to cluster tightly in the center if default settings are used, creating tangles.
+**Action:** When working with ECharts force layouts, use a combination of low `gravity` (e.g. 0.05), high range arrays for `repulsion` (e.g. `[3000, 5000]`), and `initLayout: 'circular'` combined with `layoutAnimation: true` to help ECharts evenly distribute the nodes before the physics simulation settles.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -135,3 +135,6 @@
 
 **Learning:** When using `React.Suspense` for lazy-loaded modals, utilizing a full-screen, semi-transparent background overlay as the fallback loading state causes a jarring screen flash for the user because the loading state often appears for only a fraction of a second.
 **Action:** Always use a subtle, localized loading indicator (e.g., a floating bottom-right notification) instead of a full-screen overlay for `React.Suspense` fallbacks on modals. This ensures an accessible loading state is communicated to screen readers (via `aria-busy="true"`, `role="status"`, `aria-live="polite"`) without causing visual disruption.
+## 2024-05-20 - Correlation Network Graph Edges
+**Learning:** Dense correlation network graphs in ECharts can render edges weirdly (as chunky polygons instead of distinct lines) if thickness scales excessively and `type: 'solid'` is omitted on curved connections.
+**Action:** When visualizing network edges mapping to weight/value, explicitly set `lineStyle.type: 'solid'`, increase `force.repulsion`, and constrain edge widths (e.g. `0.5 + Math.pow(rho, 2) * 2`) to ensure visually clean distinct paths rather than massive overlapping visual artifacts.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -141,3 +141,6 @@
 ## 2024-05-20 - Correlation Network Node Spacing
 **Learning:** ECharts force graph nodes tend to cluster tightly in the center if default settings are used, creating tangles.
 **Action:** When working with ECharts force layouts, use a combination of low `gravity` (e.g. 0.05), high range arrays for `repulsion` (e.g. `[3000, 5000]`), and `initLayout: 'circular'` combined with `layoutAnimation: true` to help ECharts evenly distribute the nodes before the physics simulation settles.
+## 2024-05-20 - ECharts Graph Roam & Drag Context
+**Learning:** In ECharts graph layouts, allowing nodes to be dynamically draggable (`draggable: true`, or default on some layouts) severely interferes with canvas camera panning/roaming (`roam: true`). Furthermore, system-level wheel events may be absorbed.
+**Action:** Always add an explicit ECharts `toolbox` configuration with `dataZoom`, `restore`, and `saveAsImage` when using `roam: true` so the user has guaranteed visible UI controls if the mouse wheel fails. Additionally, explicitly set `draggable: false` inside the `series` config if dragging the canvas is the primary interactive priority over moving individual nodes.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -144,3 +144,7 @@
 ## 2024-05-20 - ECharts Graph Roam & Drag Context
 **Learning:** In ECharts graph layouts, allowing nodes to be dynamically draggable (`draggable: true`, or default on some layouts) severely interferes with canvas camera panning/roaming (`roam: true`). Furthermore, system-level wheel events may be absorbed.
 **Action:** Always add an explicit ECharts `toolbox` configuration with `dataZoom`, `restore`, and `saveAsImage` when using `roam: true` so the user has guaranteed visible UI controls if the mouse wheel fails. Additionally, explicitly set `draggable: false` inside the `series` config if dragging the canvas is the primary interactive priority over moving individual nodes.
+## 2026-05-21 - ECharts Graph Roam Hit Area
+
+**Learning:** ECharts graph `roam: true` panning and zooming only captures events within the bounding box of the graph's nodes. If nodes are clumped in the center, panning and zooming on the edges of the canvas will completely fail. Adding `top/bottom/left/right: 0` or `width: 100%` does NOT expand the internal node bounding box.
+**Action:** When using `roam: true` on an ECharts graph that may clump or leave empty margins, explicitly add invisible dummy nodes with `fixed: true` coordinates at the extreme boundaries (e.g., `x: 0, y: 0` and `x: 2000, y: 2000`) and `symbolSize: 0` to forcefully stretch the event capture bounding box across the entire canvas. Additionally, update your tooltip formatter to explicitly ignore these dummy nodes.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -148,3 +148,7 @@
 
 **Learning:** ECharts graph `roam: true` panning and zooming only captures events within the bounding box of the graph's nodes. If nodes are clumped in the center, panning and zooming on the edges of the canvas will completely fail. Adding `top/bottom/left/right: 0` or `width: 100%` does NOT expand the internal node bounding box.
 **Action:** When using `roam: true` on an ECharts graph that may clump or leave empty margins, explicitly add invisible dummy nodes with `fixed: true` coordinates at the extreme boundaries (e.g., `x: 0, y: 0` and `x: 2000, y: 2000`) and `symbolSize: 0` to forcefully stretch the event capture bounding box across the entire canvas. Additionally, update your tooltip formatter to explicitly ignore these dummy nodes.
+
+## 2026-05-21 - ECharts Graph Roam Continued
+**Learning:** Adding dummy corner nodes with `fixed: true` is not always enough to fix `roam: true` panning in ECharts if the graph series height/width collapses dynamically to the computed force layout bounding box.
+**Action:** When attempting to force the `roam` hit area to expand across the entire canvas for a force-directed graph, you must explicitly declare `width: '100%'` and `height: '100%'` on the `series` configuration itself, in addition to placing the dummy coordinates.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { useAtomValue, useAtom } from 'jotai'
 
 const ScatterChart = React.lazy(() => import('./layout/ScatterChart'))
 const RadarChart = React.lazy(() => import('./layout/RadarChart'))
+const CorrelationNetworkChart = React.lazy(() => import('./layout/CorrelationNetworkChart'))
 import {
   getBioMarkersAtom,
   filterTextAtom,
@@ -43,6 +44,7 @@ export default function App() {
   const [correlationSupplement, setCorrelationSupplement] = React.useState<string | null>(null)
   const [showAiKey, setShowAiKey] = React.useState(false)
   const [showGistToken, setShowGistToken] = React.useState(false)
+  const [isNetworkViewOpen, setIsNetworkViewOpen] = React.useState(false)
 
   React.useEffect(() => {
     const handler = setTimeout(() => {
@@ -216,6 +218,8 @@ export default function App() {
       onPValue,
       onSupplementCorrelation,
       onOpenClustering: () => setIsClusteringOpen(true),
+      isNetworkViewOpen,
+      onToggleNetworkView: () => setIsNetworkViewOpen((prev) => !prev),
     }),
     [
       selected,
@@ -233,6 +237,7 @@ export default function App() {
       onPValue,
       onSupplementCorrelation,
       setIsClusteringOpen,
+      isNetworkViewOpen,
     ],
   )
 
@@ -332,14 +337,22 @@ export default function App() {
             </div>
           }
         >
-          {filterTag && (!chartKeys || chartKeys.length === 0) && (
-            <RadarChart data={radarChartData} tag={filterTag} />
-          )}
-          {chartKeys && chartKeys.length > 0 && chartType === 'scatter' && (
-            <ScatterChart keys={chartKeys} />
+          {isNetworkViewOpen ? (
+            <div className="mb-8 px-4">
+               <CorrelationNetworkChart />
+            </div>
+          ) : (
+            <>
+              {filterTag && (!chartKeys || chartKeys.length === 0) && (
+                <RadarChart data={radarChartData} tag={filterTag} />
+              )}
+              {chartKeys && chartKeys.length > 0 && chartType === 'scatter' && (
+                <ScatterChart keys={chartKeys} />
+              )}
+            </>
           )}
         </React.Suspense>
-        <Table {...tableProps} />
+        {!isNetworkViewOpen && <Table {...tableProps} />}
         <div className="flex flex-wrap justify-center gap-4 mt-4 pb-8">
           <div className="flex flex-col gap-1">
             <label htmlFor="ai-model" className="text-xs text-gray-400 font-medium ml-1">

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -197,7 +197,7 @@ const CorrelationNetworkChart = React.memo(() => {
   if (!visibleData || visibleData.length === 0) return null
 
   return (
-    <div className="w-full h-full min-h-[600px]">
+    <div className="w-full h-[600px] border border-gray-700 rounded bg-dark-bg/50 mt-4 overflow-hidden relative">
       <ReactECharts
         option={options}
         style={{ height: '100%', width: '100%' }}

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -107,7 +107,7 @@ const CorrelationNetworkChart = React.memo(() => {
 
                 const result = calculateSpearmanRanked(sourceRanks, targetRanks, options)
                 if (result.pValue <= alpha) {
-                    validPairs.push({ source: sourceName, target: targetName, rho: result.statistic, pValue: result.pValue })
+                    validPairs.push({ source: sourceName, target: targetName, rho: result.pcorr, pValue: result.pValue })
                 }
             }
         }
@@ -118,7 +118,8 @@ const CorrelationNetworkChart = React.memo(() => {
     validPairs.forEach(pair => {
         const isPositive = pair.rho > 0
         const absRho = Math.abs(pair.rho)
-        const width = 1 + Math.pow(absRho, 2) * 8
+        const width = 0.5 + Math.pow(absRho, 2) * 2;
+        const opacity = 0.1 + absRho * 0.4;
 
         edges.push({
             source: pair.source,
@@ -126,9 +127,10 @@ const CorrelationNetworkChart = React.memo(() => {
             value: pair.rho,
             lineStyle: {
               width: width,
-              curveness: 0.2,
+              curveness: 0.15,
+              type: 'solid',
               color: isPositive ? '#10b981' : '#ef4444',
-              opacity: 0.6,
+              opacity: opacity,
             }
         })
 
@@ -184,8 +186,9 @@ const CorrelationNetworkChart = React.memo(() => {
             show: true,
           },
           force: {
-            repulsion: 300,
-            edgeLength: 150,
+            repulsion: 800,
+            edgeLength: [50, 200],
+            gravity: 0.1,
           },
           data: nodes,
           edges: edges,

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -177,6 +177,14 @@ const CorrelationNetworkChart = React.memo(() => {
           return params.name
         },
       },
+      toolbox: {
+        show: true,
+        feature: {
+          dataZoom: { yAxisIndex: 'none' },
+          restore: {},
+          saveAsImage: {}
+        }
+      },
       series: [
         {
           type: 'graph',
@@ -184,6 +192,8 @@ const CorrelationNetworkChart = React.memo(() => {
           layoutAnimation: true,
           layout: 'force',
           roam: true,
+          draggable: false,
+
           label: {
             show: true,
           },

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -139,10 +139,9 @@ const CorrelationNetworkChart = React.memo(() => {
     })
 
     // Add nodes
-    nodes.push({ id: '__corner_tl', name: '', x: 0, y: 0, fixed: true, symbolSize: 0, itemStyle: { opacity: 0 } })
-    nodes.push({ id: '__corner_tr', name: '', x: 2000, y: 0, fixed: true, symbolSize: 0, itemStyle: { opacity: 0 } })
-    nodes.push({ id: '__corner_bl', name: '', x: 0, y: 2000, fixed: true, symbolSize: 0, itemStyle: { opacity: 0 } })
-    nodes.push({ id: '__corner_br', name: '', x: 2000, y: 2000, fixed: true, symbolSize: 0, itemStyle: { opacity: 0 } })
+    // Dummy background node to capture roam events everywhere
+    nodes.push({ id: '__background', name: '', fixed: true, x: 500, y: 500, symbolSize: 5000, itemStyle: { color: 'transparent' } })
+
 
     Array.from(nodesSet).forEach((nodeName, index) => {
         const degree = degreeMap.get(nodeName) || 0
@@ -169,7 +168,24 @@ const CorrelationNetworkChart = React.memo(() => {
 
     return {
       theme: 'dark',
-      backgroundColor: 'rgba(1, 1, 1, 0.01)',
+      graphic: [
+        {
+          type: 'rect',
+          left: 0,
+          top: 0,
+          right: 0,
+          bottom: 0,
+          bounding: 'all',
+          style: {
+            fill: 'rgba(0,0,0,0.01)'
+          },
+          cursor: 'default',
+          // Graphic events don't automatically trigger roam, but they capture mouse.
+          // However, if the graphic is behind the graph (z: -1), does roam work?
+          z: -1
+        }
+      ],
+      backgroundColor: 'transparent',
       tooltip: {
         backgroundColor: '#111111',
         borderColor: '#3a3a3a80',
@@ -179,7 +195,7 @@ const CorrelationNetworkChart = React.memo(() => {
             const rho = (params.data.value as number).toFixed(3)
             return `${params.data.source} ↔ ${params.data.target}<br/>Rho: <strong>${rho}</strong>`
           }
-          return params.id && params.id.startsWith('__corner') ? '' : params.name
+          return params.id && params.id.startsWith('__') ? '' : params.name
         },
       },
       toolbox: {

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -180,15 +180,18 @@ const CorrelationNetworkChart = React.memo(() => {
       series: [
         {
           type: 'graph',
+          initLayout: 'circular',
+          layoutAnimation: true,
           layout: 'force',
           roam: true,
           label: {
             show: true,
           },
           force: {
-            repulsion: 3000,
-            edgeLength: [100, 300],
-                        gravity: 0.1,
+            repulsion: [3000, 5000],
+            edgeLength: [150, 400],
+            gravity: 0.05,
+            friction: 0.2,
           },
           data: nodes,
           edges: edges,

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -139,6 +139,11 @@ const CorrelationNetworkChart = React.memo(() => {
     })
 
     // Add nodes
+    nodes.push({ id: '__corner_tl', name: '', x: 0, y: 0, fixed: true, symbolSize: 0, itemStyle: { opacity: 0 } })
+    nodes.push({ id: '__corner_tr', name: '', x: 2000, y: 0, fixed: true, symbolSize: 0, itemStyle: { opacity: 0 } })
+    nodes.push({ id: '__corner_bl', name: '', x: 0, y: 2000, fixed: true, symbolSize: 0, itemStyle: { opacity: 0 } })
+    nodes.push({ id: '__corner_br', name: '', x: 2000, y: 2000, fixed: true, symbolSize: 0, itemStyle: { opacity: 0 } })
+
     Array.from(nodesSet).forEach((nodeName, index) => {
         const degree = degreeMap.get(nodeName) || 0
         const size = 15 + degree * 2 // Node size proportional to connections
@@ -164,7 +169,7 @@ const CorrelationNetworkChart = React.memo(() => {
 
     return {
       theme: 'dark',
-      backgroundColor: 'rgba(0,0,0,0)',
+      backgroundColor: 'rgba(1, 1, 1, 0.01)',
       tooltip: {
         backgroundColor: '#111111',
         borderColor: '#3a3a3a80',
@@ -174,13 +179,13 @@ const CorrelationNetworkChart = React.memo(() => {
             const rho = (params.data.value as number).toFixed(3)
             return `${params.data.source} ↔ ${params.data.target}<br/>Rho: <strong>${rho}</strong>`
           }
-          return params.name
+          return params.id && params.id.startsWith('__corner') ? '' : params.name
         },
       },
       toolbox: {
         show: true,
         feature: {
-          dataZoom: { yAxisIndex: 'none' },
+
           restore: {},
           saveAsImage: {}
         }
@@ -195,7 +200,7 @@ const CorrelationNetworkChart = React.memo(() => {
           initLayout: 'circular',
           layoutAnimation: true,
           layout: 'force',
-          roam: true,
+          roam: true, scaleLimit: { min: 0.1, max: 10 },
           draggable: false,
 
           label: {

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -1,0 +1,211 @@
+import React, { useMemo } from 'react'
+import ReactECharts from 'echarts-for-react'
+import { useAtomValue } from 'jotai'
+import { visibleDataAtom, dataMapAtom, rankedDataMapAtom } from '../atom/dataAtom'
+import {
+  correlationAlphaAtom,
+  correlationAlternativeAtom,
+  correlationMethodAtom,
+} from '../atom/correlationAtom'
+import { calculateSpearmanRanked, calculatePearson } from '../processors/stats'
+import { CHART_PALETTE } from './Chart2'
+
+const CorrelationNetworkChart = React.memo(() => {
+  const visibleData = useAtomValue(visibleDataAtom)
+  const dataMap = useAtomValue(dataMapAtom)
+  const rankedDataMap = useAtomValue(rankedDataMapAtom)
+  const alpha = useAtomValue(correlationAlphaAtom)
+  const alternative = useAtomValue(correlationAlternativeAtom)
+  const method = useAtomValue(correlationMethodAtom)
+
+  const options = useMemo(() => {
+    if (!visibleData || visibleData.length === 0) return {}
+
+    const nodes: any[] = []
+    const edges: any[] = []
+    const nodesSet = new Set<string>()
+
+    const options = { alpha, alternative }
+    const validPairs: { source: string; target: string; rho: number; pValue: number }[] = []
+
+    const numData = visibleData.length
+
+    // Create nodes for all visible data
+    for (let i = 0; i < numData; i++) {
+        const item = visibleData[i]
+        nodesSet.add(item[0])
+    }
+
+    if (method === 'pearson') {
+       // Pre-parse the source values and record valid indices to avoid O(N * M) parsing and null checks.
+       // This is complex for N*N matrix, so we'll do it pair-wise carefully.
+
+       for (let i = 0; i < numData; i++) {
+          const sourceName = visibleData[i][0]
+          const sourceValuesRaw = dataMap.get(sourceName)?.[1]
+          if (!sourceValuesRaw) continue
+
+          const len = sourceValuesRaw.length
+          const parsedSource = new Float64Array(len)
+          const validIndices: number[] = []
+
+          for (let k = 0; k < len; k++) {
+            const v = sourceValuesRaw[k]
+            if (v !== null) {
+              const vNum = Number(v)
+              if (!isNaN(vNum)) {
+                parsedSource[k] = vNum
+                validIndices.push(k)
+              }
+            }
+          }
+
+          const maxLen = validIndices.length
+          if (maxLen < 4) continue
+
+          const x = new Float64Array(maxLen)
+          const y = new Float64Array(maxLen)
+
+          for (let j = i + 1; j < numData; j++) {
+              const targetName = visibleData[j][0]
+              const targetValuesRaw = dataMap.get(targetName)?.[1]
+              if (!targetValuesRaw) continue
+
+              let count = 0
+              for (let k = 0; k < maxLen; k++) {
+                  const idx = validIndices[k]
+                  const t = targetValuesRaw[idx]
+                  if (t !== null) {
+                      const tNum = Number(t)
+                      if (!isNaN(tNum)) {
+                          x[count] = parsedSource[idx]
+                          y[count] = tNum
+                          count++
+                      }
+                  }
+              }
+
+              if (count < 4) continue
+
+              const result = calculatePearson(x.subarray(0, count), y.subarray(0, count), options)
+              if (result.pValue <= alpha) {
+                  validPairs.push({ source: sourceName, target: targetName, rho: result.pcorr, pValue: result.pValue })
+              }
+          }
+       }
+    } else {
+        // Spearman
+        for (let i = 0; i < numData; i++) {
+            const sourceName = visibleData[i][0]
+            const sourceRanks = rankedDataMap.get(sourceName)
+            if (!sourceRanks) continue
+
+            for (let j = i + 1; j < numData; j++) {
+                const targetName = visibleData[j][0]
+                const targetRanks = rankedDataMap.get(targetName)
+                if (!targetRanks) continue
+
+                const result = calculateSpearmanRanked(sourceRanks, targetRanks, options)
+                if (result.pValue <= alpha) {
+                    validPairs.push({ source: sourceName, target: targetName, rho: result.statistic, pValue: result.pValue })
+                }
+            }
+        }
+    }
+
+    const degreeMap = new Map<string, number>()
+
+    validPairs.forEach(pair => {
+        const isPositive = pair.rho > 0
+        const absRho = Math.abs(pair.rho)
+        const width = 1 + Math.pow(absRho, 2) * 8
+
+        edges.push({
+            source: pair.source,
+            target: pair.target,
+            value: pair.rho,
+            lineStyle: {
+              width: width,
+              curveness: 0.2,
+              color: isPositive ? '#10b981' : '#ef4444',
+              opacity: 0.6,
+            }
+        })
+
+        degreeMap.set(pair.source, (degreeMap.get(pair.source) || 0) + 1)
+        degreeMap.set(pair.target, (degreeMap.get(pair.target) || 0) + 1)
+    })
+
+    // Add nodes
+    Array.from(nodesSet).forEach((nodeName, index) => {
+        const degree = degreeMap.get(nodeName) || 0
+        const size = 15 + degree * 2 // Node size proportional to connections
+        const colorIndex = index % CHART_PALETTE.length
+
+        // Hide nodes with 0 connections if there are many nodes?
+        // We'll show all to maintain "entire web", but make them small.
+        nodes.push({
+            id: nodeName,
+            name: nodeName,
+            symbolSize: size,
+            itemStyle: {
+                color: CHART_PALETTE[colorIndex]
+            },
+            label: {
+                show: degree > 0, // only show labels for connected nodes to avoid clutter
+                color: '#a3a3a3',
+                position: 'bottom'
+            }
+        })
+    })
+
+
+    return {
+      theme: 'dark',
+      backgroundColor: 'transparent',
+      tooltip: {
+        backgroundColor: '#111111',
+        borderColor: '#3a3a3a80',
+        textStyle: { color: '#f0f0f0' },
+        formatter: (params: any) => {
+          if (params.dataType === 'edge') {
+            const rho = (params.data.value as number).toFixed(3)
+            return `${params.data.source} ↔ ${params.data.target}<br/>Rho: <strong>${rho}</strong>`
+          }
+          return params.name
+        },
+      },
+      series: [
+        {
+          type: 'graph',
+          layout: 'force',
+          roam: true,
+          label: {
+            show: true,
+          },
+          force: {
+            repulsion: 300,
+            edgeLength: 150,
+          },
+          data: nodes,
+          edges: edges,
+        },
+      ],
+    }
+  }, [visibleData, dataMap, rankedDataMap, alpha, alternative, method])
+
+  if (!visibleData || visibleData.length === 0) return null
+
+  return (
+    <div className="w-full h-full min-h-[600px]">
+      <ReactECharts
+        option={options}
+        style={{ height: '100%', width: '100%' }}
+        notMerge={true}
+        theme="dark"
+      />
+    </div>
+  )
+})
+
+export default CorrelationNetworkChart

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -164,7 +164,7 @@ const CorrelationNetworkChart = React.memo(() => {
 
     return {
       theme: 'dark',
-      backgroundColor: 'transparent',
+      backgroundColor: 'rgba(0,0,0,0)',
       tooltip: {
         backgroundColor: '#111111',
         borderColor: '#3a3a3a80',
@@ -188,6 +188,10 @@ const CorrelationNetworkChart = React.memo(() => {
       series: [
         {
           type: 'graph',
+          top: '0%',
+          bottom: '0%',
+          left: '0%',
+          right: '0%',
           initLayout: 'circular',
           layoutAnimation: true,
           layout: 'force',

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -118,7 +118,7 @@ const CorrelationNetworkChart = React.memo(() => {
     validPairs.forEach(pair => {
         const isPositive = pair.rho > 0
         const absRho = Math.abs(pair.rho)
-        const width = 0.5 + Math.pow(absRho, 2) * 2;
+        const width = 0.5 + Math.pow(absRho, 4) * 8;
         const opacity = 0.1 + absRho * 0.4;
 
         edges.push({
@@ -186,9 +186,9 @@ const CorrelationNetworkChart = React.memo(() => {
             show: true,
           },
           force: {
-            repulsion: 800,
-            edgeLength: [50, 200],
-            gravity: 0.1,
+            repulsion: 3000,
+            edgeLength: [100, 300],
+                        gravity: 0.1,
           },
           data: nodes,
           edges: edges,

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -193,6 +193,8 @@ const CorrelationNetworkChart = React.memo(() => {
       series: [
         {
           type: 'graph',
+          width: '100%',
+          height: '100%',
           top: '0%',
           bottom: '0%',
           left: '0%',

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -51,6 +51,8 @@ export default React.memo<NavProps>(
     onPValue,
     onSupplementCorrelation,
     onOpenClustering,
+    isNetworkViewOpen,
+    onToggleNetworkView,
   }) => {
     const [averageCount, setAverageCount] = useAtom(averageCountAtom)
     const key = useAtomValue(aiKeyAtom)
@@ -464,6 +466,20 @@ export default React.memo<NavProps>(
                   </div>
                 </div>
               )}
+              <button
+                type="button"
+                onClick={onToggleNetworkView}
+                title="View Biomarker Network Graph"
+                className={`hidden md:flex ml-4 px-3 py-1 text-xs font-medium text-white rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 transition-colors ${
+                  isNetworkViewOpen
+                    ? 'bg-blue-700 shadow-inner'
+                    : 'bg-blue-600 hover:bg-blue-500'
+                }`}
+                aria-pressed={isNetworkViewOpen}
+              >
+                View Network
+              </button>
+
               {onOpenClustering && (
                 <button
                   type="button"

--- a/src/layout/Nav.types.ts
+++ b/src/layout/Nav.types.ts
@@ -16,4 +16,6 @@ export type NavProps = {
   onPValue: () => void
   onSupplementCorrelation: (name: string) => void
   onOpenClustering?: () => void
+  isNetworkViewOpen: boolean
+  onToggleNetworkView: () => void
 }


### PR DESCRIPTION
Implemented the requested `CorrelationNetworkChart` component which uses a force-directed ECharts layout to visualize pairwise correlation networks between visible biomarkers based on the existing correlation methods and thresholds.
Added a 'View Network' button in the Nav bar alongside other view modes to toggle the network chart, mapping node sizes to degree centrality and edge thickness to the correlation coefficients.

---
*PR created automatically by Jules for task [9918215998177633937](https://jules.google.com/task/9918215998177633937) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Biomarker Correlation Network view to explore significant pairwise relationships in a force-directed graph. Fixes pan/zoom so it works across the entire canvas by expanding the ECharts roam hit area with a single large invisible node.

- **New Features**
  - New `CorrelationNetworkChart` via `echarts-for-react`; edges filtered by alpha for Pearson (handles missing data, needs ≥4 overlaps) or Spearman (pre-ranked).
  - UX: degree-sized nodes with `CHART_PALETTE`; circular init layout with tuned force; solid curved edges sized/opacity by |ρ|; `roam: true` with toolbox; node drag off; labels only for connected nodes; tooltips show endpoints and ρ; lazy-loaded; “View Network” Nav toggle hides other views and the table.

- **Bug Fixes**
  - Fixed roam hit area by setting series `width`/`height: '100%'` and adding one central, massive, transparent `fixed` node to capture drag/zoom across the whole canvas.
  - Resolved Playwright test timeout.

<sup>Written for commit 110cdfcacdb2fc65daf92f9c85ceaa0881053e8c. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/355?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

