### PR TITLE
Fix weak type annotation in `inferData.ts`

### DIFF
--- a/src/processors/enrich/inferData.ts
+++ b/src/processors/enrich/inferData.ts
@@ -2,7 +2,7 @@ import { getPhenotypicAge, getPhenotypicAge2 } from './phenoAge'
 import { labels } from '../../data'
 import { BioMarker } from '../../types/biomarker'
 
-type Recipe = [string, string[], (...args: any[]) => string, Partial<BioMarker[3]>?]
+type Recipe = [string, string[], (...args: number[]) => string, Partial<BioMarker[3]>?]
 
 const recipes: Recipe[] = [
   [


### PR DESCRIPTION
Fix weak type annotation in `inferData.ts`

Changed `(...args: any[]) => string` to `(...args: number[]) => string` in the `Recipe` type definition, as the arguments provided are consistently numeric. This improves type safety and resolves a weak typing issue flagged during the discovery scan.

---
*PR created automatically by Jules for task [12944218804599980080](https://jules.google.com/task/12944218804599980080) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the `Recipe` function type in `inferData.ts` by changing `(...args: any[]) => string` to `(...args: number[]) => string`. This matches the numeric inputs and improves type safety by catching invalid calls at compile time.

<sup>Written for commit bbb548dabd967dd47a45ff8187fb377c085940c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

