### PR TITLE
Fix oxlint correctness warnings in SystemClustering

### DIFF
--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState, useEffect } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import ReactECharts from 'echarts-for-react'
@@ -87,23 +87,11 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
     return Array.from(tags).sort()
   }, [data])
 
-  const [xAxisTag, setXAxisTag] = useState<string>('')
-  const [yAxisTag, setYAxisTag] = useState<string>('')
+  const [xAxisTag, setXAxisTag] = useState<string | null>(null)
+  const [yAxisTag, setYAxisTag] = useState<string | null>(null)
 
-  // Set defaults when tags load
-  useEffect(() => {
-    if (availableTags.length > 0) {
-      if (!xAxisTag)
-        setXAxisTag(availableTags.find((t) => t.includes('2-Metabolic')) || availableTags[0] || '')
-      if (!yAxisTag)
-        setYAxisTag(
-          availableTags.find((t) => t.includes('3-Liver') || t.includes('4-Lipid')) ||
-            availableTags[1] ||
-            availableTags[0] ||
-            '',
-        )
-    }
-  }, [availableTags, xAxisTag, yAxisTag])
+  const effectiveXAxisTag = xAxisTag !== null ? xAxisTag : (availableTags.length > 0 ? (availableTags.find((t) => t.includes('2-Metabolic')) || availableTags[0] || '') : '')
+  const effectiveYAxisTag = yAxisTag !== null ? yAxisTag : (availableTags.length > 0 ? (availableTags.find((t) => t.includes('3-Liver') || t.includes('4-Lipid')) || availableTags[1] || availableTags[0] || '') : '')
 
   const options = useMemo(() => {
     if (!data || data.length === 0 || !noteValues || noteValues.length === 0) return echartsOptions
@@ -127,8 +115,8 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
       let hasY = false
       const tagsLen = tags.length
       for (let i = 0; i < tagsLen; i++) {
-        if (xAxisTag && tags[i] === xAxisTag) hasX = true
-        if (yAxisTag && tags[i] === yAxisTag) hasY = true
+        if (effectiveXAxisTag && tags[i] === effectiveXAxisTag) hasX = true
+        if (effectiveYAxisTag && tags[i] === effectiveYAxisTag) hasY = true
       }
 
       if (hasX) m1Indices.push(m)
@@ -137,7 +125,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
 
     // Fallback: If we don't have enough markers in tags, just use the first half vs second half
     const useTags =
-      xAxisTag !== '' && yAxisTag !== '' && m1Indices.length > 0 && m2Indices.length > 0
+      effectiveXAxisTag !== '' && effectiveYAxisTag !== '' && m1Indices.length > 0 && m2Indices.length > 0
     // Bolt Optimization: Hoist fallback array calculations outside the inner loop to
     // eliminate redundant object allocations and garbage collection per timepoint.
     let g1: number[]
@@ -242,7 +230,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
       })
     }
 
-    const _useTags = xAxisTag !== '' && yAxisTag !== ''
+    const _useTags = effectiveXAxisTag !== '' && effectiveYAxisTag !== ''
     const formatTag = (tag: string) => tag.replace(/^\w-/, '')
 
     return {
@@ -260,12 +248,12 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
       xAxis: {
         ...echartsOptions.xAxis,
         scale: true,
-        name: _useTags ? `${formatTag(xAxisTag)} Optimality (%)` : 'Group 1 Optimality (%)',
+        name: _useTags ? `${formatTag(effectiveXAxisTag)} Optimality (%)` : 'Group 1 Optimality (%)',
       },
       yAxis: {
         ...echartsOptions.yAxis,
         scale: true,
-        name: _useTags ? `${formatTag(yAxisTag)} Optimality (%)` : 'Group 2 Optimality (%)',
+        name: _useTags ? `${formatTag(effectiveYAxisTag)} Optimality (%)` : 'Group 2 Optimality (%)',
       },
       series: [
         {
@@ -280,7 +268,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
         },
       ],
     }
-  }, [data, noteValues, xAxisTag, yAxisTag])
+  }, [data, noteValues, effectiveXAxisTag, effectiveYAxisTag])
 
   return (
     <Transition appear show={isOpen} as={Fragment}>
@@ -342,7 +330,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                       </label>
                       <select
                         id="x-axis-group"
-                        value={xAxisTag}
+                        value={effectiveXAxisTag}
                         onChange={(e) => setXAxisTag(e.target.value)}
                         className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                       >
@@ -362,7 +350,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                       </label>
                       <select
                         id="y-axis-group"
-                        value={yAxisTag}
+                        value={effectiveYAxisTag}
                         onChange={(e) => setYAxisTag(e.target.value)}
                         className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                       >


### PR DESCRIPTION
Fixes `react-you-might-not-need-an-effect` violations flagged by `oxlint` in `src/layout/SystemClustering.tsx` by replacing the `useEffect` derived state pattern with proper render phase calculations.

---
*PR created automatically by Jules for task [1719176330192788601](https://jules.google.com/task/1719176330192788601) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced effect-driven derived state in `src/layout/SystemClustering.tsx` with render-phase defaults for axis tags to satisfy `oxlint` (`react-you-might-not-need-an-effect`) and cut unnecessary renders. Chart and selects now use computed tags so defaults apply immediately without syncing state.

- **Refactors**
  - Removed `useEffect`; made `xAxisTag`/`yAxisTag` nullable and only set on user change.
  - Added `effectiveXAxisTag`/`effectiveYAxisTag` with fallbacks (Metabolic, Liver/Lipid, else first tags).
  - Switched option building, checks, axis labels, and `<select>` values to use effective tags; pruned unused `useEffect` import.

<sup>Written for commit 5c85d09f9af8cd88133c52c02fecbb094ad167ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

