### PR TITLE
⚙️ Engineer: Resolve weak any types in Correlation layout

### DIFF
--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -226,7 +226,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                             <select
                               id="corr-method"
                               value={method}
-                              onChange={(e) => setMethod(e.target.value as any)}
+                              onChange={(e) => setMethod(e.target.value as 'spearman' | 'pearson')}
                               className="w-24 px-2 py-1 bg-dark-bg border border-gray-600 rounded text-xs focus:border-blue-500 outline-none transition-colors text-white focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                             >
                               <option value="spearman">Spearman</option>
@@ -256,7 +256,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                             <select
                               id="corr-alt"
                               value={alternative}
-                              onChange={(e) => setAlternative(e.target.value as any)}
+                              onChange={(e) => setAlternative(e.target.value as 'two-sided' | 'less' | 'greater')}
                               className="w-24 px-2 py-1 bg-dark-bg border border-gray-600 rounded text-xs focus:border-blue-500 outline-none transition-colors text-white focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                             >
                               <option value="two-sided">Two-sided</option>


### PR DESCRIPTION
**The Issue:**
`src/layout/Correlation.tsx` line 229 and 259 used explicit `as any` casts to bypass TypeScript's type widening on the `<select>` onChange events, forcing `string` into literal union atoms. This introduces a structural weakness where adding or removing options from the atom state or UI wouldn't be caught by the compiler.

**The Discovery Signal:**
Scan C (weak types): Found multiple occurrences of `as any` casting inside `src/layout/Correlation.tsx` tied to `setMethod` and `setAlternative` state updates.

**The Fix:**
Updated `setMethod(e.target.value as any)` to strictly use the known literals `as 'spearman' | 'pearson'`.
Updated `setAlternative(e.target.value as any)` to correctly cast `as 'two-sided' | 'less' | 'greater'`.

**The Benefit:**
Eliminates a layer of weak `any` typing within the component layer and reduces implicit `any` surface area. Makes the UI resilient to changes: if the atom definition or select options evolve, `tsc` will now reliably catch discrepancies. Both `tsc --noEmit --strict` and `oxlint` pass cleanly.

---
*PR created automatically by Jules for task [11913377238420461661](https://jules.google.com/task/11913377238420461661) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced weak `any` casts in `Correlation` select handlers with strict string literal unions to improve type safety and catch option/state mismatches at compile time.

- **Refactors**
  - `setMethod(e.target.value as any)` → `setMethod(e.target.value as 'spearman' | 'pearson')`
  - `setAlternative(e.target.value as any)` → `setAlternative(e.target.value as 'two-sided' | 'less' | 'greater')`

<sup>Written for commit 9becd7a175853fcdef117f87d26a533f019b59e6. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/363?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

