### PR TITLE
🎨 Palette: Fix interactive attributes on empty data cells

### DIFF
--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -74,6 +74,14 @@ const DataCell = React.memo(
       return <td className={className}></td>
     }
 
+    if (
+      (typeof displayValue === 'number' && Number.isNaN(displayValue)) ||
+      (typeof displayValue === 'string' && displayValue.trim() === '') ||
+      displayValue === '-'
+    ) {
+      return <td className={className}>{displayValue}</td>
+    }
+
     const isUrlUnit =
       typeof unit === 'object' && unit !== null && 'url' in unit && typeof unit.url === 'string'
 


### PR DESCRIPTION
💡 What: Updated `DataCell` in `Table.tsx` to conditionally strip interactive attributes (`role="button"`, `tabIndex`) from table cells that contain 'empty' or invalid values (such as whitespace, `NaN`, or `-`), while preserving the visual rendering of placeholder values like `-` and `NaN`.
🎯 Why: To prevent screen readers from erroneously announcing these cells as "empty buttons," which violates accessibility standards and confuses users navigating via keyboard or assistive technologies.
📸 Before/After: Cells with `-` previously had `role="button"` and were focusable, now they render as a plain `<td>-</td>`.
♿ Accessibility: Directly improves keyboard navigation and screen reader announcement for placeholder data.

---
*PR created automatically by Jules for task [17563276420414336124](https://jules.google.com/task/17563276420414336124) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes table cells with placeholder values from appearing interactive. Cells that are '-', NaN, or blank now render as plain cells (no role/tabIndex), improving screen reader and keyboard navigation while keeping the placeholder visible.

<sup>Written for commit 8e273115b71831a3dfd73d3e4db0ef09badbe4d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

