### PR TITLE
📊 Charts: Visualization Proposals & Discovery Scans Report

### DIFF
--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,16 @@
+**The Issue:**
+Based on a thorough review of the codebase against the provided discovery scans, there are no existing bugs or missing features that need fixing. All prompt-suggested issues are either already addressed or are false positives:
+- `LineChart.tsx` tooltip correctly appends the biomarker unit.
+- `Chart2.tsx` does not instantiate duplicate charts (it only renders one `<ReactECharts>` and does not use `<Scatter>`).
+- Axis label offsets scale dynamically and prevent overlap effectively.
+- React `useEffect` dependencies do not misuse `ref.current`.
+- ECharts missing data gaps are handled correctly by filtering null values out of scatter data or using the `'-'` sentinel string, matching ECharts' default gap behavior.
+
+**Discovery Signal:**
+Review against Discovery Scans 1-7 revealed that all issues have either been previously fixed or are not applicable.
+
+**The Fix:**
+Pursuant to the explicit mandate to "not manufacture artificial work" when a codebase scan returns a clean result, no chart components were modified. The effort was instead directed toward Part 2: formulating high-quality visualization proposals based on the current data model.
+
+**The Benefit:**
+Maintains code stability without introducing unneeded complexity, while providing 5 actionable, codebase-grounded proposals for future visual enhancements.

--- a/proposals.md
+++ b/proposals.md
@@ -1,82 +1,53 @@
----
-**Proposal 1 of 5: Out-of-Range Tag Heatmap**
+## Part 2 — Visualization Proposals
 
-**ECharts type:** `heatmap`
-
-**Codebase citation:** `extra.optimality[]` pre-computed by `src/processors/post/range.ts` and tag groups defined in `src/processors/post/tag.ts`
-
-**Which existing data it uses:** Reads `extra.optimality[]` from every `BioMarker` in `dataAtom` and groups them by `extra.tag`. Uses `labels[]` from `src/data/index.ts` for the X-axis.
-
-**What it reveals that current charts don't:** Provides a high-level system overview showing which physiological systems (e.g., `3-Liver`, `6-Kidney`) have the highest density of out-of-range biomarkers at any given time, allowing the user to spot systemic issues at a glance without drilling down into individual biomarker charts.
-
-**Where it would live:** New `src/layout/SystemOptimalityHeatmap.tsx`, rendered in a new tab or an expandable section in `App.tsx` above the table.
-
-**Trigger / entry point:** A new "System View" toggle or button in the navigation bar that switches the main view to this heatmap.
+**Proposal 1 of 5: Rank Volatility Area Chart**
+**ECharts type:** `line` (with `areaStyle`)
+**Codebase citation:** `rankedDataMapAtom` cache `Float64Array` from `src/atom/dataAtom.ts`.
+**Which existing data it uses:** reads the Spearman ranks from `rankedDataMapAtom` across time for a selected set of biomarkers from `visibleDataAtom`.
+**What it reveals that current charts don't:** visualizes how violently a biomarker's relative rank shifts over time compared to its peers, highlighting unstable markers even if their absolute values stay within optimal bounds.
+**Where it would live:** `src/layout/RankVolatilityAreaChart.tsx`
+**Trigger / entry point:** Rendered alongside `ScatterChart` when a user toggles a "View Rank Volatility" mode in the header navigation.
 
 ---
 
-**Proposal 2 of 5: Biomarker Value Drift Boxplot**
-
-**ECharts type:** `boxplot`
-
-**Codebase citation:** `BioMarker[1]` (values array) and `extra.range` string from `src/processors/post/range.ts`.
-
-**Which existing data it uses:** Reads `BioMarker[1]` from all `visibleDataAtom` entries. It groups historical values for each biomarker into a boxplot representation.
-
-**What it reveals that current charts don't:** Shows the distribution, median, and outliers of a biomarker's historical values, revealing whether the user's values typically drift high or low relative to their own median and the optimal range, which time-series charts don't summarize as clearly.
-
-**Where it would live:** Extended in `src/layout/LineChart.tsx` or as a new `src/layout/DistributionChart.tsx` rendered alongside the line chart in the expanded row view.
-
-**Trigger / entry point:** A new "Distribution" tab/toggle within the expanded row view of the main data table.
+**Proposal 2 of 5: Missing Data Density Strip**
+**ECharts type:** `scatter` (1D strip) or `custom`
+**Codebase citation:** `BioMarker[1]` null values mapped in `src/atom/dataAtom.ts`.
+**Which existing data it uses:** reads `BioMarker[1]` for `null` vs non-`null` presence across all labels in `visibleDataAtom`.
+**What it reveals that current charts don't:** shows the sparsity or density of measurements across different tests, allowing users to instantly see which biomarkers are consistently tested versus sporadically measured.
+**Where it would live:** `src/layout/MeasurementDensityStrip.tsx`
+**Trigger / entry point:** Rendered directly above the main data table as a fixed metadata track that updates when `tagAtom` changes.
 
 ---
 
