### PR TITLE
refactor: extract ScatterChartProps to sibling types file

### DIFF
--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -4,10 +4,7 @@ import { dataMapAtom } from '../atom/dataAtom'
 import ReactECharts from 'echarts-for-react'
 import { labels, formattedLabels } from '../data'
 import { CHART_PALETTE } from './Chart2'
-
-interface ScatterChartProps {
-  keys: string[]
-}
+import type { ScatterChartProps } from './ScatterChart.types'
 
 const echartsOptions = {
   style: { height: 400 },

--- a/src/layout/ScatterChart.types.ts
+++ b/src/layout/ScatterChart.types.ts
@@ -1,0 +1,3 @@
+export interface ScatterChartProps {
+  keys: string[]
+}


### PR DESCRIPTION
**The Issue:**
`src/layout/ScatterChart.tsx` lines 8-10 — The `ScatterChartProps` interface was defined inline within the component file. This violates the project's structural pattern, which dictates that components with complex props should have a sibling `.types.ts` file (e.g., `Nav.types.ts`, `Table.types.ts`).

**The Discovery Signal:**
Scan A: Checked each `.tsx` file for `interface` or `type` declarations. I found `ScatterChartProps` defined inline in `src/layout/ScatterChart.tsx` rather than in a dedicated types file.

**The Fix:**
Extracted the `ScatterChartProps` interface definition from `src/layout/ScatterChart.tsx` into a newly created sibling file, `src/layout/ScatterChart.types.ts`. I then imported `ScatterChartProps` into `ScatterChart.tsx` using `import type { ScatterChartProps } from './ScatterChart.types'`.

**The Benefit:**
Improved structural consistency. This change aligns `ScatterChart` with the rest of the codebase's file structure conventions, making the codebase easier to navigate and preventing confusion for future engineers and agents working on the repository.

---
*PR created automatically by Jules for task [1527319358302805422](https://jules.google.com/task/1527319358302805422) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the `ScatterChartProps` interface from `src/layout/ScatterChart.tsx` into a new sibling `src/layout/ScatterChart.types.ts`, and updated the component to import it. This aligns with our types-by-file pattern and keeps props definitions organized.

<sup>Written for commit b64f185d9695d90e2fc6b158ab4aa75e91493b48. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/368?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

