### PR TITLE
⚡ Bolt: [performance improvement] Optimize array methods and document V8 holey arrays

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -14,3 +14,7 @@
 
 **Learning:** Replaced array.map() with traditional for-loops, saving closure allocation and function call overheads per item.
 **Action:** Replace `recipes.map(...)` with `for (let i = 0; i < recipes.length; i++)` and preallocate output arrays where lengths are known statically.
+
+## YYYY-MM-DD - Performance Anti-Pattern (V8 Engine)
+**Learning:** Do not replace native `Array.prototype.map()` calls with `for` loops and pre-allocated standard arrays (e.g., `Array(len)`) in React render cycles. Pre-allocating standard arrays creates 'holey' (sparse) arrays, which de-optimize operations in modern V8 engines and are often slower than using `.map()` or initializing an empty array and using `.push()`.
+**Action:** Reserve pre-allocation optimization strategies strictly for TypedArrays. Avoid converting native `.map()` to loops where holey arrays are created.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,8 +150,8 @@ export default function App() {
     const sourceTargetMap = new Map(sourceTarget.map((item) => [item![0], item]))
     sourceTarget = selected.map((name) => sourceTargetMap.get(name))
 
-    if (sourceTarget.some((i) => !i)) {
-      return
+    for (let i = 0; i < sourceTarget.length; i++) {
+      if (!sourceTarget[i]) return
     }
     setSourceTarget((v) => {
       if (v && sourceTarget[0] === v[0] && sourceTarget[1] === v[1]) {

--- a/src/processors/pre/convertUnit.ts
+++ b/src/processors/pre/convertUnit.ts
@@ -63,7 +63,7 @@ const valueMapper = (
     unit = 'μg/dL'
   }
 
-  if (unit === 'mmol/L' && ['Cholesterol', 'HDL', 'LDL'].includes(name)) {
+  if (unit === 'mmol/L' && (name === 'Cholesterol' || name === 'HDL' || name === 'LDL')) {
     originValue = value
     value = converter[name](value)
     originUnit = unit


### PR DESCRIPTION
💡 What:
Replaced `.some()` and `.includes()` array checks with standard `for` loops and logical operators in `App.tsx` and `convertUnit.ts`. Also documented a V8 performance anti-pattern about 'holey' arrays in the bolt journal to avoid incorrectly replacing `.map()`.

🎯 Why:
Array methods like `.some()` and `.includes([array])` often incur overhead due to closure creation, callback execution, and redundant array allocations (e.g. `['a', 'b'].includes(v)` allocates a new array each time). 

📊 Impact:
Micro-optimization: Eliminates closure creation and garbage collection overhead in hot processing loops. The documentation on V8 holey arrays will also prevent degraded performance from incorrect pre-allocation in future optimizations.

🔬 Measurement:
1. Run `pnpm lint` and `pnpm tsc --noEmit --strict`.
2. Ensure Playwright test suite passes.

---
*PR created automatically by Jules for task [3870848209619537054](https://jules.google.com/task/3870848209619537054) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced array callbacks with simple loops and direct comparisons in `src/App.tsx` and `src/processors/pre/convertUnit.ts` to remove callback and allocation overhead in hot paths. Added guidance in `.jules/bolt.md` on V8 holey arrays to avoid slow pre-allocation patterns.

- **Refactors**
  - In `App.tsx`, replaced `some(...)` with a `for` loop and early return when `sourceTarget` has missing items.
  - In `convertUnit.ts`, replaced `['Cholesterol','HDL','LDL'].includes(name)` with `name === 'Cholesterol' || name === 'HDL' || name === 'LDL'`.

<sup>Written for commit 69ff0ef6e9a3fab2813c0ce9f2ac56677376b59f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

