### PR TITLE
Fix react-you-might-not-need-an-effect warnings in SystemClustering

### DIFF
--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState, useEffect } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import ReactECharts from 'echarts-for-react'
@@ -87,23 +87,20 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
     return Array.from(tags).sort()
   }, [data])
 
-  const [xAxisTag, setXAxisTag] = useState<string>('')
-  const [yAxisTag, setYAxisTag] = useState<string>('')
+  const [xAxisTag, setXAxisTag] = useState<string | null>(null)
+  const [yAxisTag, setYAxisTag] = useState<string | null>(null)
 
-  // Set defaults when tags load
-  useEffect(() => {
-    if (availableTags.length > 0) {
-      if (!xAxisTag)
-        setXAxisTag(availableTags.find((t) => t.includes('2-Metabolic')) || availableTags[0] || '')
-      if (!yAxisTag)
-        setYAxisTag(
-          availableTags.find((t) => t.includes('3-Liver') || t.includes('4-Lipid')) ||
-            availableTags[1] ||
-            availableTags[0] ||
-            '',
-        )
-    }
-  }, [availableTags, xAxisTag, yAxisTag])
+  const effectiveXAxisTag =
+    xAxisTag !== null
+      ? xAxisTag
+      : availableTags.find((t) => t.includes('2-Metabolic')) || availableTags[0] || ''
+  const effectiveYAxisTag =
+    yAxisTag !== null
+      ? yAxisTag
+      : availableTags.find((t) => t.includes('3-Liver') || t.includes('4-Lipid')) ||
+        availableTags[1] ||
+        availableTags[0] ||
+        ''
 
   const options = useMemo(() => {
     if (!data || data.length === 0 || !noteValues || noteValues.length === 0) return echartsOptions
@@ -127,8 +124,8 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
       let hasY = false
       const tagsLen = tags.length
       for (let i = 0; i < tagsLen; i++) {
-        if (xAxisTag && tags[i] === xAxisTag) hasX = true
-        if (yAxisTag && tags[i] === yAxisTag) hasY = true
+        if (effectiveXAxisTag && tags[i] === effectiveXAxisTag) hasX = true
+        if (effectiveYAxisTag && tags[i] === effectiveYAxisTag) hasY = true
       }
 
       if (hasX) m1Indices.push(m)
@@ -137,7 +134,10 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
 
     // Fallback: If we don't have enough markers in tags, just use the first half vs second half
     const useTags =
-      xAxisTag !== '' && yAxisTag !== '' && m1Indices.length > 0 && m2Indices.length > 0
+      effectiveXAxisTag !== '' &&
+      effectiveYAxisTag !== '' &&
+      m1Indices.length > 0 &&
+      m2Indices.length > 0
     // Bolt Optimization: Hoist fallback array calculations outside the inner loop to
     // eliminate redundant object allocations and garbage collection per timepoint.
     let g1: number[]
@@ -242,7 +242,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
       })
     }
 
-    const _useTags = xAxisTag !== '' && yAxisTag !== ''
+    const _useTags = effectiveXAxisTag !== '' && effectiveYAxisTag !== ''
     const formatTag = (tag: string) => tag.replace(/^\w-/, '')
 
     return {
@@ -260,12 +260,12 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
       xAxis: {
         ...echartsOptions.xAxis,
         scale: true,
-        name: _useTags ? `${formatTag(xAxisTag)} Optimality (%)` : 'Group 1 Optimality (%)',
+        name: _useTags ? `${formatTag(effectiveXAxisTag)} Optimality (%)` : 'Group 1 Optimality (%)',
       },
       yAxis: {
         ...echartsOptions.yAxis,
         scale: true,
-        name: _useTags ? `${formatTag(yAxisTag)} Optimality (%)` : 'Group 2 Optimality (%)',
+        name: _useTags ? `${formatTag(effectiveYAxisTag)} Optimality (%)` : 'Group 2 Optimality (%)',
       },
       series: [
         {
@@ -280,7 +280,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
         },
       ],
     }
-  }, [data, noteValues, xAxisTag, yAxisTag])
+  }, [data, noteValues, effectiveXAxisTag, effectiveYAxisTag])
 
   return (
     <Transition appear show={isOpen} as={Fragment}>
@@ -342,7 +342,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                       </label>
                       <select
                         id="x-axis-group"
-                        value={xAxisTag}
+                        value={effectiveXAxisTag}
                         onChange={(e) => setXAxisTag(e.target.value)}
                         className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                       >
@@ -362,7 +362,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                       </label>
                       <select
                         id="y-axis-group"
-                        value={yAxisTag}
+                        value={effectiveYAxisTag}
                         onChange={(e) => setYAxisTag(e.target.value)}
                         className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                       >


### PR DESCRIPTION
**The Issue:**
The `src/layout/SystemClustering.tsx` component used a `useEffect` hook to synchronize the default values of `xAxisTag` and `yAxisTag` based on `availableTags`. This is a classic React anti-pattern that causes unnecessary render cycles and violates explicit user intent if state logic isn't perfectly guarded.

**The Discovery Signal:**
Scan B triggered this. Running `npx oxlint src/` reported 4 correctness violations in `src/layout/SystemClustering.tsx` related to the `react-you-might-not-need-an-effect` rule (specifically `no-chain-state-updates` and `no-event-handler` warnings on lines 96, 97, 98, and 99).

**The Fix:**
I replaced the `useEffect` synchronization with an inline state pattern:
1. Updated `useState<string>('')` to `useState<string | null>(null)` for both axes.
2. Deleted the synchronization `useEffect`.
3. Computed `effectiveXAxisTag` and `effectiveYAxisTag` dynamically directly within the render flow, falling back to the default `availableTags` values only when the state is strictly `null`.
4. Updated all references in `useMemo` dependencies and the `select` element values to use the new derived `effective*` constants.

**The Benefit:**
- Eliminates a useless render cycle caused by chaining state updates inside an effect.
- Resolves 4 high-priority correctness/suspicious oxlint violations.
- Reduces component complexity by managing default state derived from props strictly during the render phase.
- Fixes a subtle edge-case where a user selecting a genuinely blank tag could have had their selection overwritten by the `useEffect` defaulting logic.

---
*PR created automatically by Jules for task [4448372282495128261](https://jules.google.com/task/4448372282495128261) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `useEffect`-based state syncing in `SystemClustering` with derived axis tag defaults computed during render. Fixes `oxlint` `react-you-might-not-need-an-effect` warnings, prevents extra renders, and preserves user selections.

- **Bug Fixes**
  - Initialized `xAxisTag`/`yAxisTag` as `null` and derived `effective*` tags from `availableTags`.
  - Updated `useMemo` deps and `<select>` values to use derived tags.
  - Resolved four `oxlint` warnings (`no-chain-state-updates`, `no-event-handler`) and fixed blank-selection overwrite.

<sup>Written for commit 44ff3040efe197f321f5fed088fc0bb0b508ef1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

