### PR TITLE
Code Quality: Fix weak type annotation for Chart ref

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useEffect, useMemo, useState, useCallback } from 'react'
+import { memo, useRef, useEffect, useMemo, useState, useCallback, ElementRef } from 'react'
 import { useAtomValue } from 'jotai'
 import { dataMapAtom } from '../atom/dataAtom'
 import { ChartProvider, ChartContext } from '@echarts-readymade/core'
@@ -156,10 +156,10 @@ export default memo(({ keys }: ChartProps) => {
     return result
   }, [dataMap, keys, valueList])
 
-  const ref = useRef<any>(null)
+  const ref = useRef<ElementRef<typeof Line> | null>(null)
   const [isChartReady, setIsChartReady] = useState(false)
 
-  const handleRef = useCallback((node: any) => {
+  const handleRef = useCallback((node: ElementRef<typeof Line> | null) => {
     ref.current = node
     if (node) {
       setIsChartReady(true)


### PR DESCRIPTION
**The Issue:**
`src/layout/Chart.tsx` (lines 159 & 162) used `useRef<any>` and an implicitly/explicitly typed `any` callback parameter `(node: any) => ...` for the `@echarts-readymade/line` `Line` component reference. This is a structural typing flaw where a weakly typed boundary undermines strict type checking.

**The Discovery Signal:**
Scan C (Weak or Missing Type Annotations) flagged `useRef<any>` and `(node: any)` in `src/layout/Chart.tsx`.

**The Fix:**
Replaced `any` with React's built-in `ElementRef` utility to securely infer the correct type of the target component (`ElementRef<typeof Line>`).

**The Benefit:**
Eliminates a `tsc --strict` blind spot, significantly improving typing safety and clarity. The ref usage is now strictly verified against the underlying component's type definition, ensuring robust IDE autocomplete and reducing the risk of runtime reference errors.

---
*PR created automatically by Jules for task [14898875881991715665](https://jules.google.com/task/14898875881991715665) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened type safety for the chart ref by replacing `useRef<any>` and `(node: any)` with `ElementRef<typeof Line>` in `src/layout/Chart.tsx`. This closes a weakly typed boundary, improves `tsc --strict` checks, and reduces the risk of ref misuse.

<sup>Written for commit 3be74812413ccb656847ff6a648db579d4f98607. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