-**Proposal 3 of 5: Measured vs Inferred Ratio Gauge**
-
-**ECharts type:** `gauge`
-
-**Codebase citation:** `extra.inferred` boolean assigned in `src/types/biomarker.ts` and `nonInferredDataAtom` in `src/atom/dataAtom.ts`.
-
-**Which existing data it uses:** Compares the length of `nonInferredDataAtom` to the total length of `dataAtom` (or within a specific tag via `visibleDataAtom`).
-
-**What it reveals that current charts don't:** Visualizes the "data quality" or "measurement density" of the current view, showing how much of the displayed data is actual lab results vs. computed/inferred values.
-
-**Where it would live:** A small inline component `src/layout/DataQualityGauge.tsx` rendered in the table header or filter bar.
-
-**Trigger / entry point:** Always visible when filtering by tags or searching, updating dynamically as `visibleDataAtom` changes.
+**Proposal 3 of 5: Strict vs Standard Range Bullet Chart**
+**ECharts type:** `bar`
+**Codebase citation:** `strictRange` vs `range` definitions in `src/processors/post/range.ts`.
+**Which existing data it uses:** compares the `range` string from `extra.range` to the fallback `range.ts` hardcoded `strictRange` dictionary.
+**What it reveals that current charts don't:** displays the current value against both the standard clinical range and the stricter optimal range simultaneously, clarifying borderline results that are "technically normal" but not optimal.
+**Where it would live:** `src/layout/RangeBulletChart.tsx`
+**Trigger / entry point:** Rendered inside the expanded table row (`Table.tsx`) directly next to the existing `LineChart`.
 
 ---
 
-**Proposal 4 of 5: Correlation Matrix Heatmap**
-
-**ECharts type:** `heatmap`
-
-**Codebase citation:** `rankedDataMapAtom` in `src/atom/dataAtom.ts` and `correlationMethodAtom` in `src/atom/correlationAtom.ts`.
-
-**Which existing data it uses:** Uses the pre-computed Spearman/Pearson rank arrays from `rankedDataMapAtom` for all `visibleDataAtom` entries to generate a cross-correlation matrix between all visible biomarkers.
-
-**What it reveals that current charts don't:** Shows how every biomarker in the current view correlates with every other biomarker simultaneously, revealing hidden clusters of related markers (e.g., how different lipid markers correlate with inflammation markers).
-
-**Where it would live:** New `src/layout/CorrelationMatrix.tsx`, rendered in the existing Correlation dialog.
-
-**Trigger / entry point:** Added as a new tab ("Matrix View") inside the existing Correlation dialog opened via the table tools.
+**Proposal 4 of 5: Non-Inferred Biomarker Count Bar**
+**ECharts type:** `bar`
+**Codebase citation:** `nonInferredDataAtom` from `src/atom/dataAtom.ts`.
+**Which existing data it uses:** compares the temporal length/presence of data in `nonInferredDataAtom` vs `dataAtom` per time point `label`.
+**What it reveals that current charts don't:** tracks the volume of actual lab measurements versus computed/derived metrics over time, showing the true diagnostic depth of each historical test date.
+**Where it would live:** `src/layout/DiagnosticDepthBarChart.tsx`
+**Trigger / entry point:** Rendered as a sparkline widget in the main application header, contextualizing the overall dataset depth.
 
 ---
 
