### PR TITLE
refactor: replace weakly typed useRefs with explicit ElementRefs

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useEffect, useMemo, useState, useCallback } from 'react'
+import { memo, useRef, useEffect, useMemo, useState, useCallback, ElementRef } from 'react'
 import { useAtomValue } from 'jotai'
 import { dataMapAtom } from '../atom/dataAtom'
 import { ChartProvider, ChartContext } from '@echarts-readymade/core'
@@ -156,10 +156,10 @@ export default memo(({ keys }: ChartProps) => {
     return result
   }, [dataMap, keys, valueList])
 
-  const ref = useRef<any>(null)
+  const ref = useRef<ElementRef<typeof Line> | null>(null)
   const [isChartReady, setIsChartReady] = useState(false)
 
-  const handleRef = useCallback((node: any) => {
+  const handleRef = useCallback((node: ElementRef<typeof Line> | null) => {
     ref.current = node
     if (node) {
       setIsChartReady(true)


### PR DESCRIPTION
Code quality engineer - Focused on code maintainability fix for weak typings.

---
*PR created automatically by Jules for task [11527692976645545334](https://jules.google.com/task/11527692976645545334) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced weakly typed refs in the chart with explicit React `ElementRef` to remove `any` and improve type safety. No runtime behavior changes.

- **Refactors**
  - Import `ElementRef` from `react` and use `useRef<ElementRef<typeof Line> | null>`.
  - Type `handleRef` as `ElementRef<typeof Line> | null` in `src/layout/Chart.tsx`.

<sup>Written for commit 262a30c47ac0e8a5c48d9f07f4c03468cdf5b516. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/376?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

