### PR TITLE
refactor(ScatterChart): eliminate any types in ECharts configs

### DIFF
--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from 'react'
 import { useAtomValue } from 'jotai'
 import { dataMapAtom } from '../atom/dataAtom'
 import ReactECharts from 'echarts-for-react'
+import type { YAXisComponentOption, ScatterSeriesOption } from 'echarts'
 import { labels, formattedLabels } from '../data'
 import { CHART_PALETTE } from './Chart2'
 import type { ScatterChartProps } from './ScatterChart.types'
@@ -14,8 +15,8 @@ const echartsOptions = {
   xAxis: {
     type: 'time',
   },
-  yAxis: [] as any[],
-  series: [] as any[],
+  yAxis: [] as YAXisComponentOption[],
+  series: [] as ScatterSeriesOption[],
   tooltip: {
     trigger: 'axis',
     backgroundColor: '#111111',
@@ -74,9 +75,9 @@ const echartsOptions = {
 export default memo(({ keys }: ScatterChartProps) => {
   const dataMap = useAtomValue(dataMapAtom)
 
-  const yAxes = useMemo(() => {
+  const yAxes: YAXisComponentOption[] = useMemo(() => {
     const numKeys = keys.length
-    const result = Array<any>(numKeys)
+    const result = Array<YAXisComponentOption>(numKeys)
     for (let index = 0; index < numKeys; index++) {
       const key = keys[index]
       const isEven = index % 2 === 0
@@ -104,11 +105,11 @@ export default memo(({ keys }: ScatterChartProps) => {
     return result
   }, [keys])
 
-  const chartData = useMemo(() => {
+  const chartData: ScatterSeriesOption[] = useMemo(() => {
     // Optimization: Replace chained Array.map() with a classic for-loop and pre-allocated array.
     // This eliminates the closure allocation and avoids garbage collection spikes in component render paths.
     const numKeys = keys.length
-    const result = Array<any>(numKeys)
+    const result = Array<ScatterSeriesOption>(numKeys)
     for (let k = 0; k < numKeys; k++) {
       const key = keys[k]
       const bioMarker = dataMap.get(key)


### PR DESCRIPTION
**The Issue:**
`src/layout/ScatterChart.tsx` lines 17-18 and 78/108 contained weak `any` type definitions (`yAxis: [] as any[]`, `series: [] as any[]`, and `Array<any>`). This bypassed TypeScript's checking mechanisms for ECharts configuration objects, leaving the codebase vulnerable to configuration regressions.

**The Discovery Signal:**
Scan C: `src/layout/ScatterChart.tsx` — found multiple instances of `as any[]` and `Array<any>` being used to allocate and type ECharts component options.

**The Fix:**
Imported `YAXisComponentOption` and `ScatterSeriesOption` directly from `echarts`. Replaced `as any[]` and `Array<any>` pre-allocations within `yAxis`, `series`, `yAxes` useMemo, and `chartData` useMemo with these strict ECharts types.

**The Benefit:**
Improved type safety for the `ScatterChart` component by preventing implicit widening of ECharts configuration types. It cleanly resolves the weak typings found in the file, resulting in a cleaner `tsc --noEmit --strict` profile while avoiding the introduction of non-standard interface inventions.

---
*PR created automatically by Jules for task [12367807891566436532](https://jules.google.com/task/12367807891566436532) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `any` types in `ScatterChart` ECharts config with explicit types from `echarts` to improve type safety and prevent config regressions. No runtime behavior changes.

- **Refactors**
  - Imported `YAXisComponentOption` and `ScatterSeriesOption` from `echarts`.
  - Typed `yAxis`, `series`, `yAxes`, and `chartData` with these strict types.

<sup>Written for commit c9a7367e72dccc0f7fd732c578648c1eed2018c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

