### PR TITLE
fix(chart): use nonInferredData and fix drag/zoom issues

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -137,20 +137,28 @@
 
 **Learning:** When using `React.Suspense` for lazy-loaded modals, utilizing a full-screen, semi-transparent background overlay as the fallback loading state causes a jarring screen flash for the user because the loading state often appears for only a fraction of a second.
 **Action:** Always use a subtle, localized loading indicator (e.g., a floating bottom-right notification) instead of a full-screen overlay for `React.Suspense` fallbacks on modals. This ensures an accessible loading state is communicated to screen readers (via `aria-busy="true"`, `role="status"`, `aria-live="polite"`) without causing visual disruption.
+
 ## 2024-05-20 - Correlation Network Graph Edges
+
 **Learning:** Dense correlation network graphs in ECharts can render edges weirdly (as chunky polygons instead of distinct lines) if thickness scales excessively and `type: 'solid'` is omitted on curved connections.
 **Action:** When visualizing network edges mapping to weight/value, explicitly set `lineStyle.type: 'solid'`, increase `force.repulsion`, and constrain edge widths (e.g. `0.5 + Math.pow(rho, 2) * 2`) to ensure visually clean distinct paths rather than massive overlapping visual artifacts.
+
 ## 2024-05-20 - Correlation Network Node Spacing
+
 **Learning:** ECharts force graph nodes tend to cluster tightly in the center if default settings are used, creating tangles.
 **Action:** When working with ECharts force layouts, use a combination of low `gravity` (e.g. 0.05), high range arrays for `repulsion` (e.g. `[3000, 5000]`), and `initLayout: 'circular'` combined with `layoutAnimation: true` to help ECharts evenly distribute the nodes before the physics simulation settles.
+
 ## 2024-05-20 - ECharts Graph Roam & Drag Context
+
 **Learning:** In ECharts graph layouts, allowing nodes to be dynamically draggable (`draggable: true`, or default on some layouts) severely interferes with canvas camera panning/roaming (`roam: true`). Furthermore, system-level wheel events may be absorbed.
 **Action:** Always add an explicit ECharts `toolbox` configuration with `dataZoom`, `restore`, and `saveAsImage` when using `roam: true` so the user has guaranteed visible UI controls if the mouse wheel fails. Additionally, explicitly set `draggable: false` inside the `series` config if dragging the canvas is the primary interactive priority over moving individual nodes.
+
 ## 2026-05-21 - ECharts Graph Roam Hit Area
 
 **Learning:** ECharts graph `roam: true` panning and zooming only captures events within the bounding box of the graph's nodes. If nodes are clumped in the center, panning and zooming on the edges of the canvas will completely fail. Adding `top/bottom/left/right: 0` or `width: 100%` does NOT expand the internal node bounding box.
 **Action:** When using `roam: true` on an ECharts graph that may clump or leave empty margins, explicitly add invisible dummy nodes with `fixed: true` coordinates at the extreme boundaries (e.g., `x: 0, y: 0` and `x: 2000, y: 2000`) and `symbolSize: 0` to forcefully stretch the event capture bounding box across the entire canvas. Additionally, update your tooltip formatter to explicitly ignore these dummy nodes.
 
 ## 2026-05-21 - ECharts Graph Roam Continued
+
 **Learning:** Adding dummy corner nodes with `fixed: true` is not always enough to fix `roam: true` panning in ECharts if the graph series height/width collapses dynamically to the computed force layout bounding box.
 **Action:** When attempting to force the `roam` hit area to expand across the entire canvas for a force-directed graph, you must explicitly declare `width: '100%'` and `height: '100%'` on the `series` configuration itself, in addition to placing the dummy coordinates.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,10 +2,15 @@
 
 **Learning:** Chained array methods (`.filter().map()`, `.filter().some()`, etc.) create unnecessary intermediate arrays and closures, which cause significant garbage collection overhead in hot paths (like candidate filtering in large datasets or inside component memos).
 **Action:** Replace these chains with standard `for` loops that push valid items into pre-allocated or shared arrays.
