### PR TITLE
refactor: enforce strict EChartsOption types in Chart2

### DIFF
--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -4,8 +4,9 @@ import { dataMapAtom } from '../atom/dataAtom'
 
 import { labels, formattedLabels } from '../data'
 import ReactECharts from 'echarts-for-react'
+import type { EChartsReactProps } from 'echarts-for-react'
 import * as echarts from 'echarts'
-import type { DatasetComponentOption } from 'echarts'
+import type { DatasetComponentOption, EChartsOption } from 'echarts'
 import * as ecStat from 'echarts-stat'
 import { ChartProps } from './Chart.types'
 
@@ -26,7 +27,7 @@ export const CHART_PALETTE = [
   '#2559B7',
 ]
 
-const echartsOptions: any = {
+const echartsOptions: EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'> = {
   style: { height: 400, maxWidth: 800 },
   theme: 'dark',
   backgroundColor: 'transparent',
@@ -98,12 +99,12 @@ const echartsOptions: any = {
       symbolSize: 40,
       legendHoverLink: true,
       large: false,
-      zIndex: 2,
+      zlevel: 2,
     },
     {
       type: 'line',
       symbol: 'circle',
-      zIndex: -1,
+      zlevel: 0,
       showSymbol: false,
       lineStyle: {
         color: '#5470C688',
@@ -112,18 +113,12 @@ const echartsOptions: any = {
       legendHoverLink: true,
       markPoint: {
         itemStyle: {
-          normal: {
-            color: 'transparent',
-          },
+          color: 'transparent',
         },
         label: {
-          normal: {
-            show: true,
-            textStyle: {
-              color: '#f0f0f0',
-              fontSize: 14,
-            },
-          },
+          show: true,
+          color: '#f0f0f0',
+          fontSize: 14,
         },
       },
     },
@@ -149,7 +144,7 @@ export default memo(({ keys }: ChartProps) => {
       // ⚡ Bolt Optimization: Avoid pre-allocating 'holey' arrays for generic types.
       // Pre-allocating Array<any[]>(len) creates sparse arrays which de-optimize modern V8 engines.
       // Replacing with standard array pushes and eliminating the slice operation improves performance.
-      const mappedData: any[] = []
+      const mappedData: (string | number)[][] = []
 
       for (let i = 0; i < len; i++) {
         const v0 = values0[i]
@@ -165,11 +160,13 @@ export default memo(({ keys }: ChartProps) => {
     return { data: [] }
   }, [dataMap, keys])
 
-  const options: any = useMemo(() => {
-    const { series, yAxis, xAxis } = echartsOptions
+  const options: EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'> = useMemo(() => {
+    const series = (echartsOptions.series as echarts.SeriesOption[]) || []
+    const xAxis = (echartsOptions.xAxis as echarts.XAXisComponentOption[]) || []
+    const yAxis = (echartsOptions.yAxis as echarts.YAXisComponentOption[]) || []
 
-    const nextXAxis = [{ ...xAxis[0], name: keys[0] }, ...xAxis.slice(1)]
-    const nextYAxis = [{ ...yAxis[0], name: keys[1] }, ...yAxis.slice(1)]
+    const nextXAxis = xAxis.length > 0 ? [{ ...xAxis[0], name: keys[0] }, ...xAxis.slice(1)] : []
+    const nextYAxis = yAxis.length > 0 ? [{ ...yAxis[0], name: keys[1] }, ...yAxis.slice(1)] : []
 
     const dataset: DatasetComponentOption[] = [
       {


### PR DESCRIPTION
**The Issue:**
`src/layout/Chart2.tsx` contained multiple instances of weakly typed variables using `any` (lines 29, 152, 168), specifically targeting `echartsOptions`, `options`, and the intermediate `mappedData` array. Using `any` on massive configuration objects like ECharts breaks type safety and autocomplete, obscuring runtime errors.

**The Discovery Signal:**
Scan C (Weak Types): `src/layout/Chart2.tsx` lines 29, 152, 168 — Explicit `: any` types used on variables `echartsOptions`, `mappedData`, and `options`.

**The Fix:**
- Imported `EChartsOption` from `echarts` and `EChartsReactProps` from `echarts-for-react`.
- Extracted and intersected types (`EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'>`) for the global `echartsOptions` and the hook-generated `options`.
- Updated `mappedData` from `any[]` to explicitly `(string | number)[][]`.
- Updated deprecated ECharts v4 syntax by moving `zIndex` to `zlevel` and flattening the `normal` block inside `markPoint.itemStyle` and `markPoint.label`.
- Eliminated all usage of `as any` within the target modification area.

**The Benefit:**
Eliminates a massive surface area of weakly typed configurations, providing proper autocompletion for ECharts configuration props and preventing developers from passing invalid ECharts 5 options in the future. Passes `tsc --noEmit --strict`, `oxlint`, and all existing Playwright UI tests with zero regressions.

---
*PR created automatically by Jules for task [1103382062693391833](https://jules.google.com/task/1103382062693391833) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforced strict typing for Chart2 ECharts configuration to remove `any` and align with ECharts v5. This improves type safety and autocomplete and blocks invalid config.

- **Refactors**
  - Typed `echartsOptions` and `options` as `EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'>` using imports from `echarts` and `echarts-for-react`.
  - Updated v4 syntax to v5: replaced `zIndex` with `zlevel` and flattened `markPoint.itemStyle` and `markPoint.label`.
  - Changed `mappedData` from `any[]` to `(string | number)[][]`.
  - Removed `as any` and added safe casts for `series`, `xAxis`, and `yAxis`.

<sup>Written for commit 553654b8dbbad6342b12fa32406a2ee404ecb3f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

