### PR TITLE
⚡ Bolt: Replace `.map()` chained methods with loops in data inference

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -6,3 +6,6 @@
 ## 2025-05-23 - Pre-allocate TypedArrays across loops
 **Learning:** Repeatedly instantiating temporary `Float64Array` inside nested loops or React `useMemo` iterations causes enormous garbage collection churn, even when arrays are small. `Map.prototype.entries()` should be traversed without function closures using `for (const [k, v] of map.entries())` instead of `.forEach()`.
 **Action:** Hoist TypedArray allocations to the highest viable scope before the loop, and reuse the memory buffer inside the loop via `.subarray(0, count)` to pass zero-copy, right-sized views to subsequent operations.
+## 2024-05-24 - Pre-allocate Arrays when replacing array.map()
+**Learning:** Replaced array.map() with traditional for-loops, saving closure allocation and function call overheads per item.
+**Action:** Replace `recipes.map(...)` with `for (let i = 0; i < recipes.length; i++)` and preallocate output arrays where lengths are known statically.

--- a/src/processors/enrich/inferData.ts
+++ b/src/processors/enrich/inferData.ts
@@ -51,13 +51,22 @@ export default (entries: BioMarker[]): BioMarker[] => {
     entryMap.set(entries[i][0], entries[i][1])
   }
 
-  const data = recipes.map(([name, fields, func, extra = {}]) => {
+  // Optimization: Replace array.map with a traditional for loop to avoid closure creation
+  // and multiple array allocations per recipe.
+  const data = Array<any>(recipes.length)
+  for (let r = 0; r < recipes.length; r++) {
+    const [name, fields, func, extra = {}] = recipes[r]
     // Look up required field arrays once per recipe
-    const fieldArrays = fields.map((field) => entryMap.get(field))
-
-    // If any required field is entirely missing, all calculated values for this recipe will be null
-    const hasMissingField = fieldArrays.some((arr) => arr === undefined)
-    const numFields = fieldArrays.length
+    const numFields = fields.length
+    const fieldArrays = Array<number[] | undefined>(numFields)
+    let hasMissingField = false
+    for (let f = 0; f < numFields; f++) {
+      const arr = entryMap.get(fields[f])
+      fieldArrays[f] = arr
+      if (arr === undefined) {
+        hasMissingField = true
+      }
+    }
 
     // Optimization: Avoid chaining Array.from({ length }).map() and inner array.map().some()
     // inside hot loops to reduce multiple array allocations and closure overheads per period.
@@ -91,8 +100,8 @@ export default (entries: BioMarker[]): BioMarker[] => {
       ;(extra as any).originValues = Array<any>(periods)
     }
     ;(extra as any).inferred = true
-    return [name, values, null, extra] as any
-  })
+    data[r] = [name, values, null, extra] as any
+  }
 
   return [...entries, ...data]
 }


### PR DESCRIPTION
💡 **What:** 
Replaced functional array mapping chains (`recipes.map()`, `fields.map()`, `fieldArrays.some()`) with classic `for` loops and pre-allocated arrays in `src/processors/enrich/inferData.ts`. 

🎯 **Why:** 
The use of functional array methods inside potentially hot data enrichment loops causes significant intermediate array allocation and repeated closure creation. This results in unnecessary memory churn and garbage collection overhead. Pre-allocating arrays and using index-based loops eliminates these overheads.

📊 **Impact:** 
Reduces memory allocation and GC pauses during the data enrichment phase, leading to faster data processing initialization.

🔬 **Measurement:** 
Run `pnpm lint`, `pnpm tsc --noEmit --strict`, and the complete Playwright test suite (`pnpm exec playwright test`). All tests pass, indicating that the transformation preserves exactly the same logic while reducing execution overhead.

---
*PR created automatically by Jules for task [3286649165114984461](https://jules.google.com/task/3286649165114984461) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced chained array methods with indexed loops and preallocated arrays in data inference to cut allocations and GC. This speeds up data enrichment and reduces memory churn.

- **Refactors**
  - Replaced `recipes.map(...)`, inner `fields.map(...)`, and `.some(...)` with indexed `for` loops and preallocated arrays in `src/processors/enrich/inferData.ts`.
  - Avoids per-item closure creation and intermediate array allocations on the hot path; behavior unchanged.
  - Verified with `pnpm lint`, `pnpm tsc --noEmit --strict`, and Playwright tests.

<sup>Written for commit ab63a2fa6b950f2525d2c343a76f2b2e00a97e90. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/364?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

