### PR TITLE
⚡ Bolt: Hoist TypedArray Allocations in Hot Correlation Loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -14,3 +14,7 @@
 
 **Learning:** Replaced array.map() with traditional for-loops, saving closure allocation and function call overheads per item.
 **Action:** Replace `recipes.map(...)` with `for (let i = 0; i < recipes.length; i++)` and preallocate output arrays where lengths are known statically.
+
+## 2024-05-18 - TypedArray Buffer Sizing Bug in Nested Loops
+**Learning:** When hoisting TypedArray allocations (like `Float64Array` and `Int32Array`) out of N-squared rendering loops, you cannot assume all datasets share the exact same length by just checking `data[0].length`. If a subsequent array is longer than the hoisted buffer, JS will silently ignore out-of-bounds writes, leading to data truncation and broken charts.
+**Action:** Always safely pre-calculate the true maximum length across *all* datasets you intend to process before allocating shared or hoisted TypedArrays. Use `.subarray(0, actualLength)` when slicing into the buffer inside the loop.

--- a/src/layout/BiomarkerCorrelationBumpChart.tsx
+++ b/src/layout/BiomarkerCorrelationBumpChart.tsx
@@ -27,13 +27,16 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
     const targetRanks = rankedDataMap.get(targetBiomarker)
     if (!targetRanks) return {}
 
-    const validIndices: number[] = []
-    for (let i = 0; i < formattedLabels.length; i++) {
+    const maxLen = formattedLabels.length
+    const validIndicesArray = new Int32Array(maxLen)
+    let count = 0
+    for (let i = 0; i < maxLen; i++) {
       if (!Number.isNaN(targetRanks[i])) {
-        validIndices.push(i)
+        validIndicesArray[count++] = i
       }
     }
-    const count = validIndices.length
+
+    const validIndices = validIndicesArray.subarray(0, count)
 
     // Create binary vectors for top supplements over the entire valid length
     const suppVectors = new Map<string, Int8Array>()
@@ -76,7 +79,7 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
       const endIdxInValid =
         w === numWindowsDynamic - 1 ? count : Math.floor(((w + 1) * count) / numWindowsDynamic)
 
-      const windowValidIndices = validIndices.slice(startIdxInValid, endIdxInValid)
+      const windowValidIndices = validIndices.subarray(startIdxInValid, endIdxInValid)
       const windowCount = windowValidIndices.length
 
       // Use the last date of the window for the label so we can see the time span

--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -50,7 +50,8 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
       // Pre-parse the source values and record valid indices to avoid O(N * M) parsing and null checks.
       const len = sourceValues.length
       const parsedSource = new Float64Array(len)
-      const validIndices: number[] = []
+      const validIndicesArray = new Int32Array(len)
+      let validCount = 0
 
       for (let i = 0; i < len; i++) {
         const v = sourceValues[i]
@@ -58,14 +59,16 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
           const vNum = Number(v)
           if (!isNaN(vNum)) {
             parsedSource[i] = vNum
-            validIndices.push(i)
+            validIndicesArray[validCount++] = i
           }
         }
       }
 
+      const validIndices = validIndicesArray.subarray(0, validCount)
+
       // Optimization: Pre-allocate Float64Arrays for pairwise values and reuse them
       // across targets to avoid the overhead of `[]` array allocations and `push()` inside the loop.
-      const maxLen = validIndices.length
+      const maxLen = validCount
       const x = new Float64Array(maxLen)
       const y = new Float64Array(maxLen)
 

