### PR TITLE
refactor: Extract RadarChartProps to sibling types file

### DIFF
--- a/src/layout/RadarChart.tsx
+++ b/src/layout/RadarChart.tsx
@@ -1,11 +1,6 @@
 import { memo, useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
-import { BioMarker } from '../types/biomarker'
-
-interface RadarChartProps {
-  data: BioMarker[]
-  tag: string
-}
+import { RadarChartProps } from './RadarChart.types'
 
 export default memo(({ data, tag }: RadarChartProps) => {
   const options = useMemo(() => {

--- a/src/layout/RadarChart.types.ts
+++ b/src/layout/RadarChart.types.ts
@@ -1,0 +1,6 @@
+import { BioMarker } from '../types/biomarker'
+
+export interface RadarChartProps {
+  data: BioMarker[]
+  tag: string
+}


### PR DESCRIPTION
Extracts `RadarChartProps` interface into a new `src/layout/RadarChart.types.ts` file.

**The Issue:**
The `interface RadarChartProps` in `src/layout/RadarChart.tsx` was defined locally instead of being exported to a corresponding `.types.ts` sibling file. This violated the codebase's established structural pattern for React components with complex props (e.g., `Nav.types.ts`, `Table.types.ts`).

**The Fix:**
1. Created `src/layout/RadarChart.types.ts`.
2. Moved the `BioMarker` type import and the `RadarChartProps` interface definition to the new `RadarChart.types.ts` file, and exported it.
3. Updated `src/layout/RadarChart.tsx` to remove the local definitions and instead import `RadarChartProps` from `./RadarChart.types`.

**The Benefit:**
This refactoring maintains structural consistency across the repository by adhering to the established pattern of separating complex prop types into dedicated `.types.ts` sibling files. This improves codebase maintainability and reduces clutter in the main component file.

---
*PR created automatically by Jules for task [926845444435648707](https://jules.google.com/task/926845444435648707) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `RadarChartProps` (and its `BioMarker` dependency) from `src/layout/RadarChart.tsx` into new `src/layout/RadarChart.types.ts`, and updated the component to import it. This matches our `.types.ts` sibling pattern and keeps the component file cleaner.

<sup>Written for commit f6442f5abf2b3d92d697a9b528f084a278728c25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

