### PR TITLE
refactor(ui): resolve SystemClustering chained state updates

### DIFF
--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState, useEffect } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import ReactECharts from 'echarts-for-react'
@@ -87,23 +87,20 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
     return Array.from(tags).sort()
   }, [data])
 
-  const [xAxisTag, setXAxisTag] = useState<string>('')
-  const [yAxisTag, setYAxisTag] = useState<string>('')
+  const [userXAxisTag, setUserXAxisTag] = useState<string | null>(null)
+  const [userYAxisTag, setUserYAxisTag] = useState<string | null>(null)
 
-  // Set defaults when tags load
-  useEffect(() => {
-    if (availableTags.length > 0) {
-      if (!xAxisTag)
-        setXAxisTag(availableTags.find((t) => t.includes('2-Metabolic')) || availableTags[0] || '')
-      if (!yAxisTag)
-        setYAxisTag(
-          availableTags.find((t) => t.includes('3-Liver') || t.includes('4-Lipid')) ||
-            availableTags[1] ||
-            availableTags[0] ||
-            '',
-        )
-    }
-  }, [availableTags, xAxisTag, yAxisTag])
+  const xAxisTag =
+    userXAxisTag !== null
+      ? userXAxisTag
+      : availableTags.find((t) => t.includes('2-Metabolic')) || availableTags[0] || ''
+  const yAxisTag =
+    userYAxisTag !== null
+      ? userYAxisTag
+      : availableTags.find((t) => t.includes('3-Liver') || t.includes('4-Lipid')) ||
+        availableTags[1] ||
+        availableTags[0] ||
+        ''
 
   const options = useMemo(() => {
     if (!data || data.length === 0 || !noteValues || noteValues.length === 0) return echartsOptions
@@ -343,7 +340,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                       <select
                         id="x-axis-group"
                         value={xAxisTag}
-                        onChange={(e) => setXAxisTag(e.target.value)}
+                        onChange={(e) => setUserXAxisTag(e.target.value)}
                         className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                       >
                         {availableTags.map((t) => (
@@ -363,7 +360,7 @@ const SystemClustering = memo(({ isOpen, onClose }: SystemClusteringProps) => {
                       <select
                         id="y-axis-group"
                         value={yAxisTag}
-                        onChange={(e) => setYAxisTag(e.target.value)}
+                        onChange={(e) => setUserYAxisTag(e.target.value)}
                         className="bg-[#111111] text-white border border-[#3a3a3a] rounded p-2 text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
                       >
                         {availableTags.map((t) => (


### PR DESCRIPTION
**The Issue:**
`src/layout/SystemClustering.tsx` lines 96-105. The component contained structural problems by utilizing `useEffect` to synchronise `xAxisTag` and `yAxisTag` states with the loaded `availableTags` list, violating React core concepts by chaining state updates on mount and using an effect block as an event handler fallback.

**The Discovery Signal:**
Scan B (oxlint):
- `correctness/react-you-might-not-need-an-effect(no-chain-state-updates)` triggered twice on `SystemClustering.tsx`.
- `correctness/react-you-might-not-need-an-effect(no-event-handler)` triggered twice on `SystemClustering.tsx`.
- `eslint(no-unused-vars)` triggered on `useEffect` import after fixing.

**The Fix:**
- Removed the `useEffect` block that synchronized `xAxisTag` and `yAxisTag` with `availableTags`.
- Replaced the direct value states with `userXAxisTag` and `userYAxisTag` (initialized to `null`).
- Dynamically derived the effective `xAxisTag` and `yAxisTag` values inline during the component render path based on whether the user had made a selection, falling back to the original `availableTags` list logic if `null`.
- Updated the dropdown `<select>` `onChange` handlers to strictly modify the user-specific state.
- Removed the `useEffect` import from React.

**The Benefit:**
Completely resolves multiple `oxlint` correctness/suspicious violations, making the codebase cleaner. Most crucially, this safely removes a React "stale render" anti-pattern (syncing state in `useEffect`), saving one unnecessary rendering cycle when the component mounts or tags update, significantly decreasing complexity and reducing confusion for future maintainers.

---
*PR created automatically by Jules for task [9937446756301208974](https://jules.google.com/task/9937446756301208974) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed effect-based state syncing in SystemClustering to stop chained updates and stale renders. Axis defaults are now derived at render, with user selections tracked separately, resolving `oxlint` warnings and avoiding an extra render.

- **Refactors**
  - Compute `xAxisTag`/`yAxisTag` during render from `availableTags` unless `userXAxisTag`/`userYAxisTag` is set.
  - Added `userXAxisTag` and `userYAxisTag` (null-initialized) and wired `<select>` handlers to update them.
  - Removed the `useEffect` block and its import; clears two `oxlint` correctness warnings and simplifies mount behavior.

<sup>Written for commit e0c1ba3f35ba42c0c976bb8e4ced4c54a24ba255. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

