### PR TITLE
refactor: replace any type with MarkAreaComponentOption in LineChart

### DIFF
--- a/src/layout/LineChart.tsx
+++ b/src/layout/LineChart.tsx
@@ -3,6 +3,7 @@ import ReactECharts from 'echarts-for-react'
 import { labels, formattedLabels } from '../data'
 import { CHART_PALETTE } from './Chart2'
 import type { LineChartProps } from './LineChart.types'
+import type { MarkAreaComponentOption } from 'echarts'
 
 const echartsOptions = {
   style: { height: 300, width: '100%' },
@@ -74,7 +75,7 @@ export default memo(({ name, values, rangeStr }: LineChartProps) => {
   }, [values])
 
   const options = useMemo(() => {
-    let markArea: any = undefined
+    let markArea: MarkAreaComponentOption | undefined = undefined
 
     if (rangeStr) {
       let min: number | undefined


### PR DESCRIPTION
**The Issue:**
`src/layout/LineChart.tsx` line 77 — The variable `markArea` was explicitly typed as `any` (`let markArea: any = undefined`), which is a structural problem because it bypasses TypeScript's strict type-checking for the complex ECharts configuration object it holds, allowing potential typos or invalid properties to slip through compilation.

**The Discovery Signal:**
Scan C (Weak or Missing Type Annotations) triggered this find. Running `grep -rn ": any" src/layout/` identified multiple uses of explicit `any` types, including the `let markArea: any = undefined` in `src/layout/LineChart.tsx`.

**The Fix:**
I replaced the explicit `any` type with the concrete `MarkAreaComponentOption` type imported from `echarts` (`import type { MarkAreaComponentOption } from 'echarts'`). The variable declaration was updated to `let markArea: MarkAreaComponentOption | undefined = undefined`.

**The Benefit:**
This structural improvement eliminates a blind spot in the type system, ensuring that any future modifications to the `markArea` configuration in this component will be strictly validated against the official ECharts API shape. It cleanly satisfies `tsc --noEmit --strict` and `oxlint` without inventing new types, making the code safer and more maintainable for future developers or agents.

---
*PR created automatically by Jules for task [7173397866038812498](https://jules.google.com/task/7173397866038812498) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `any` with `MarkAreaComponentOption` from `echarts` for the LineChart `markArea` in `src/layout/LineChart.tsx` to enforce valid ECharts config typing. Improves type safety under `--strict` with no runtime changes.

<sup>Written for commit 084d480bcdc01cc27d90fed8435c1972af370ce2. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/362?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

