### PR TITLE
⚡ Bolt: Optimize V8 dense array allocations over 'holey' arrays

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -43,3 +43,7 @@
 ## YYYY-MM-DD - Refactoring Constaints: UI Side Effects
 **Learning:** When applying performance optimizations (like fixing 'holey' array allocations) in ECharts layout components, it is critical to strictly preserve the exact object structures. I accidentally added `symbolSize` and `itemStyle` to the scatter chart dataset as a side effect while modifying the loop. This can cause reference errors (if styling objects aren't imported) or visual regressions.
 **Action:** When refactoring loop bodies or object creations for performance, do not introduce new properties or styling configurations that were not in the original code unless explicitly instructed.
+
+## 2026-06-07 - Refactoring 'holey' array allocations
+**Learning:** Found several instances where standard JS generic arrays were initialized via `Array<Type>(len)` within `useMemo` hooks (e.g. `src/layout/Table.tsx`, `src/layout/ScatterChart.tsx`). This pre-allocation causes V8 to treat them as 'holey' (sparse) arrays, dropping performance compared to using sequential push operations into dense arrays `[]`.
+**Action:** When replacing array iterations with standard `for` loops in hot render cycles, always initialize standard JS arrays densely (`const arr = []`) and add elements using `.push(val)` or sequential direct assignment (`arr[i] = val` only when strictly sequential without gaps). Reserve pre-allocated sizing exclusively for TypedArrays.

--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -77,7 +77,7 @@ export default memo(({ keys }: ScatterChartProps) => {
 
   const yAxes: YAXisComponentOption[] = useMemo(() => {
     const numKeys = keys.length
-    const result = Array<YAXisComponentOption>(numKeys)
+    const result: YAXisComponentOption[] = []
     for (let index = 0; index < numKeys; index++) {
       const key = keys[index]
       const isEven = index % 2 === 0
@@ -106,10 +106,10 @@ export default memo(({ keys }: ScatterChartProps) => {
   }, [keys])
 
   const chartData: ScatterSeriesOption[] = useMemo(() => {
-    // Optimization: Replace chained Array.map() with a classic for-loop and pre-allocated array.
-    // This eliminates the closure allocation and avoids garbage collection spikes in component render paths.
+    // Optimization: Replace chained Array.map() with a classic for-loop and dense array.
+    // This eliminates the closure allocation and avoids garbage collection spikes in component render paths without causing V8 'holey' array issues.
     const numKeys = keys.length
-    const result = Array<ScatterSeriesOption>(numKeys)
+    const result: ScatterSeriesOption[] = []
     for (let k = 0; k < numKeys; k++) {
       const key = keys[k]
       const bioMarker = dataMap.get(key)

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -370,11 +370,10 @@ const columns: ColumnDef<DisplayedEntry, any>[] = [
     footer: 'Supp',
   }),
   ...(() => {
-    // Optimization: Replace labels.map() with a classic for-loop and pre-allocated array.
-    // This avoids closure allocation overhead and speeds up the module initialization.
+    // Optimization: Replace labels.map() with a classic for-loop and dense array.
+    // This avoids closure allocation overhead and V8 'holey' array de-optimization.
     const numLabels = labels.length
-    // eslint-disable-next-line eslint-plugin-unicorn/no-new-array
-    const result = new Array<ColumnDef<DisplayedEntry, any>>(numLabels)
+    const result: ColumnDef<DisplayedEntry, any>[] = []
     for (let index = 0; index < numLabels; index++) {
       const label = labels[index]
       const dist = numLabels - 1 - index
@@ -383,9 +382,8 @@ const columns: ColumnDef<DisplayedEntry, any>[] = [
       else if (dist > 2 && dist <= 4) className = 'hidden md:table-cell'
       else if (dist > 4) className = 'hidden lg:table-cell'
 
-      result[index] = columnHelper.accessor(
-        (row) => row[label as keyof typeof row] ?? row.values[index],
-        {
+      result.push(
+        columnHelper.accessor((row) => row[label as keyof typeof row] ?? row.values[index], {
           id: label,
           header: getKeyFromTime(label),
           meta: {
@@ -394,7 +392,7 @@ const columns: ColumnDef<DisplayedEntry, any>[] = [
             title: label,
             className,
           },
-        },
+        }),
       )
     }
     return result
@@ -498,15 +496,17 @@ export default React.memo(
 
     const cellBaseClasses = React.useMemo(() => {
       const count = showRecords || labels.length
-      const result = Array<string>(count)
+      const result: string[] = []
       for (let index = 0; index < count; index++) {
         const dist = count - 1 - index
-        result[index] = cn('p-2 border border-gray-700 text-right cursor-pointer select-none', {
-          'is-latest': dist === 0,
-          'hidden sm:table-cell': dist === 2,
-          'hidden md:table-cell': dist > 2 && dist <= 4,
-          'hidden lg:table-cell': dist > 4,
-        })
+        result.push(
+          cn('p-2 border border-gray-700 text-right cursor-pointer select-none', {
+            'is-latest': dist === 0,
+            'hidden sm:table-cell': dist === 2,
+            'hidden md:table-cell': dist > 2 && dist <= 4,
+            'hidden lg:table-cell': dist > 4,
+          }),
+        )
       }
       return result
     }, [showRecords])

--- a/src/processors/post/index.ts
+++ b/src/processors/post/index.ts
@@ -12,12 +12,12 @@ const postProcessEntry = (entry: Entry): Entry => {
 }
 
 export default (entries: Entry[]): Entry[] => {
-  // Optimization: Use a classic for-loop with pre-allocated array instead of .map()
-  // to reduce object allocation and garbage collection overhead.
+  // Optimization: Use a classic for-loop with dense array instead of .map()
+  // to reduce closure overhead and avoid V8 'holey' array de-optimization.
   const len = entries.length
-  const result = Array<Entry>(len)
+  const result: Entry[] = []
   for (let i = 0; i < len; i++) {
-    result[i] = postProcessEntry(entries[i])
+    result.push(postProcessEntry(entries[i]))
   }
   return result
 }


### PR DESCRIPTION
💡 **What:** Refactored instances of `Array<Type>(len)` pre-allocations across `Table.tsx`, `ScatterChart.tsx`, and `processors/post/index.ts` to initialize empty arrays `[]` and use `.push()` to append elements.

🎯 **Why:** While pre-allocating is essential for TypedArrays, pre-allocating standard Javascript object or mixed-type arrays creates sparse ('holey') arrays. V8 engine de-optimizes operations on holey arrays, making them significantly slower to iterate over and manipulate than continuously pushing to a dense array. This eliminates an identified performance anti-pattern.

📊 **Impact:** Provides a measurable micro-optimization during heavy rendering cycles (e.g. data table generation and scatter chart configuration) by keeping arrays dense, improving array manipulation speeds within V8's hot paths.

🔬 **Measurement:** Verify by running the full Playwright test suite (`pnpm exec playwright test`), ensuring benchmark tests pass, and visually confirming `Table` and `ScatterChart` render correctly without data loss or structure alteration.

---
*PR created automatically by Jules for task [10085766367686658857](https://jules.google.com/task/10085766367686658857) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize array allocations by replacing preallocated `Array(len)` with dense arrays built using `[]` and `.push()` in hot paths. This avoids V8 de-opts on holey arrays and speeds up renders.

- **Refactors**
  - `src/layout/Table.tsx`: use dense arrays for dynamic columns and `cellBaseClasses`.
  - `src/layout/ScatterChart.tsx`: use dense arrays for `yAxes` and `chartData`.
  - `src/processors/post/index.ts`: replace `.map()` with a `for` loop that pushes to a dense array.
  - No UI or API changes.

<sup>Written for commit 21c550d1bb17fac30797347c052514dc43303153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

