### PR TITLE
fix: replace explicit any on Chart component ref with strict ElementRef

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useEffect, useMemo, useState, useCallback } from 'react'
+import { memo, useRef, useEffect, useMemo, useState, useCallback, ElementRef } from 'react'
 import { useAtomValue } from 'jotai'
 import { dataMapAtom } from '../atom/dataAtom'
 import { ChartProvider, ChartContext } from '@echarts-readymade/core'
@@ -156,10 +156,10 @@ export default memo(({ keys }: ChartProps) => {
     return result
   }, [dataMap, keys, valueList])
 
-  const ref = useRef<any>(null)
+  const ref = useRef<ElementRef<typeof Line> | null>(null)
   const [isChartReady, setIsChartReady] = useState(false)
 
-  const handleRef = useCallback((node: any) => {
+  const handleRef = useCallback((node: ElementRef<typeof Line> | null) => {
     ref.current = node
     if (node) {
       setIsChartReady(true)


### PR DESCRIPTION
**The Issue:**
In `src/layout/Chart.tsx` at lines 159 and 162, a React `useRef` and its associated `useCallback` hook parameter were typed with an explicit `any` (`const ref = useRef<any>(null)`). This is a structural problem because it bypasses TypeScript's safety mechanisms for the ECharts instance (`@echarts-readymade/line`), allowing arbitrary method calls (like `getEchartsInstance()`) without compiler verification.

**The Discovery Signal:**
Scan C (Weak or Missing Type Annotations) triggered this. A recursive grep search for `any` usage (`grep -rn "any" src/layout/Chart.tsx`) returned the explicit `any` typings on the `ref` variable and the `node` parameter in `handleRef`.

**The Fix:**
I imported the native React utility `ElementRef` into `src/layout/Chart.tsx`. I replaced `useRef<any>(null)` with `useRef<ElementRef<typeof Line> | null>(null)` and updated the parameter on line 162 to match: `(node: ElementRef<typeof Line> | null)`. This directly inferred the type shape without inventing any new types.

**The Benefit:**
Concrete maintenance win: Eliminated an unsafe runtime pattern where the ECharts wrapper could potentially lack the `.getEchartsInstance()` method unnoticed by the compiler. We achieved robust type-checking for the chart ref interaction while maintaining a clean, error-free `tsc --noEmit --strict` build.

---
*PR created automatically by Jules for task [3168242532609668215](https://jules.google.com/task/3168242532609668215) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced explicit `any` on the Chart ref with strict `ElementRef<typeof Line>` in `src/layout/Chart.tsx`, and updated the ref callback parameter to match. This improves type safety when accessing the chart instance and keeps strict TypeScript builds clean.

<sup>Written for commit ca989e576f4fc222056d54f80b56eaf57e2ff831. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/371?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