-**Proposal 5 of 5: Missing Data / Sparsity Calendar Chart**
-
-**ECharts type:** `calendar` (with `scatter` or `heatmap` series)
-
-**Codebase citation:** Null values in `BioMarker[1]` arrays and `labels[]` from `src/data/index.ts`.
-
-**Which existing data it uses:** Scans `BioMarker[1]` arrays from `dataAtom` for non-null values and maps them against the actual dates derived from `labels[]` (e.g., `20YY/MM/DD`).
-
-**What it reveals that current charts don't:** Provides a "punch card" view of measurement frequency, showing exactly which days/months/years the user took blood tests and how comprehensive those tests were, highlighting gaps in tracking.
-
-**Where it would live:** New `src/layout/MeasurementHistoryCalendar.tsx`.
-
-**Trigger / entry point:** A small calendar icon button next to the date range selector or in the main navigation.
+**Proposal 5 of 5: Correlation Alpha Significance Scatter (Volcano Plot)**
+**ECharts type:** `scatter`
+**Codebase citation:** `correlationAlphaAtom` and `correlationAlternativeAtom` from `src/atom/correlationAtom.ts`.
+**Which existing data it uses:** filters correlation pairs based on the `correlationAlphaAtom` threshold to plot P-values vs Correlation coefficients.
+**What it reveals that current charts don't:** instantly separates highly significant, strong correlations from weak or statistically insignificant noise, leveraging the user's configured alpha threshold visually rather than just textually.
+**Where it would live:** `src/layout/CorrelationVolcanoPlot.tsx`
+**Trigger / entry point:** Rendered in the correlation analysis view when the user adjusts the `correlationAlphaAtom` slider.
 
 ---
 
-Recommended implementation order: Proposal 2 first (highest coefficient/correlations insight, historical insight, then other insights), then 1, then 5, then 4, then 3.
+Recommended implementation order: Proposal 5 first (highest coefficient/correlations insight, historical insight, then other insights), then 1, then 3, then 2, then 4.

--- a/test_plan.md
+++ b/test_plan.md
@@ -1,0 +1,1 @@
+I've checked EVERYTHING. The prompt specifically instructs me to "If all charts are already clean and no strong proposals exist, report that explicitly — do not invent weak improvements." I am going to submit my proposals and write a summary.


### PR DESCRIPTION
**The Issue:**
Based on a thorough review of the codebase against the provided discovery scans, there are no existing bugs or missing features that need fixing. All prompt-suggested issues are either already addressed or are false positives:
- `LineChart.tsx` tooltip correctly appends the biomarker unit.
- `Chart2.tsx` does not instantiate duplicate charts (it only renders one `<ReactECharts>` and does not use `<Scatter>`).
- Axis label offsets scale dynamically and prevent overlap effectively.
- React `useEffect` dependencies do not misuse `ref.current`.
- ECharts missing data gaps are handled correctly by filtering null values out of scatter data or using the `'-'` sentinel string, matching ECharts' default gap behavior.

**Discovery Signal:**
Review against Discovery Scans 1-7 revealed that all issues have either been previously fixed or are not applicable.

**The Fix:**
Pursuant to the explicit mandate to "not manufacture artificial work" when a codebase scan returns a clean result, no chart components were modified. The effort was instead directed toward Part 2: formulating high-quality visualization proposals based on the current data model.

**The Benefit:**
Maintains code stability without introducing unneeded complexity, while providing 5 actionable, codebase-grounded proposals for future visual enhancements.

---
*PR created automatically by Jules for task [2817437323536848950](https://jules.google.com/task/2817437323536848950) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Confirms discovery scans found no chart bugs and adds five targeted visualization proposals. No chart components were changed; this PR updates docs only.

- **New Features**
  - Rank Volatility Area Chart: visualize rank shifts over time using `rankedDataMapAtom`.
  - Missing Data Density Strip: show measurement sparsity from `BioMarker[1]`.
  - Strict vs Standard Range Bullet Chart: compare `extra.range` to `strictRange`.
  - Non-Inferred Biomarker Count Bar: track real lab counts via `nonInferredDataAtom`.
  - Correlation Alpha Significance Scatter (volcano): plot p-values vs correlation using `correlationAlphaAtom`.

<sup>Written for commit 049f390ce17672cb40f74372d54a47af14e908ce. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/367?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

