### PR TITLE
Fix `oxlint` state synchronization violation in `Nav` component

### DIFF
--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -229,12 +229,6 @@ export default React.memo<NavProps>(
     const [isGistViewerOpen, setIsGistViewerOpen] = React.useState(false)
     const [hasGistViewerMounted, setHasGistViewerMounted] = React.useState(false)
 
-    React.useEffect(() => {
-      if (isGistViewerOpen && !hasGistViewerMounted) {
-        setHasGistViewerMounted(true)
-      }
-    }, [isGistViewerOpen, hasGistViewerMounted])
-
     const handleClose = React.useCallback(() => {
       setCanvasText(null)
       setGistUrl(null)
@@ -525,7 +519,7 @@ export default React.memo<NavProps>(
 
               <button
                 type="button"
-                onClick={() => setIsGistViewerOpen(true)}
+                onClick={() => { setIsGistViewerOpen(true); setHasGistViewerMounted(true); }}
                 title="View AI History"
                 className="hidden md:flex ml-4 px-3 py-1 text-xs font-medium bg-gray-700 text-white rounded hover:bg-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 transition-colors"
               >


### PR DESCRIPTION
**The Issue:**
`src/layout/Nav.tsx` line 232-236 — There was an unnecessary structural `useEffect` that synchronized local state (`hasGistViewerMounted`) in response to a change in another piece of local state (`isGistViewerOpen`).

**The Discovery Signal:**
Scan B: `src/layout/Nav.tsx` lines 233 and 234 — `oxlint` reported `react-you-might-not-need-an-effect(no-chain-state-updates)` and `react-you-might-not-need-an-effect(no-event-handler)`, noting that state adjustments should happen directly within the event handlers instead of chaining state changes.

**The Fix:**
I removed the `useEffect` entirely from `Nav.tsx` and updated the "View History" button's `onClick` event handler to simultaneously set both states: `setIsGistViewerOpen(true)` and `setHasGistViewerMounted(true)`.

**The Benefit:**
This structural refactoring satisfies the "You Might Not Need an Effect" pattern in modern React development, clearing two `correctness` level warnings from `oxlint`. It improves code maintainability by keeping state logic colocated with user actions and reduces computational overhead by eliminating an unnecessary secondary render cycle when opening the AI History viewer.

---
*PR created automatically by Jules for task [11276197377240639309](https://jules.google.com/task/11276197377240639309) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an unnecessary useEffect in `src/layout/Nav.tsx` by setting `hasGistViewerMounted` directly in the "View History" button onClick when opening the viewer. This clears `oxlint` warnings and removes an extra render from chained state updates.

<sup>Written for commit e2634b82410ad3c56464d6b17264b13c0304a22e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

