### PR TITLE
refactor: fix weak any typing in Chart echartsOptions

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -6,6 +6,7 @@ import { Line } from '@echarts-readymade/line'
 import { labels, formattedLabels } from '../data'
 import { CHART_PALETTE } from './Chart2'
 import { ChartProps } from './Chart.types'
+import type { EChartsReactProps } from 'echarts-for-react'
 
 const dimension = [
   {
@@ -14,7 +15,7 @@ const dimension = [
   },
 ]
 
-const echartsOptions: any = {
+const echartsOptions: EChartsReactProps = {
   style: { height: 400 },
   theme: 'dark',
   option: {


### PR DESCRIPTION
**The Issue:**
`src/layout/Chart.tsx` line 17. The `echartsOptions` configuration object was typed as `any`, bypassing TypeScript's static checks for a complex configuration object used to render the chart.

**The Discovery Signal:**
Scan C (Weak or Missing Type Annotations): `src/layout/Chart.tsx` line 17 — `echartsOptions` assigned explicit `any` type where a concrete type exists.

**The Fix:**
Replaced `any` with `EChartsReactProps` from `echarts-for-react` for the `echartsOptions` configuration object, and added the correct import statement. This type perfectly maps to the object shape being used and successfully passes compilation without any restructuring required for this specific chart layout.

**The Benefit:**
Eliminates a weak type assignment, providing strict type-checking on the configuration object. This reduces the risk of accidental runtime typos when modifying chart configurations in the future and provides a cleaner `tsc` output without relying on `any`.

---
*PR created automatically by Jules for task [7325467646532173060](https://jules.google.com/task/7325467646532173060) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `any` typing of `echartsOptions` with `EChartsReactProps` from `echarts-for-react` in `src/layout/Chart.tsx`. This strengthens type safety for the chart config and reduces risk of runtime typos.

<sup>Written for commit d9e2bed551ffdb57090b2c2dd87c80ef2bc6d376. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/358?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

