### PR TITLE
⚡ Bolt: Avoid pre-allocating sparse arrays in BumpChart

### DIFF
--- a/src/layout/BiomarkerCorrelationBumpChart.tsx
+++ b/src/layout/BiomarkerCorrelationBumpChart.tsx
@@ -59,15 +59,12 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
     // Dynamic number of windows based on actual valid data points to ensure enough data per window
     // Aim for 5 windows, but fallback to fewer if data is sparse. Require at least 2 points per window.
     const numWindowsDynamic = count >= 30 ? 5 : count >= 10 ? 3 : count >= 4 ? 2 : 1
-    const windowLabelsDynamic = Array<string>(numWindowsDynamic)
+    const windowLabelsDynamic: string[] = []
 
     const windowedRanksMap = new Map<string, (number | string | null)[]>()
-    // ⚡ Bolt Optimization: Replace loop-based array building with pre-allocated Array(N)
+    // ⚡ Bolt Optimization: Avoid pre-allocating 'holey' arrays for generic types.
     for (let i = 0; i < topCorrelations.length; i++) {
-      windowedRanksMap.set(
-        topCorrelations[i].name,
-        Array<number | string | null>(numWindowsDynamic),
-      )
+      windowedRanksMap.set(topCorrelations[i].name, [])
     }
 
     // Chunk the valid data indices into windows and recalculate rho for each window
@@ -86,7 +83,7 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
 
       // Map to a complex object with a unique value to bypass category duplication,
       // and use a formatter to display the clean label.
-      windowLabelsDynamic[w] = w.toString()
+      windowLabelsDynamic.push(w.toString())
 
       // Without variation in the binary supplement vector (e.g. they took it every day, or never),
       // correlation is technically 0/undefined.
@@ -97,7 +94,7 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
         for (let i = 0; i < topCorrelations.length; i++) {
           const currentRanks = windowedRanksMap.get(topCorrelations[i].name)!
           const prevRank = w > 0 ? currentRanks[w - 1] : 6
-          currentRanks[w] = prevRank
+          currentRanks.push(prevRank)
         }
         continue
       }
@@ -156,7 +153,7 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
         // If rho is exactly 0 and no variation existed, we omit the rank by pushing null
         // to avoid erratic jumps. connectNulls: true will bridge the gaps cleanly.
         if (wr.rho === 0) {
-          currentRanks[w] = null
+          currentRanks.push(null)
         } else {
           // Check for ties with the previous item
           if (i > 0 && Math.abs(windowRhos[i].rho - windowRhos[i - 1].rho) < 1e-9) {
@@ -164,7 +161,7 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
           } else {
             currentRank = i + 1
           }
-          currentRanks[w] = currentRank
+          currentRanks.push(currentRank)
         }
       }
     }


### PR DESCRIPTION
💡 **What:** The optimization implemented replaces the use of `Array(N)` (which creates sparse/"holey" arrays) with the initialization of empty dense arrays (`[]`) and the use of `.push()` in `BiomarkerCorrelationBumpChart.tsx`.
🎯 **Why:** Pre-allocating standard generic arrays using `Array(length)` or `new Array(length)` creates sparse arrays. In modern V8 engines, operations on sparse arrays are de-optimized and significantly slower than pushing into dense arrays.
📊 **Impact:** Reduces V8 execution overhead and prevents Javascript engine de-optimization when constructing chart labels and series.
🔬 **Measurement:** This can be verified by confirming no test failures were introduced (tests run cleanly with `pnpm exec playwright test`).

---
*PR created automatically by Jules for task [18186999787613531416](https://jules.google.com/task/18186999787613531416) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized Bump Chart array construction by switching from pre-allocated sparse arrays to dense arrays with push. This avoids V8 de-optimizations and reduces runtime overhead when building labels and ranks.

- **Refactors**
  - In `BiomarkerCorrelationBumpChart.tsx`, replaced `Array(N)` and indexed writes with `[]` + `.push()` for `windowLabelsDynamic` and `windowedRanksMap`.
  - Updated logic to push `prevRank`, `null`, or `currentRank` per window instead of setting by index.

<sup>Written for commit aca6596f0d82837903e93b99d4c3b2480f3c28b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

