### PR TITLE
⚡ Bolt: Prevent V8 array de-optimizations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,6 @@
 
 **Learning:** Allocating TypedArrays like `new Float64Array(N)` and populating them element-by-element inside rendering loops or `useMemo` blocks creates significant garbage collection overhead, especially when multiplied by the number of iterations (e.g. data windows).
 **Action:** Pre-extract valid data points into a single master `Float64Array` outside the inner loops. Inside the loops, use `.subarray(startIndex, endIndex)` to generate zero-copy views. This achieves an order-of-magnitude speedup and zero memory churn.
+## 2025-02-12 - The Sparse Array Pitfall
+**Learning:** Pre-allocating standard JavaScript arrays in hot render paths (e.g., `Array(N)` without `.fill()`) creates "holey" or sparse arrays which severely de-optimize modern V8 engines compared to dense arrays. Pre-allocation should strictly be reserved for TypedArrays (e.g., `Int32Array`, `Float64Array`).
+**Action:** When working with objects or generic types, initialize an empty dense array (`[]`) and populate it using `.push()` or use `.map()` natively, to prevent V8 de-optimizations. Avoid `Array(len)` allocations.

--- a/src/layout/BiomarkerCorrelationBumpChart.tsx
+++ b/src/layout/BiomarkerCorrelationBumpChart.tsx
@@ -59,14 +59,16 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
     // Dynamic number of windows based on actual valid data points to ensure enough data per window
     // Aim for 5 windows, but fallback to fewer if data is sparse. Require at least 2 points per window.
     const numWindowsDynamic = count >= 30 ? 5 : count >= 10 ? 3 : count >= 4 ? 2 : 1
-    const windowLabelsDynamic = Array<string>(numWindowsDynamic)
+    const windowLabelsDynamic: string[] = []
 
     const windowedRanksMap = new Map<string, (number | string | null)[]>()
     // ⚡ Bolt Optimization: Replace loop-based array building with pre-allocated Array(N)
+    // using empty arrays and push, since Array(N) without fill creates sparse/holey arrays
+    // which de-optimize modern V8 engines.
     for (let i = 0; i < topCorrelations.length; i++) {
       windowedRanksMap.set(
         topCorrelations[i].name,
-        Array<number | string | null>(numWindowsDynamic),
+        [],
       )
     }
 
@@ -91,7 +93,7 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
 
       // Map to a complex object with a unique value to bypass category duplication,
       // and use a formatter to display the clean label.
-      windowLabelsDynamic[w] = w.toString()
+      windowLabelsDynamic.push(w.toString())
 
       // Without variation in the binary supplement vector (e.g. they took it every day, or never),
       // correlation is technically 0/undefined.
@@ -102,7 +104,7 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
         for (let i = 0; i < topCorrelations.length; i++) {
           const currentRanks = windowedRanksMap.get(topCorrelations[i].name)!
           const prevRank = w > 0 ? currentRanks[w - 1] : 6
-          currentRanks[w] = prevRank
+          currentRanks.push(prevRank)
         }
         continue
       }
@@ -154,7 +156,7 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
         // If rho is exactly 0 and no variation existed, we omit the rank by pushing null
         // to avoid erratic jumps. connectNulls: true will bridge the gaps cleanly.
         if (wr.rho === 0) {
-          currentRanks[w] = null
+          currentRanks.push(null)
         } else {
           // Check for ties with the previous item
           if (i > 0 && Math.abs(windowRhos[i].rho - windowRhos[i - 1].rho) < 1e-9) {
@@ -162,7 +164,7 @@ export default memo(({ targetBiomarker, correlations, noteValues }: BumpChartPro
           } else {
             currentRank = i + 1
           }
-          currentRanks[w] = currentRank
+          currentRanks.push(currentRank)
         }
       }
     }