-## 2026-05-23 - Pre-allocate TypedArrays across loops\n**Learning:** Repeatedly instantiating temporary  inside nested loops or React  iterations causes enormous garbage collection churn, even when arrays are small.  should be traversed without function closures using  instead of .\n**Action:** Hoist TypedArray allocations to the highest viable scope before the loop, and reuse the memory buffer inside the loop via  to pass zero-copy, right-sized views to subsequent operations.
+
+## 2026-05-23 - Pre-allocate TypedArrays across loops\n**Learning:** Repeatedly instantiating temporary inside nested loops or React iterations causes enormous garbage collection churn, even when arrays are small. should be traversed without function closures using instead of .\n**Action:** Hoist TypedArray allocations to the highest viable scope before the loop, and reuse the memory buffer inside the loop via to pass zero-copy, right-sized views to subsequent operations.
+
 ## 2025-05-23 - Pre-allocate TypedArrays across loops
+
 **Learning:** Repeatedly instantiating temporary `Float64Array` inside nested loops or React `useMemo` iterations causes enormous garbage collection churn, even when arrays are small. `Map.prototype.entries()` should be traversed without function closures using `for (const [k, v] of map.entries())` instead of `.forEach()`.
 **Action:** Hoist TypedArray allocations to the highest viable scope before the loop, and reuse the memory buffer inside the loop via `.subarray(0, count)` to pass zero-copy, right-sized views to subsequent operations.
+
 ## 2024-05-24 - Pre-allocate Arrays when replacing array.map()
