### PR TITLE
Fix weak type annotation in Chart2 dataset

### DIFF
--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -5,6 +5,7 @@ import { dataMapAtom } from '../atom/dataAtom'
 import { labels, formattedLabels } from '../data'
 import ReactECharts from 'echarts-for-react'
 import * as echarts from 'echarts'
+import type { DatasetComponentOption } from 'echarts'
 import * as ecStat from 'echarts-stat'
 import { ChartProps } from './Chart.types'
 
@@ -168,7 +169,7 @@ export default memo(({ keys }: ChartProps) => {
     const nextXAxis = [{ ...xAxis[0], name: keys[0] }, ...xAxis.slice(1)]
     const nextYAxis = [{ ...yAxis[0], name: keys[1] }, ...yAxis.slice(1)]
 
-    const dataset: any[] = [
+    const dataset: DatasetComponentOption[] = [
       {
         dimensions: [keys[0], keys[1], 'Date', 'unitX', 'unitY'],
         source: mappedScatterData.data,


### PR DESCRIPTION
**The Issue:**
`src/layout/Chart2.tsx` line 171 used a weak `any` type for the `dataset` array holding ECharts configurations, bypassing strict type checking. This was identified as a structural problem during discovery scans.

**The Discovery Signal:**
Scan C (Weak or Missing Type Annotations) surfaced this issue: `src/layout/Chart2.tsx` line 171 used explicit `any[]` where a concrete type was available from the library.

**The Fix:**
Imported `DatasetComponentOption` from the existing `echarts` dependency and replaced `const dataset: any[]` with `const dataset: DatasetComponentOption[]`.

**The Benefit:**
Improved strict type safety for the ECharts dataset configuration in `Chart2.tsx`, reducing the risk of unsafe runtime patterns and ensuring the code compiles cleanly under `tsc --noEmit --strict`. The fix was applied without modifying any logic or UI behavior, adhering strictly to code maintainability goals.

---
*PR created automatically by Jules for task [5472504134045813621](https://jules.google.com/task/5472504134045813621) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened typing in `src/layout/Chart2.tsx` by replacing the dataset’s `any[]` with `DatasetComponentOption[]` from `echarts`, improving strict type safety with no behavior changes.

<sup>Written for commit a84def00b444af79e6827534b32d219822542170. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/366?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

