### PR TITLE
Fix: Eliminate useEffect state syncing in SystemClustering

### DIFF
--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState, useEffect } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import ReactECharts from 'echarts-for-react'
@@ -87,23 +87,16 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
     return Array.from(tags).sort()
   }, [data])
 
-  const [xAxisTag, setXAxisTag] = useState<string>('')
-  const [yAxisTag, setYAxisTag] = useState<string>('')
+  const [selectedXAxisTag, setSelectedXAxisTag] = useState<string | null>(null)
+  const [selectedYAxisTag, setSelectedYAxisTag] = useState<string | null>(null)
 
-  // Set defaults when tags load
-  useEffect(() => {
-    if (availableTags.length > 0) {
-      if (!xAxisTag)
-        setXAxisTag(availableTags.find((t) => t.includes('2-Metabolic')) || availableTags[0] || '')
-      if (!yAxisTag)
-        setYAxisTag(
-          availableTags.find((t) => t.includes('3-Liver') || t.includes('4-Lipid')) ||
-            availableTags[1] ||
-            availableTags[0] ||
-            '',
-        )
-    }
-  }, [availableTags, xAxisTag, yAxisTag])
+  const xAxisTag = selectedXAxisTag !== null
+    ? selectedXAxisTag
+    : (availableTags.find((t) => t.includes('2-Metabolic')) || availableTags[0] || '')
+
+  const yAxisTag = selectedYAxisTag !== null
+    ? selectedYAxisTag
+    : (availableTags.find((t) => t.includes('3-Liver') || t.includes('4-Lipid')) || availableTags[1] || availableTags[0] || '')
 
   const options = useMemo(() => {
     if (!data || data.length === 0 || !noteValues || noteValues.length === 0) return echartsOptions
@@ -343,7 +336,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                       <select
                         id="x-axis-group"
                         value={xAxisTag}
-                        onChange={(e) => setXAxisTag(e.target.value)}
+                        onChange={(e) => setSelectedXAxisTag(e.target.value)}
                         className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                       >
                         {availableTags.map((t) => (
@@ -363,7 +356,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                       <select
                         id="y-axis-group"
                         value={yAxisTag}
-                        onChange={(e) => setYAxisTag(e.target.value)}
+                        onChange={(e) => setSelectedYAxisTag(e.target.value)}
                         className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                       >
                         {availableTags.map((t) => (


### PR DESCRIPTION
**The Issue:**
`src/layout/SystemClustering.tsx` lines 90-105
The component synchronized `xAxisTag` and `yAxisTag` defaults using a `useEffect`, causing chained state updates and violating React best practices for event handling and derived state.

**The Discovery Signal:**
Scan B: `npx oxlint src/` reported:
- `correctness/no-chain-state-updates`
- `correctness/no-event-handler`

**The Fix:**
Removed the `useEffect` entirely. Tracked explicit user selections via state (`selectedXAxisTag`, `selectedYAxisTag`), and computed the effective tag inline during the render cycle (`selectedXAxisTag !== null ? selectedXAxisTag : default`).

**The Benefit:**
Eliminated unnecessary re-renders, removed dead/dangerous synchronization effects, fixed the subtle bug where re-evaluating the effect could overwrite an intentional clear/empty state by the user, and resolved the oxlint violations.

---
*PR created automatically by Jules for task [17093908988449748837](https://jules.google.com/task/17093908988449748837) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `useEffect`-based syncing of axis tag defaults in `SystemClustering`. Defaults are now computed during render with only explicit user selections stored, preventing chained state updates, avoiding overwriting cleared values, reducing re-renders, and resolving `oxlint` warnings.

<sup>Written for commit 31219d8cfe5f9fa99332d85f51186dc7b92d1b86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

