### PR TITLE
Code quality fix: Remove effect for state sync in SystemClustering

### DIFF
--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState, useEffect } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import ReactECharts from 'echarts-for-react'
@@ -87,23 +87,25 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
     return Array.from(tags).sort()
   }, [data])
 
-  const [xAxisTag, setXAxisTag] = useState<string>('')
-  const [yAxisTag, setYAxisTag] = useState<string>('')
+  const [xAxisTag, setXAxisTag] = useState<string | null>(null)
+  const [yAxisTag, setYAxisTag] = useState<string | null>(null)
 
-  // Set defaults when tags load
-  useEffect(() => {
-    if (availableTags.length > 0) {
-      if (!xAxisTag)
-        setXAxisTag(availableTags.find((t) => t.includes('2-Metabolic')) || availableTags[0] || '')
-      if (!yAxisTag)
-        setYAxisTag(
-          availableTags.find((t) => t.includes('3-Liver') || t.includes('4-Lipid')) ||
-            availableTags[1] ||
-            availableTags[0] ||
-            '',
-        )
-    }
-  }, [availableTags, xAxisTag, yAxisTag])
+  const effectiveXAxisTag =
+    xAxisTag !== null
+      ? xAxisTag
+      : availableTags.length > 0
+        ? availableTags.find((t) => t.includes('2-Metabolic')) || availableTags[0] || ''
+        : ''
+
+  const effectiveYAxisTag =
+    yAxisTag !== null
+      ? yAxisTag
+      : availableTags.length > 0
+        ? availableTags.find((t) => t.includes('3-Liver') || t.includes('4-Lipid')) ||
+          availableTags[1] ||
+          availableTags[0] ||
+          ''
+        : ''
 
   const options = useMemo(() => {
     if (!data || data.length === 0 || !noteValues || noteValues.length === 0) return echartsOptions
@@ -127,8 +129,8 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
       let hasY = false
       const tagsLen = tags.length
       for (let i = 0; i < tagsLen; i++) {
-        if (xAxisTag && tags[i] === xAxisTag) hasX = true
-        if (yAxisTag && tags[i] === yAxisTag) hasY = true
+        if (effectiveXAxisTag && tags[i] === effectiveXAxisTag) hasX = true
+        if (effectiveYAxisTag && tags[i] === effectiveYAxisTag) hasY = true
       }
 
       if (hasX) m1Indices.push(m)
@@ -137,7 +139,10 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
 
     // Fallback: If we don't have enough markers in tags, just use the first half vs second half
     const useTags =
-      xAxisTag !== '' && yAxisTag !== '' && m1Indices.length > 0 && m2Indices.length > 0
+      effectiveXAxisTag !== '' &&
+      effectiveYAxisTag !== '' &&
+      m1Indices.length > 0 &&
+      m2Indices.length > 0
     // Bolt Optimization: Hoist fallback array calculations outside the inner loop to
     // eliminate redundant object allocations and garbage collection per timepoint.
     let g1: number[]
@@ -242,7 +247,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
       })
     }
 
-    const _useTags = xAxisTag !== '' && yAxisTag !== ''
+    const _useTags = effectiveXAxisTag !== '' && effectiveYAxisTag !== ''
     const formatTag = (tag: string) => tag.replace(/^\w-/, '')
 
     return {
@@ -260,12 +265,12 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
       xAxis: {
         ...echartsOptions.xAxis,
         scale: true,
-        name: _useTags ? `${formatTag(xAxisTag)} Optimality (%)` : 'Group 1 Optimality (%)',
+        name: _useTags ? `${formatTag(effectiveXAxisTag)} Optimality (%)` : 'Group 1 Optimality (%)',
       },
       yAxis: {
         ...echartsOptions.yAxis,
         scale: true,
-        name: _useTags ? `${formatTag(yAxisTag)} Optimality (%)` : 'Group 2 Optimality (%)',
+        name: _useTags ? `${formatTag(effectiveYAxisTag)} Optimality (%)` : 'Group 2 Optimality (%)',
       },
       series: [
         {
@@ -280,7 +285,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
         },
       ],
     }
-  }, [data, noteValues, xAxisTag, yAxisTag])
+  }, [data, noteValues, effectiveXAxisTag, effectiveYAxisTag])
 
   return (
     <Transition appear show={isOpen} as={Fragment}>
@@ -342,7 +347,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                       </label>
                       <select
                         id="x-axis-group"
-                        value={xAxisTag}
+                        value={effectiveXAxisTag}
                         onChange={(e) => setXAxisTag(e.target.value)}
                         className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                       >
@@ -362,7 +367,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                       </label>
                       <select
                         id="y-axis-group"
-                        value={yAxisTag}
+                        value={effectiveYAxisTag}
                         onChange={(e) => setYAxisTag(e.target.value)}
                         className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                       >


### PR DESCRIPTION
**The Issue:**
`src/layout/SystemClustering.tsx` lines 94-106. The code used a `useEffect` to synchronize fallback states for `xAxisTag` and `yAxisTag` based on `availableTags` when the component mounted or tags loaded. This is a classic React anti-pattern (syncing derived state in an effect) that causes an unnecessary additional render cycle.

**The Discovery Signal:**
Scan B: `src/layout/SystemClustering.tsx` — oxlint rule `react-you-might-not-need-an-effect(no-chain-state-updates)` reports Avoid chaining state changes for `xAxisTag` and `yAxisTag`.

**The Fix:**
- Removed the `useEffect` entirely from `SystemClustering.tsx`.
- Changed the initial `useState` hook signatures for the tags from `''` to `null` to explicitly distinguish between "no user selection" and "empty".
- Derived `effectiveXAxisTag` and `effectiveYAxisTag` directly during the render cycle.
- Updated the `options` `useMemo` block and `value` props on the `select` elements to consume the derived effective tags.

**The Benefit:**
Eliminates an unnecessary double-render cycle when `availableTags` load, ensures that fallback logic consistently applies without racing lifecycles, genuinely resolves two high-priority oxlint warnings under `correctness` without relying on suppression comments, and simplifies the internal state model of the component.

---
*PR created automatically by Jules for task [10118223485009740742](https://jules.google.com/task/10118223485009740742) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the state-sync effect in `SystemClustering` and now derive axis tags during render. This avoids an extra render when tags load and resolves oxlint warnings.

- **Refactors**
  - Removed the `useEffect` that synchronized `xAxisTag` and `yAxisTag`.
  - Initialized tag state to `null` to distinguish “unset” from “empty”.
  - Derived `effectiveXAxisTag` and `effectiveYAxisTag` during render with the same fallback rules.
  - Updated the options `useMemo`, dependencies, and `select` `value` props to use the effective tags.

<sup>Written for commit fe2d94fcc9db9be600d2413305dc773fac05274d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