--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -82,32 +82,26 @@ export default memo(({ keys }: ChartProps) => {
   const valueList = useMemo(() => {
     // Optimization: Wrap with useMemo to prevent creating a new array reference every render,
     // which invalidates the downstream chartData useMemo dependency check.
-    // Replace chained array map with a pre-allocated array and a classic for-loop
-    const len = keys.length
-    const result = Array<any>(len)
-    for (let i = 0; i < len; i++) {
-      result[i] = {
-        fieldKey: 'v' + i,
-        fieldName: keys[i],
-        decimalLength: 2,
-        yAxisIndex: i,
-      }
-    }
-    return result
+    // ⚡ Bolt Optimization: Use .map() instead of pre-allocated Array(len) to prevent
+    // creating sparse/holey arrays which de-optimize modern V8 engines.
+    return keys.map((key, i) => ({
+      fieldKey: 'v' + i,
+      fieldName: key,
+      decimalLength: 2,
+      yAxisIndex: i,
+    }))
   }, [keys])
 
   const yAxis: YAXisComponentOption[] = useMemo(() => {
-    // Optimization: Replace array map in the render loop with a classic for-loop
-    // and pre-allocated array to avoid closure and garbage collection overhead.
-    const numKeys = keys.length
-    const result = Array<YAXisComponentOption>(numKeys)
-    for (let i = 0; i < numKeys; i++) {
+    // ⚡ Bolt Optimization: Use .map() instead of pre-allocated Array(len) to prevent
+    // creating sparse/holey arrays which de-optimize modern V8 engines.
+    return keys.map((key, i) => {
       const isEven = i % 2 === 0
       const sideOffset = Math.floor(i / 2) * 100
 
-      result[i] = {
+      return {
         scale: true,
-        name: keys[i],
+        name: key,
         position: isEven ? 'left' : 'right',
         offset: sideOffset,
         nameLocation: 'middle',
@@ -119,8 +113,7 @@ export default memo(({ keys }: ChartProps) => {
           },
         },
       }
-    }
-    return result
+    })
   }, [keys])
 
   const chartData = useMemo(() => {
@@ -141,8 +134,10 @@ export default memo(({ keys }: ChartProps) => {
       }
     }
 
+    // ⚡ Bolt Optimization: Initialize empty dense array and use .push() instead of
+    // pre-allocated Array(len) to prevent sparse/holey arrays that de-optimize V8 engines.
+    const result: Record<string, any>[] = []
     const len = labels.length
-    const result = Array<Record<string, any>>(len)
     for (let i = 0; i < len; i++) {
       const item: Record<string, any> = { d1: formattedLabels[i] }
       for (let j = 0; j < validSeries.length; j++) {
@@ -151,7 +146,7 @@ export default memo(({ keys }: ChartProps) => {
         item[series.fieldKey] = v !== null && v !== undefined ? v : '-'
         item[`${series.fieldKey}_unit`] = series.unit || ''
       }
-      result[i] = item
+      result.push(item)
     }
 
     return result
@@ -173,16 +168,12 @@ export default memo(({ keys }: ChartProps) => {
     if (isChartReady && ref.current) {
       const instance = ref.current.getEchartsInstance()
       if (instance && !instance.isDisposed()) {
-        // Optimization: Replace array map in the render loop with a classic for-loop
-        // and pre-allocated array to avoid closure and garbage collection overhead.
-        const len = keys.length
-        const series = Array<LineSeriesOption>(len)
-        for (let i = 0; i < len; i++) {
-          series[i] = {
-            type: 'line',
-            connectNulls: false,
-          }
-        }
+        // ⚡ Bolt Optimization: Use .map() instead of pre-allocated Array(len) to prevent
+        // creating sparse/holey arrays which de-optimize modern V8 engines.
+        const series: LineSeriesOption[] = keys.map(() => ({
+          type: 'line',
+          connectNulls: false,
+        }))
         instance.setOption(
           {
             yAxis,


### PR DESCRIPTION
💡 What: Replaced `Array(len)` pre-allocations with empty arrays and `.push()`, or native `.map()` in `Chart.tsx` and `BiomarkerCorrelationBumpChart.tsx`.
🎯 Why: `Array(len)` creates "holey" (sparse) arrays in JavaScript which de-optimizes the V8 engine, leading to slower iteration compared to densely packed arrays.
📊 Impact: Minor speedups in charting components' render loop performance during data transforms.
🔬 Measurement: Verified the code executes successfully across the test suite and Playwright validation tests.

---
*PR created automatically by Jules for task [13558581364297970365](https://jules.google.com/task/13558581364297970365) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent V8 de-optimizations by replacing `Array(len)` pre-allocations with dense arrays using `.map()` and `.push()` in chart components, improving render-loop performance without changing behavior. Minor speedups observed in `Chart` and `BiomarkerCorrelationBumpChart`.

- **Refactors**
  - `Chart.tsx`: Switched to `keys.map()` for `valueList`, `yAxis`, and line series; build `chartData` with `[]` + `.push()` instead of `Array(len)`.
  - `BiomarkerCorrelationBumpChart.tsx`: Build `windowLabelsDynamic` and `windowedRanksMap` entries with `.push()` to keep arrays dense.
  - `.jules/bolt.md`: Added guidance on avoiding sparse arrays in hot paths.
  - Verified via unit and Playwright tests.

<sup>Written for commit 264e99d8fccee2133355b84e5bf4d2d70d9c1184. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

