### PR TITLE
docs: update CHARTS.md with comprehensive chart list and info

### DIFF
--- a/docs/CHARTS.md
+++ b/docs/CHARTS.md
@@ -1,136 +1,148 @@
 # Charts Documentation
 
-This document provides an overview of all implemented charts in the application. It is structured to be easily parsable and understood by LLMs, detailing the name, description, typical use cases, and data shape (props) for each chart component.
+This document provides an overview of all implemented charts in the application. It details the name, UI and code locations, purpose, and technical specifications for each chart component.
 
 ## Table of Contents
-1. [Chart (Wrapper)](#chart)
-2. [Chart2 (Base Definitions)](#chart2)
+1. [Chart (Wrapper)](#chart-wrapper)
+2. [Chart2 (Base Definitions)](#chart2-base-definitions)
 3. [BiomarkerCorrelationBumpChart](#biomarkercorrelationbumpchart)
-4. [BoxplotChart](#boxplotchart)
-5. [FocusedCorrelationChart](#focusedcorrelationchart)
-6. [HistogramChart](#histogramchart)
-7. [LineChart](#linechart)
-8. [RadarChart](#radarchart)
-9. [ScatterChart](#scatterchart)
+4. [BiomarkerCorrelationGraph](#biomarkercorrelationgraph)
+5. [BoxplotChart](#boxplotchart)
+6. [CorrelationChordDiagram](#correlationchorddiagram)
+7. [FocusedCorrelationChart](#focusedcorrelationchart)
+8. [HistogramChart](#histogramchart)
+9. [LineChart](#linechart)
+10. [RadarChart](#radarchart)
+11. [ScatterChart](#scatterchart)
+12. [SupplementCorrelationGraph](#supplementcorrelationgraph)
+13. [SystemClustering](#systemclustering)
 
 ---
 
-## Chart
-**Description:** A multi-axis line chart wrapper built on `@echarts-readymade/core` and `echarts-for-react`. It dynamically generates multiple Y-axes (alternating left/right with offsets) to support plotting multiple series on the same timeline grid without overlap.
-**Typical Use Cases:** Displaying multiple distinct biomarker timelines simultaneously on a single view, allowing for visual correlation across different units and scales.
-**Data Shape (Props):**
-```typescript
-interface ChartProps {
-  keys: string[]; // Array of biomarker names to fetch from global state and plot.
-}
-```
+## Chart (Wrapper)
+**Locations in UI:** Main View (Dashboard)
+**Locations in code file:** `src/layout/Chart.tsx`
+**Purpose:** A multi-axis line chart wrapper built on `@echarts-readymade/core`. It dynamically generates multiple Y-axes (alternating left/right with offsets) to support plotting multiple series on the same timeline grid without overlap. Used for displaying multiple distinct biomarker timelines simultaneously on a single view, allowing for visual correlation across different units and scales.
+**Technical info:**
+- **Chart Type:** `line`
+- **Data/Atom:** Prop: `keys: string[]` (Array of biomarker names to fetch from global state). Uses `ChartProvider` context for data injection.
 
 ---
 
-## Chart2
-**Description:** Not a standalone chart component, but a foundational file exporting shared chart configurations, specifically the `CHART_PALETTE` array used across multiple visualizations to ensure consistent theming. It also registers the `echarts-stat` regression transform.
-**Typical Use Cases:** Imported by other charts to retrieve the application's standard dark-mode color palette.
+## Chart2 (Base Definitions)
+**Locations in UI:** N/A (Helper)
+**Locations in code file:** `src/layout/Chart2.tsx`
+**Purpose:** Not a standalone chart component, but a foundational file exporting shared chart configurations, specifically the `CHART_PALETTE` array used across multiple visualizations to ensure consistent dark-mode theming. It also registers the `echarts-stat` regression transform.
+**Technical info:**
+- **Chart Type:** N/A
+- **Data/Atom:** Exports `CHART_PALETTE` and base `echartsOptions`.
 
 ---
 
 ## BiomarkerCorrelationBumpChart
-**Description:** A specialized bump chart displaying the correlation ranking between a target biomarker and various supplements/factors over time. It visually tracks how the correlation rank changes across different time windows.
-**Typical Use Cases:** Identifying which lifestyle factors or supplements consistently correlate strongly (positively or negatively) with a specific biomarker over rolling periods.
-**Data Shape (Props):**
-```typescript
-interface BumpChartProps {
-  targetBiomarker: string;
-  correlations: CorrelationResult[];
-  noteValues: NoteItem[];
-}
+**Locations in UI:** Biomarker Correlation Modal (`BiomarkerCorrelation.tsx`)
+**Locations in code file:** `src/layout/BiomarkerCorrelationBumpChart.tsx`
+**Purpose:** A specialized bump chart displaying the correlation ranking between a target biomarker and various supplements/factors over time. It visually tracks how the correlation rank changes across different time windows.
+**Technical info:**
+- **Chart Type:** `line` (styled as a bump chart with rankings)
+- **Data/Atom:** Props: `targetBiomarker: string`, `correlations: CorrelationResult[]`, `noteValues: NoteItem[]`.
 
-// Referenced shapes
-type CorrelationResult = [string, number, number, number]; // [name, N, pValue, coeff]
-interface NoteItem {
-  id: string;
-  date: string;
-  content: string;
-  // ... other note properties
-}
-```
+---
+
+## BiomarkerCorrelationGraph
+**Locations in UI:** Biomarker Correlation Modal (`BiomarkerCorrelation.tsx`)
+**Locations in code file:** `src/layout/BiomarkerCorrelationGraph.tsx`
+**Purpose:** A force-directed network graph showing the correlation strength between a specific target biomarker and other related factors. Node size and edge thickness represent the absolute correlation magnitude (rho), while colors represent positive (emerald) vs negative (red) correlations.
+**Technical info:**
+- **Chart Type:** `graph` (force layout)
+- **Data/Atom:** Props: `biomarkerId: string`, `correlations: CorrelationResult[]`.
 
 ---
 
 ## BoxplotChart
-**Description:** A standard boxplot visualization for a single continuous variable, built using `echarts-for-react`.
-**Typical Use Cases:** Analyzing the distribution, central tendency, and outliers of a specific biomarker's values across all recorded timepoints.
-**Data Shape (Props):**
-```typescript
-interface BoxplotChartProps {
-  name: string;      // The name of the biomarker or dataset
-  values: number[];  // Array of numeric values representing the distribution
-}
-```
+**Locations in UI:** Table Row Expansion (Data Grid)
+**Locations in code file:** `src/layout/BoxplotChart.tsx`
+**Purpose:** A standard boxplot visualization for a single continuous variable. Analyzes the distribution, central tendency, and outliers of a specific biomarker's values across all recorded timepoints.
+**Technical info:**
+- **Chart Type:** `boxplot` (via custom series or `echarts-stat` transform)
+- **Data/Atom:** Props: `name: string`, `values: number[]`.
+
+---
+
+## CorrelationChordDiagram
+**Locations in UI:** Main View (Dashboard)
+**Locations in code file:** `src/layout/CorrelationChordDiagram.tsx`
+**Purpose:** A circular layout graph (chord-style diagram) displaying global correlations across all tracked biomarkers simultaneously. Allows users to see the entire network of relationships, with edge thickness denoting correlation strength.
+**Technical info:**
+- **Chart Type:** `graph` (circular layout)
+- **Data/Atom:** Directly consumes Jotai atoms: `nonInferredDataAtom`, `dataMapAtom`, `rankedDataMapAtom`, `correlationAlphaAtom`, `correlationAlternativeAtom`, `correlationMethodAtom`.
 
 ---
 
 ## FocusedCorrelationChart
-**Description:** A horizontal bar chart displaying the strongest positive and negative correlations for a given context. It dynamically scales the opacity of bars based on statistical significance (p-value compared to an alpha threshold).
-**Typical Use Cases:** Providing a quick summary of the top positive and negative influences (e.g., diet, sleep, supplements) on a target metric, filtering out insignificant noise.
-**Data Shape (Props):**
-```typescript
-interface FocusedCorrelationChartProps {
-  correlations: Array<[string, number, number, number]>; // [name, N, pValue, coeff]
-  alpha: number; // The significance threshold (e.g., 0.05)
-}
-```
+**Locations in UI:** Correlation Modal (`Correlation.tsx`)
+**Locations in code file:** `src/layout/FocusedCorrelationChart.tsx`
+**Purpose:** A horizontal bar chart displaying the strongest positive and negative correlations for a given context. It dynamically scales the opacity of bars based on statistical significance (p-value compared to an alpha threshold).
+**Technical info:**
+- **Chart Type:** `bar` (horizontal layout)
+- **Data/Atom:** Props: `correlations: Array<[string, number, number, number]>`, `alpha: number`.
 
 ---
 
 ## HistogramChart
-**Description:** A histogram visualization that uses `echarts-stat` transform to bucket continuous data into frequency bins.
-**Typical Use Cases:** Understanding the frequency distribution and density of a biomarker's values, helping to identify normal ranges versus rare extremes for the individual.
-**Data Shape (Props):**
-```typescript
-interface HistogramChartProps {
-  name: string;      // The name of the dataset
-  values: number[];  // Array of numeric values to be bucketed
-}
-```
+**Locations in UI:** Table Row Expansion (Data Grid)
+**Locations in code file:** `src/layout/HistogramChart.tsx`
+**Purpose:** A histogram visualization that uses `echarts-stat` transform to bucket continuous data into frequency bins. Helps understand the frequency distribution and density of a biomarker's values.
+**Technical info:**
+- **Chart Type:** `bar` (using `echarts-stat` histogram transform)
+- **Data/Atom:** Props: `name: string`, `values: number[]`.
 
 ---
 
 ## LineChart
-**Description:** A single-series line chart with optional background mark areas to highlight specific target ranges or safe zones.
-**Typical Use Cases:** Showing the trend of a single biomarker over time, often overlaying a visual "optimal range" band so users can see when they fell in or out of bounds.
-**Data Shape (Props):**
-```typescript
-interface LineChartProps {
-  name: string;        // The name of the dataset being plotted
-  values: number[];    // Array of numeric values corresponding to the timeline
-  rangeStr?: string;   // Optional string representing the target range (e.g., "5.0-7.0")
-}
-```
+**Locations in UI:** Table Row Expansion (Data Grid)
+**Locations in code file:** `src/layout/LineChart.tsx`
+**Purpose:** A single-series line chart with optional background mark areas to highlight specific target ranges or safe zones. Shows the trend of a single biomarker over time, overlaying a visual "optimal range" band.
+**Technical info:**
+- **Chart Type:** `line` (with `markArea`)
+- **Data/Atom:** Props: `name: string`, `values: number[]`, `rangeStr?: string`.
 
 ---
 
 ## RadarChart
-**Description:** A radar (spider) chart displaying multiple variables on a radial grid.
-**Typical Use Cases:** Comparing a snapshot of multiple related biomarkers (or system health scores) against each other at a specific point in time or comparing current values to historical baselines.
-**Data Shape (Props):**
-```typescript
-interface RadarChartProps {
-  data: BioMarker[]; // Array of biomarker data tuples
-  tag: string;       // A specific tag or category to filter/focus the radar on
-}
-
-// Referenced shapes
-type BioMarker = [string, number[], string?]; // [name, values, unit]
-```
+**Locations in UI:** Main View (Dashboard)
+**Locations in code file:** `src/layout/RadarChart.tsx`
+**Purpose:** A radar (spider) chart displaying multiple variables on a radial grid. Used for comparing a snapshot of multiple related biomarkers or system health scores against each other at a specific point in time.
+**Technical info:**
+- **Chart Type:** `radar`
+- **Data/Atom:** Props: `data: BioMarker[]`, `tag: string`.
 
 ---
 
 ## ScatterChart
-**Description:** A multi-series scatter plot that plots distinct data points over time.
-**Typical Use Cases:** Visualizing sparse data, specific measurement events, or comparing the exact measurement timing of multiple biomarkers without interpolating lines between points.
-**Data Shape (Props):**
-```typescript
-interface ScatterChartProps {
-  keys: string[]; // Array of biomarker names to fetch and plot
-}
-```
+**Locations in UI:** Main View (Dashboard)
+**Locations in code file:** `src/layout/ScatterChart.tsx`
+**Purpose:** A multi-series scatter plot that plots distinct data points over time. Useful for visualizing sparse data, specific measurement events, or comparing exact measurement timing without interpolating lines between points.
+**Technical info:**
+- **Chart Type:** `scatter`
+- **Data/Atom:** Prop: `keys: string[]` (Array of biomarker names to plot).
+
+---
+
+## SupplementCorrelationGraph
+**Locations in UI:** Supplement Correlation Modal (`SupplementCorrelation.tsx`)
+**Locations in code file:** `src/layout/SupplementCorrelationGraph.tsx`
+**Purpose:** A force-directed network graph visualizing the strongest correlations between a specific supplement and various biomarkers. Node size and line width scale with correlation strength, highlighting key relationships.
+**Technical info:**
+- **Chart Type:** `graph` (force layout)
+- **Data/Atom:** Props: `supplementName: string`, `correlations: SupplementCorrelationResult[]`.
+
+---
+
+## SystemClustering
+**Locations in UI:** Sidebar / Overlay (Triggered from App header)
+**Locations in code file:** `src/layout/SystemClustering.tsx`
+**Purpose:** A treemap chart intended to visually cluster and group related systems, biomarkers, and metrics hierarchically. Allows users to drill down into specific physiological systems or categories.
+**Technical info:**
+- **Chart Type:** `treemap`
+- **Data/Atom:** Props: `isOpen: boolean`, `onClose: () => void`. Directly consumes Jotai atoms for global data state (e.g., `dataMapAtom`).


### PR DESCRIPTION
**The Issue:** `docs/CHARTS.md` only showed types of charts, which was not informative. It also missed multiple new charts.
**Discovery Signal:** User request.
**The Fix:** Updated `docs/CHARTS.md` to show the list of current chart implementations, locations in UI, locations in code file, purposes, and technical info (data/atom to use, chart type) for all 13 chart components.
**The Benefit:** A clear, informative, and up-to-date documentation file for all charts.

---
*PR created automatically by Jules for task [4055823552165366023](https://jules.google.com/task/4055823552165366023) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Overhauled `docs/CHARTS.md` to document all 13 chart components with UI locations, code paths, purpose, chart type, and inputs. Replaces the previous type-only list and adds the new correlation graphs, chord diagram, and system clustering for a complete, up-to-date reference.

<sup>Written for commit 40158a50605a5fe5f55f7d3ae61b1c9643f89fac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

