### PR TITLE
refactor: Extract LineChartProps to LineChart.types.ts

### DIFF
--- a/src/layout/LineChart.tsx
+++ b/src/layout/LineChart.tsx
@@ -2,12 +2,7 @@ import React, { memo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import { labels, formattedLabels } from '../data'
 import { CHART_PALETTE } from './Chart2'
-
-interface LineChartProps {
-  name: string
-  values: number[]
-  rangeStr?: string
-}
+import type { LineChartProps } from './LineChart.types'
 
 const echartsOptions = {
   style: { height: 300, width: '100%' },

--- a/src/layout/LineChart.types.ts
+++ b/src/layout/LineChart.types.ts
@@ -1,0 +1,5 @@
+export interface LineChartProps {
+  name: string
+  values: number[]
+  rangeStr?: string
+}


### PR DESCRIPTION
**The Issue:**
`src/layout/LineChart.tsx` lines 6-10 defined `interface LineChartProps` inside the component file, which violates the established structural pattern of extracting shared or complex component props into a sibling `.types.ts` file.

**The Discovery Signal:**
Scan A (Misplaced Shared Types) revealed that `LineChart.tsx` was defining its own prop interface inline instead of keeping it in a dedicated `.types.ts` file.

**The Fix:**
Extracted `LineChartProps` out of `src/layout/LineChart.tsx` into a newly created `src/layout/LineChart.types.ts` file and added an import for the type in `src/layout/LineChart.tsx`. 

**The Benefit:**
Maintains structural consistency by strictly enforcing the project's convention of placing types in `.types.ts` files. This aligns `LineChart.tsx` with other components and clarifies the location of shared types for future modifications, avoiding potential confusion.

---
*PR created automatically by Jules for task [12766804064189862207](https://jules.google.com/task/12766804064189862207) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `LineChartProps` into `src/layout/LineChart.types.ts` to align with our component types pattern. No behavior changes.

- **Refactors**
  - Updated `LineChart.tsx` to import `LineChartProps` from the new `LineChart.types.ts`.
  - Improves discoverability and reuse of the chart props.

<sup>Written for commit 17d68a6d2bc00fa29238c8f98d320a5ee58f23d0. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/359?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

