### PR TITLE
refactor(types): replace weak generic array types with specific ECharts types in Chart component

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -7,6 +7,7 @@ import { labels, formattedLabels } from '../data'
 import { CHART_PALETTE } from './Chart2'
 import { ChartProps } from './Chart.types'
 import type { EChartsReactProps } from 'echarts-for-react'
+import type { YAXisComponentOption, LineSeriesOption } from 'echarts'
 
 const dimension = [
   {
@@ -95,11 +96,11 @@ export default memo(({ keys }: ChartProps) => {
     return result
   }, [keys])
 
-  const yAxis: any[] = useMemo(() => {
+  const yAxis: YAXisComponentOption[] = useMemo(() => {
     // Optimization: Replace array map in the render loop with a classic for-loop
     // and pre-allocated array to avoid closure and garbage collection overhead.
     const numKeys = keys.length
-    const result = Array<any>(numKeys)
+    const result = Array<YAXisComponentOption>(numKeys)
     for (let i = 0; i < numKeys; i++) {
       const isEven = i % 2 === 0
       const sideOffset = Math.floor(i / 2) * 100
@@ -175,7 +176,7 @@ export default memo(({ keys }: ChartProps) => {
         // Optimization: Replace array map in the render loop with a classic for-loop
         // and pre-allocated array to avoid closure and garbage collection overhead.
         const len = keys.length
-        const series = Array<any>(len)
+        const series = Array<LineSeriesOption>(len)
         for (let i = 0; i < len; i++) {
           series[i] = {
             type: 'line',


### PR DESCRIPTION
**The Issue:**
`src/layout/Chart.tsx` lines 98, 102, and 178. The component relied on weakly typed arrays (`any[]` and `Array<any>`) to pre-allocate its ECharts Y-axis and series configurations during render paths. This creates a structural weakness where complex nested objects lose TypeScript protection.

**The Discovery Signal:**
Scan C: `src/layout/Chart.tsx` — Weak Types found:
- line 98: `const yAxis: any[] = useMemo(() => {`
- line 102: `const result = Array<any>(numKeys)`
- line 178: `const series = Array<any>(len)`

**The Fix:**
I replaced the explicit `any` usage with exact structural types imported directly from the vendor library (`YAXisComponentOption` and `LineSeriesOption` from `echarts`). The `yAxis` and `series` variables are now strictly typed throughout their pre-allocation loops.

**The Benefit:**
This eliminates a dead code surface area where type errors could silently propagate. By ensuring `tsc --noEmit` verifies the exact shape of the ECharts configurations pushed into these arrays, future agents or developers modifying this component's chart structure will receive immediate feedback if they introduce invalid option keys.

---
*PR created automatically by Jules for task [16332997338567462978](https://jules.google.com/task/16332997338567462978) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened type safety in `src/layout/Chart.tsx` by replacing weak `any` arrays with exact ECharts option types for y-axis and series. No behavior changes; this catches invalid config shapes at compile time.

- **Refactors**
  - Imported `YAXisComponentOption` and `LineSeriesOption` from `echarts`.
  - Typed `yAxis` as `YAXisComponentOption[]` and `series` as `LineSeriesOption[]` instead of `any[]`/`Array<any>`.
  - Kept the existing pre-allocation loops; only types were tightened.

<sup>Written for commit b4018e1ad68bfa8502cc7c44ea802e57064ed3c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