--- a/src/layout/CorrelationNetworkChart.tsx
+++ b/src/layout/CorrelationNetworkChart.tsx
@@ -37,6 +37,20 @@ const CorrelationNetworkChart = React.memo(() => {
     }
 
     if (method === 'pearson') {
+      // Optimization: Hoist TypedArray allocations outside the loops to eliminate
+      // O(N^2) dynamic allocations and garbage collection overhead in hot network rendering.
+      // Use Int32Array for validIndices instead of standard arrays with .push().
+      let maxDatasetLen = 0
+      for (let i = 0; i < numData; i++) {
+        const len = dataMap.get(visibleData[i][0])?.[1].length || 0
+        if (len > maxDatasetLen) maxDatasetLen = len
+      }
+
+      const parsedSource = new Float64Array(maxDatasetLen)
+      const validIndicesArray = new Int32Array(maxDatasetLen)
+      const x = new Float64Array(maxDatasetLen)
+      const y = new Float64Array(maxDatasetLen)
+
       // Pre-parse the source values and record valid indices to avoid O(N * M) parsing and null checks.
       // This is complex for N*N matrix, so we'll do it pair-wise carefully.
 
@@ -46,8 +60,7 @@ const CorrelationNetworkChart = React.memo(() => {
         if (!sourceValuesRaw) continue
 
         const len = sourceValuesRaw.length
-        const parsedSource = new Float64Array(len)
-        const validIndices: number[] = []
+        let validCount = 0
 
         for (let k = 0; k < len; k++) {
           const v = sourceValuesRaw[k]
@@ -55,16 +68,13 @@ const CorrelationNetworkChart = React.memo(() => {
             const vNum = Number(v)
             if (!isNaN(vNum)) {
               parsedSource[k] = vNum
-              validIndices.push(k)
+              validIndicesArray[validCount++] = k
             }
           }
         }
 
-        const maxLen = validIndices.length
-        if (maxLen < 4) continue
-
-        const x = new Float64Array(maxLen)
-        const y = new Float64Array(maxLen)
+        if (validCount < 4) continue
+        const validIndices = validIndicesArray.subarray(0, validCount)
 
         for (let j = i + 1; j < numData; j++) {
           const targetName = visibleData[j][0]
@@ -72,7 +82,7 @@ const CorrelationNetworkChart = React.memo(() => {
           if (!targetValuesRaw) continue
 
           let count = 0
-          for (let k = 0; k < maxLen; k++) {
+          for (let k = 0; k < validCount; k++) {
             const idx = validIndices[k]
             const t = targetValuesRaw[idx]
             if (t !== null) {


### PR DESCRIPTION
💡 **What**: Hoisted `Float64Array` and `Int32Array` buffer allocations outside of nested N^2 rendering loops in `CorrelationNetworkChart`, `Correlation`, and `BiomarkerCorrelationBumpChart`. Replaced dynamically resizing `.push()` arrays with statically sized `Int32Array` using a `validCount` tracker and zero-copy `.subarray()`.

🎯 **Why**: In component render paths, especially for complex visualisations like Network charts, nested loops that constantly re-allocate objects and dynamically resize arrays trigger massive garbage collection spikes and JS engine de-optimizations, which blocks the main thread.

📊 **Impact**: Eliminates `O(N^2)` memory allocations and significantly reduces garbage collection overhead when filtering and parsing large data matrices for correlation rendering.

🔬 **Measurement**: Verified via `pnpm lint`, `pnpm exec tsc --noEmit --strict`, and the entire Playwright test suite (`pnpm exec playwright test`), which all pass successfully.

---
*PR created automatically by Jules for task [10462176910834762678](https://jules.google.com/task/10462176910834762678) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hoisted `Float64Array`/`Int32Array` allocations and replaced dynamic array pushes with preallocated buffers in correlation visualizations. This removes O(N^2) allocations, cuts GC pressure, and speeds up large renders.

- **Refactors**
  - Pre-allocate and reuse typed buffers in CorrelationNetworkChart, Correlation, and BiomarkerCorrelationBumpChart.
  - Replace `[]` + `.push()` with `Int32Array` + `validCount` and zero-copy `.subarray()`.
  - Compute maximum dataset length upfront to size buffers safely; switch `.slice()` to `.subarray()` where applicable.

<sup>Written for commit 53796f3f10148cf0a9ba317c55da54b04e76e1d7. Summary will update on new commits. <a href="https://cubic.dev/pr/fantasia949/myhealth/pull/372?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