+
 **Learning:** Replaced array.map() with traditional for-loops, saving closure allocation and function call overheads per item.
 **Action:** Replace `recipes.map(...)` with `for (let i = 0; i < recipes.length; i++)` and preallocate output arrays where lengths are known statically.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -339,7 +339,7 @@ export default function App() {
         >
           {isNetworkViewOpen ? (
             <div className="mb-8 px-4">
-               <CorrelationNetworkChart />
+              <CorrelationNetworkChart />
             </div>
           ) : (
             <>

--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -256,7 +256,9 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                             <select
                               id="corr-alt"
                               value={alternative}
-                              onChange={(e) => setAlternative(e.target.value as 'two-sided' | 'less' | 'greater')}
+                              onChange={(e) =>
+                                setAlternative(e.target.value as 'two-sided' | 'less' | 'greater')
+                              }
                               className="w-24 px-2 py-1 bg-dark-bg border border-gray-600 rounded text-xs focus:border-blue-500 outline-none transition-colors text-white focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                             >
                               <option value="two-sided">Two-sided</option>

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import { useAtomValue } from 'jotai'
-import { visibleDataAtom, dataMapAtom, rankedDataMapAtom } from '../atom/dataAtom'
+import { nonInferredDataAtom, dataMapAtom, rankedDataMapAtom } from '../atom/dataAtom'
 import {
   correlationAlphaAtom,
   correlationAlternativeAtom,
@@ -11,7 +11,7 @@ import { calculateSpearmanRanked, calculatePearson } from '../processors/stats'
 import { CHART_PALETTE } from './Chart2'
 
 const CorrelationNetworkChart = React.memo(() => {
-  const visibleData = useAtomValue(visibleDataAtom)
+  const visibleData = useAtomValue(nonInferredDataAtom)
   const dataMap = useAtomValue(dataMapAtom)
   const rankedDataMap = useAtomValue(rankedDataMapAtom)
   const alpha = useAtomValue(correlationAlphaAtom)
@@ -32,159 +32,158 @@ const CorrelationNetworkChart = React.memo(() => {
 
     // Create nodes for all visible data
     for (let i = 0; i < numData; i++) {
-        const item = visibleData[i]
-        nodesSet.add(item[0])
+      const item = visibleData[i]
+      nodesSet.add(item[0])
     }
 
     if (method === 'pearson') {
-       // Pre-parse the source values and record valid indices to avoid O(N * M) parsing and null checks.
-       // This is complex for N*N matrix, so we'll do it pair-wise carefully.
+      // Pre-parse the source values and record valid indices to avoid O(N * M) parsing and null checks.
+      // This is complex for N*N matrix, so we'll do it pair-wise carefully.
 
-       for (let i = 0; i < numData; i++) {
-          const sourceName = visibleData[i][0]
-          const sourceValuesRaw = dataMap.get(sourceName)?.[1]
-          if (!sourceValuesRaw) continue
+      for (let i = 0; i < numData; i++) {
+        const sourceName = visibleData[i][0]
+        const sourceValuesRaw = dataMap.get(sourceName)?.[1]
+        if (!sourceValuesRaw) continue
 
-          const len = sourceValuesRaw.length
-          const parsedSource = new Float64Array(len)
-          const validIndices: number[] = []
+        const len = sourceValuesRaw.length
+        const parsedSource = new Float64Array(len)
+        const validIndices: number[] = []
 
-          for (let k = 0; k < len; k++) {
-            const v = sourceValuesRaw[k]
-            if (v !== null) {
-              const vNum = Number(v)
-              if (!isNaN(vNum)) {
-                parsedSource[k] = vNum
-                validIndices.push(k)
-              }
+        for (let k = 0; k < len; k++) {
+          const v = sourceValuesRaw[k]
+          if (v !== null) {
+            const vNum = Number(v)
+            if (!isNaN(vNum)) {
+              parsedSource[k] = vNum
+              validIndices.push(k)
             }
           }
-
-          const maxLen = validIndices.length
-          if (maxLen < 4) continue
-
-          const x = new Float64Array(maxLen)
-          const y = new Float64Array(maxLen)
-
-          for (let j = i + 1; j < numData; j++) {
-              const targetName = visibleData[j][0]
-              const targetValuesRaw = dataMap.get(targetName)?.[1]
-              if (!targetValuesRaw) continue
-
-              let count = 0
-              for (let k = 0; k < maxLen; k++) {
-                  const idx = validIndices[k]
-                  const t = targetValuesRaw[idx]
-                  if (t !== null) {
-                      const tNum = Number(t)
-                      if (!isNaN(tNum)) {
-                          x[count] = parsedSource[idx]
-                          y[count] = tNum
-                          count++
-                      }
-                  }
-              }
-
-              if (count < 4) continue
-
-              const result = calculatePearson(x.subarray(0, count), y.subarray(0, count), options)
-              if (result.pValue <= alpha) {
-                  validPairs.push({ source: sourceName, target: targetName, rho: result.pcorr, pValue: result.pValue })
-              }
-          }
-       }
-    } else {
-        // Spearman
-        for (let i = 0; i < numData; i++) {
-            const sourceName = visibleData[i][0]
-            const sourceRanks = rankedDataMap.get(sourceName)
-            if (!sourceRanks) continue
-
-            for (let j = i + 1; j < numData; j++) {
-                const targetName = visibleData[j][0]
-                const targetRanks = rankedDataMap.get(targetName)
-                if (!targetRanks) continue
-
-                const result = calculateSpearmanRanked(sourceRanks, targetRanks, options)
-                if (result.pValue <= alpha) {
-                    validPairs.push({ source: sourceName, target: targetName, rho: result.pcorr, pValue: result.pValue })
-                }
-            }
         }
+
+        const maxLen = validIndices.length
+        if (maxLen < 4) continue
+
+        const x = new Float64Array(maxLen)
+        const y = new Float64Array(maxLen)
+
+        for (let j = i + 1; j < numData; j++) {
+          const targetName = visibleData[j][0]
+          const targetValuesRaw = dataMap.get(targetName)?.[1]
+          if (!targetValuesRaw) continue
+
+          let count = 0
+          for (let k = 0; k < maxLen; k++) {
+            const idx = validIndices[k]
+            const t = targetValuesRaw[idx]
+            if (t !== null) {
+              const tNum = Number(t)
+              if (!isNaN(tNum)) {
+                x[count] = parsedSource[idx]
+                y[count] = tNum
+                count++
+              }
+            }
+          }
+
+          if (count < 4) continue
+
+          const result = calculatePearson(x.subarray(0, count), y.subarray(0, count), options)
+          if (result.pValue <= alpha) {
+            validPairs.push({
+              source: sourceName,
+              target: targetName,
+              rho: result.pcorr,
+              pValue: result.pValue,
+            })
+          }
+        }
+      }
+    } else {
+      // Spearman
+      for (let i = 0; i < numData; i++) {
+        const sourceName = visibleData[i][0]
+        const sourceRanks = rankedDataMap.get(sourceName)
+        if (!sourceRanks) continue
+
+        for (let j = i + 1; j < numData; j++) {
+          const targetName = visibleData[j][0]
+          const targetRanks = rankedDataMap.get(targetName)
+          if (!targetRanks) continue
+
+          const result = calculateSpearmanRanked(sourceRanks, targetRanks, options)
+          if (result.pValue <= alpha) {
+            validPairs.push({
+              source: sourceName,
+              target: targetName,
+              rho: result.pcorr,
+              pValue: result.pValue,
+            })
+          }
+        }
+      }
     }
 
     const degreeMap = new Map<string, number>()
 
-    validPairs.forEach(pair => {
-        const isPositive = pair.rho > 0
-        const absRho = Math.abs(pair.rho)
-        const width = 0.5 + Math.pow(absRho, 4) * 8;
-        const opacity = 0.1 + absRho * 0.4;
+    validPairs.forEach((pair) => {
+      const isPositive = pair.rho > 0
+      const absRho = Math.abs(pair.rho)
+      const width = 0.5 + Math.pow(absRho, 4) * 8
+      const opacity = 0.1 + absRho * 0.4
 
-        edges.push({
-            source: pair.source,
-            target: pair.target,
-            value: pair.rho,
-            lineStyle: {
-              width: width,
-              curveness: 0.15,
-              type: 'solid',
-              color: isPositive ? '#10b981' : '#ef4444',
-              opacity: opacity,
-            }
-        })
+      edges.push({
+        source: pair.source,
+        target: pair.target,
+        value: pair.rho,
+        lineStyle: {
+          width: width,
+          curveness: 0.15,
+          type: 'solid',
+          color: isPositive ? '#10b981' : '#ef4444',
+          opacity: opacity,
+        },
+      })
 
-        degreeMap.set(pair.source, (degreeMap.get(pair.source) || 0) + 1)
-        degreeMap.set(pair.target, (degreeMap.get(pair.target) || 0) + 1)
+      degreeMap.set(pair.source, (degreeMap.get(pair.source) || 0) + 1)
+      degreeMap.set(pair.target, (degreeMap.get(pair.target) || 0) + 1)
     })
 
     // Add nodes
     // Dummy background node to capture roam events everywhere
-    nodes.push({ id: '__background', name: '', fixed: true, x: 500, y: 500, symbolSize: 5000, itemStyle: { color: 'transparent' } })
-
-
-    Array.from(nodesSet).forEach((nodeName, index) => {
-        const degree = degreeMap.get(nodeName) || 0
-        const size = 15 + degree * 2 // Node size proportional to connections
-        const colorIndex = index % CHART_PALETTE.length
-
-        // Hide nodes with 0 connections if there are many nodes?
-        // We'll show all to maintain "entire web", but make them small.
-        nodes.push({
-            id: nodeName,
-            name: nodeName,
-            symbolSize: size,
-            itemStyle: {
-                color: CHART_PALETTE[colorIndex]
-            },
-            label: {
-                show: degree > 0, // only show labels for connected nodes to avoid clutter
-                color: '#a3a3a3',
-                position: 'bottom'
-            }
-        })
+    nodes.push({
+      id: '__background',
+      name: '',
+      fixed: true,
+      x: 500,
+      y: 500,
+      symbolSize: 5000,
+      itemStyle: { color: 'transparent' },
     })
 
+    Array.from(nodesSet).forEach((nodeName, index) => {
+      const degree = degreeMap.get(nodeName) || 0
+      const size = 15 + degree * 2 // Node size proportional to connections
+      const colorIndex = index % CHART_PALETTE.length
+
+      // Hide nodes with 0 connections if there are many nodes?
+      // We'll show all to maintain "entire web", but make them small.
+      nodes.push({
+        id: nodeName,
+        name: nodeName,
+        symbolSize: size,
+        itemStyle: {
+          color: CHART_PALETTE[colorIndex],
+        },
+        label: {
+          show: degree > 0, // only show labels for connected nodes to avoid clutter
+          color: '#a3a3a3',
+          position: 'bottom',
+        },
+      })
+    })
 
     return {
       theme: 'dark',
-      graphic: [
-        {
-          type: 'rect',
-          left: 0,
-          top: 0,
-          right: 0,
-          bottom: 0,
-          bounding: 'all',
-          style: {
-            fill: 'rgba(0,0,0,0.01)'
-          },
-          cursor: 'default',
-          // Graphic events don't automatically trigger roam, but they capture mouse.
-          // However, if the graphic is behind the graph (z: -1), does roam work?
-          z: -1
-        }
-      ],
       backgroundColor: 'transparent',
       tooltip: {
         backgroundColor: '#111111',
@@ -201,10 +200,9 @@ const CorrelationNetworkChart = React.memo(() => {
       toolbox: {
         show: true,
         feature: {
-
           restore: {},
-          saveAsImage: {}
-        }
+          saveAsImage: {},
+        },
       },
       series: [
         {
@@ -218,7 +216,8 @@ const CorrelationNetworkChart = React.memo(() => {
           initLayout: 'circular',
           layoutAnimation: true,
           layout: 'force',
-          roam: true, scaleLimit: { min: 0.1, max: 10 },
+          roam: true,
+          scaleLimit: { min: 0.1, max: 10 },
           draggable: false,
 
           label: {

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -151,13 +151,22 @@ const CorrelationNetworkChart = React.memo(() => {
     // Add nodes
     // Dummy background node to capture roam events everywhere
     nodes.push({
-      id: '__background',
+      id: '__bg_1',
       name: '',
       fixed: true,
-      x: 500,
-      y: 500,
-      symbolSize: 5000,
-      itemStyle: { color: 'transparent' },
+      x: 0,
+      y: 0,
+      symbolSize: 0,
+      itemStyle: { opacity: 0 },
+    })
+    nodes.push({
+      id: '__bg_2',
+      name: '',
+      fixed: true,
+      x: 2000,
+      y: 2000,
+      symbolSize: 0,
+      itemStyle: { opacity: 0 },
     })
 
     Array.from(nodesSet).forEach((nodeName, index) => {

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -171,6 +171,7 @@ const CorrelationNetworkChart = React.memo(() => {
 
     Array.from(nodesSet).forEach((nodeName, index) => {
       const degree = degreeMap.get(nodeName) || 0
+      if (degree === 0) return
       const size = 15 + degree * 2 // Node size proportional to connections
       const colorIndex = index % CHART_PALETTE.length
 

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -471,9 +471,7 @@ export default React.memo<NavProps>(
                 onClick={onToggleNetworkView}
                 title="View Biomarker Network Graph"
                 className={`hidden md:flex ml-4 px-3 py-1 text-xs font-medium text-white rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 transition-colors ${
-                  isNetworkViewOpen
-                    ? 'bg-blue-700 shadow-inner'
-                    : 'bg-blue-600 hover:bg-blue-500'
+                  isNetworkViewOpen ? 'bg-blue-700 shadow-inner' : 'bg-blue-600 hover:bg-blue-500'
                 }`}
                 aria-pressed={isNetworkViewOpen}
               >


### PR DESCRIPTION
- Use nonInferredDataAtom instead of visibleDataAtom to ensure all actual non-inferred data is used for correlation, not just the visible data.
- Remove the transparent graphic overlay in the ECharts configuration to allow mouse events to reach the graph components, fixing drag and zoom functionality.

---
*PR created automatically by Jules for task [6707945640441323076](https://jules.google.com/task/6707945640441323076) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch correlation to use the full non‑inferred dataset and make the network graph’s drag/zoom work across the whole canvas. Also hides unconnected nodes for a cleaner view.

- **Bug Fixes**
  - Compute correlations from `nonInferredDataAtom` instead of `visibleDataAtom` to include all real measurements.
  - Restore drag/zoom by removing the blocking ECharts `graphic` overlay and adding two invisible boundary nodes at `[0,0]` and `[2000,2000]` to expand the roam hit area.
  - Exclude nodes with no edges to reduce clutter.

<sup>Written for commit 2955acc1966a3580e6dca207476f3ef8373b2974. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/365?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

