### PR TITLE
refactor(Chart): Replace weak `any` type with inferred ElementRef for component ref

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useEffect, useMemo, useState, useCallback } from 'react'
+import { memo, useRef, useEffect, useMemo, useState, useCallback, ElementRef } from 'react'
 import { useAtomValue } from 'jotai'
 import { dataMapAtom } from '../atom/dataAtom'
 import { ChartProvider, ChartContext } from '@echarts-readymade/core'
@@ -156,10 +156,10 @@ export default memo(({ keys }: ChartProps) => {
     return result
   }, [dataMap, keys, valueList])
 
-  const ref = useRef<any>(null)
+  const ref = useRef<ElementRef<typeof Line> | null>(null)
   const [isChartReady, setIsChartReady] = useState(false)
 
-  const handleRef = useCallback((node: any) => {
+  const handleRef = useCallback((node: ElementRef<typeof Line> | null) => {
     ref.current = node
     if (node) {
       setIsChartReady(true)


### PR DESCRIPTION
**The Issue:**
In `src/layout/Chart.tsx` (lines 159, 162), a React `ref` and its assignment callback (`handleRef`) were using weak explicit `any` types: `useRef<any>(null)` and `(node: any)`. This breaks type safety for the `Line` component instance, potentially leading to unsafe method calls (like `getEchartsInstance`) without proper compilation checking.

**The Discovery Signal:**
Scan C (Weak or Missing Type Annotations) flagged:
- `src/layout/Chart.tsx` line 162 — `handleRef = useCallback((node: any) => {`

**The Fix:**
I imported the `ElementRef` utility from React.
I updated `useRef<any>` to `useRef<ElementRef<typeof Line> | null>(null)`.
I updated `(node: any)` to `(node: ElementRef<typeof Line> | null)`.

**The Benefit:**
This improves maintainability and strictness by entirely eliminating the `any` surface area around the chart component reference. It uses the correct, inferred shape derived directly from the `@echarts-readymade/line` component without inventing any new ad-hoc interfaces or resorting to suppression comments. Code perfectly complies with `tsc --noEmit --strict` and `oxlint`.

---
*PR created automatically by Jules for task [2690726155982603113](https://jules.google.com/task/2690726155982603113) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `any` types for the chart ref with `ElementRef<typeof Line>` to restore type safety for the `Line` component and its ref callback. Updated `useRef` and `handleRef` to use `ElementRef<typeof Line> | null`, removing unsafe `any`.

<sup>Written for commit 6232aac67f13416506e2658cb5e84df35da3def8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

