### PR TITLE
feat: Add RankScatterMatrix chart

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -351,7 +351,7 @@ export default function App() {
               {chartKeys && chartKeys.length > 0 && chartType === 'scatter' && (
                 <ScatterChart keys={chartKeys} />
               )}
-              {chartKeys && (chartKeys.length === 2 || chartKeys.length === 3) && chartType === 'scatter' && (
+              {chartKeys && chartKeys.length >= 2 && chartKeys.length <= 5 && chartType === 'scatter' && (
                 <RankScatterMatrix keys={chartKeys} />
               )}
             </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -352,7 +352,7 @@ export default function App() {
                 <ScatterChart keys={chartKeys} />
               )}
               {chartKeys && (chartKeys.length === 2 || chartKeys.length === 3) && chartType === 'scatter' && (
-                <RankScatterMatrix />
+                <RankScatterMatrix keys={chartKeys} />
               )}
             </>
           )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import { useAtomValue, useAtom } from 'jotai'
 const ScatterChart = React.lazy(() => import('./layout/ScatterChart'))
 const RadarChart = React.lazy(() => import('./layout/RadarChart'))
 const CorrelationChordDiagram = React.lazy(() => import('./layout/CorrelationChordDiagram'))
+const RankScatterMatrix = React.lazy(() => import('./layout/RankScatterMatrix'))
+
 import {
   getBioMarkersAtom,
   filterTextAtom,
@@ -348,6 +350,9 @@ export default function App() {
               )}
               {chartKeys && chartKeys.length > 0 && chartType === 'scatter' && (
                 <ScatterChart keys={chartKeys} />
+              )}
+              {chartKeys && (chartKeys.length === 2 || chartKeys.length === 3) && chartType === 'scatter' && (
+                <RankScatterMatrix />
               )}
             </>
           )}

--- a/src/layout/RankScatterMatrix.tsx
+++ b/src/layout/RankScatterMatrix.tsx
@@ -1,23 +1,14 @@
 import { memo, useMemo } from 'react'
 import { useAtomValue } from 'jotai'
-import { visibleDataAtom, rankedDataMapAtom } from '../atom/dataAtom'
+import { rankedDataMapAtom } from '../atom/dataAtom'
 import ReactECharts from 'echarts-for-react'
 import type { GridComponentOption, XAXisComponentOption, YAXisComponentOption, ScatterSeriesOption, TooltipComponentOption } from 'echarts'
 import { CHART_PALETTE } from './Chart2'
 import { formattedLabels } from '../data'
 import { RankScatterMatrixProps } from './RankScatterMatrix.types'
 
-export default memo((_props: RankScatterMatrixProps) => {
-  const visibleData = useAtomValue(visibleDataAtom)
+export default memo(({ keys }: RankScatterMatrixProps) => {
   const rankedDataMap = useAtomValue(rankedDataMapAtom)
-
-  const keys = useMemo(() => {
-    const k = []
-    for (let i = 0; i < visibleData.length; i++) {
-      k.push(visibleData[i][0])
-    }
-    return k
-  }, [visibleData])
 
   const options = useMemo(() => {
     const numVars = keys.length

--- a/src/layout/RankScatterMatrix.tsx
+++ b/src/layout/RankScatterMatrix.tsx
@@ -1,0 +1,190 @@
+import { memo, useMemo } from 'react'
+import { useAtomValue } from 'jotai'
+import { visibleDataAtom, rankedDataMapAtom } from '../atom/dataAtom'
+import ReactECharts from 'echarts-for-react'
+import type { GridComponentOption, XAXisComponentOption, YAXisComponentOption, ScatterSeriesOption, TooltipComponentOption } from 'echarts'
+import { CHART_PALETTE } from './Chart2'
+import { formattedLabels } from '../data'
+import { RankScatterMatrixProps } from './RankScatterMatrix.types'
+
+export default memo((_props: RankScatterMatrixProps) => {
+  const visibleData = useAtomValue(visibleDataAtom)
+  const rankedDataMap = useAtomValue(rankedDataMapAtom)
+
+  const keys = useMemo(() => {
+    const k = []
+    for (let i = 0; i < visibleData.length; i++) {
+      k.push(visibleData[i][0])
+    }
+    return k
+  }, [visibleData])
+
+  const options = useMemo(() => {
+    const numVars = keys.length
+    if (numVars !== 2 && numVars !== 3) return null
+
+    const datasetSource: any[][] = []
+    const headerRow: any[] = ['Date']
+    for (let i = 0; i < numVars; i++) {
+      headerRow.push(keys[i])
+    }
+    datasetSource.push(headerRow)
+
+    const rankArrays = []
+    let maxLen = 0
+    for (let i = 0; i < numVars; i++) {
+      const arr = rankedDataMap.get(keys[i])
+      rankArrays.push(arr)
+      if (arr && arr.length > maxLen) {
+        maxLen = arr.length
+      }
+    }
+
+    if (maxLen === 0) return null
+
+    for (let i = 0; i < maxLen; i++) {
+      let isValidRow = true
+      const row: any[] = [formattedLabels[i] || `Point ${i}`]
+      for (let j = 0; j < numVars; j++) {
+        const arr = rankArrays[j]
+        const val = arr ? arr[i] : NaN
+        if (Number.isNaN(val) || val === null || val === undefined) {
+          isValidRow = false
+          break
+        }
+        row.push(val)
+      }
+      if (isValidRow) {
+        datasetSource.push(row)
+      }
+    }
+
+    if (datasetSource.length <= 1) return null // Only header
+
+    const grids: GridComponentOption[] = []
+    const xAxes: XAXisComponentOption[] = []
+    const yAxes: YAXisComponentOption[] = []
+    const series: ScatterSeriesOption[] = []
+
+    // Matrix calculation
+    // Left padding: 50, right padding: 20
+    // Top padding: 50, bottom padding: 50
+    // Gap: 10%
+    const gap = 10
+    const cellWidth = (100 - gap * (numVars - 1)) / numVars
+    const cellHeight = (100 - gap * (numVars - 1)) / numVars
+
+    for (let i = 0; i < numVars; i++) {
+      for (let j = 0; j < numVars; j++) {
+        const gridIndex = i * numVars + j
+
+        // Calculate grid position using percentage
+        grids.push({
+          left: `${(j * (cellWidth + gap))}%`,
+          top: `${(i * (cellHeight + gap))}%`,
+          width: `${cellWidth}%`,
+          height: `${cellHeight}%`
+        })
+
+        const showXLabel = i === numVars - 1
+        const showYLabel = j === 0
+
+        xAxes.push({
+          gridIndex: gridIndex,
+          type: 'value',
+          scale: true,
+          name: showXLabel ? keys[j] : '',
+          nameLocation: 'middle',
+          nameGap: 30,
+          splitLine: { show: false },
+          axisLabel: { show: showXLabel },
+          axisTick: { show: showXLabel },
+          axisLine: { show: true, lineStyle: { color: '#666' } }
+        })
+
+        yAxes.push({
+          gridIndex: gridIndex,
+          type: 'value',
+          scale: true,
+          name: showYLabel ? keys[i] : '',
+          nameLocation: 'middle',
+          nameGap: 30,
+          splitLine: { show: false },
+          axisLabel: { show: showYLabel },
+          axisTick: { show: showYLabel },
+          axisLine: { show: true, lineStyle: { color: '#666' } }
+        })
+
+        if (i !== j) {
+            series.push({
+                type: 'scatter',
+                xAxisIndex: gridIndex,
+                yAxisIndex: gridIndex,
+                encode: {
+                    x: j + 1, // +1 because dataset starts with Date
+                    y: i + 1,
+                    tooltip: [0, j + 1, i + 1]
+                },
+                itemStyle: {
+                    color: CHART_PALETTE[gridIndex % CHART_PALETTE.length],
+                    opacity: 0.7
+                },
+                symbolSize: 6
+            })
+        }
+      }
+    }
+
+    const opt = {
+      theme: 'dark',
+      backgroundColor: 'transparent',
+      tooltip: {
+        trigger: 'item',
+        backgroundColor: '#111111',
+        borderColor: '#3a3a3a80',
+        textStyle: {
+            color: '#f0f0f0',
+        },
+        formatter: (params: any) => {
+           if (params.value) {
+                const date = params.value[0]
+                const valX = params.value[params.encode.x[0]]
+                const valY = params.value[params.encode.y[0]]
+                const nameX = keys[params.encode.x[0] - 1]
+                const nameY = keys[params.encode.y[0] - 1]
+                return `<strong>${date}</strong><br/>${params.marker} ${nameX}: <strong>${valX}</strong><br/>${params.marker} ${nameY}: <strong>${valY}</strong>`
+           }
+           return ''
+        }
+      } as TooltipComponentOption,
+      dataset: {
+        source: datasetSource
+      },
+      grid: grids,
+      xAxis: xAxes,
+      yAxis: yAxes,
+      series: series
+    }
+
+    return opt
+
+  }, [keys, rankedDataMap])
+
+  if (!options) return null
+
+  return (
+    <div className="w-full mt-8 px-8 py-4 border-t border-gray-800">
+      <h3 className="text-gray-400 text-sm mb-4 text-center uppercase tracking-wider">
+        Correlation Rank Scatter Matrix
+      </h3>
+      <div className="relative w-full aspect-square max-h-[800px] mx-auto">
+        <ReactECharts
+            option={options}
+            style={{ height: '100%', width: '100%' }}
+            theme="dark"
+            notMerge={true}
+        />
+      </div>
+    </div>
+  )
+})

--- a/src/layout/RankScatterMatrix.tsx
+++ b/src/layout/RankScatterMatrix.tsx
@@ -12,7 +12,7 @@ export default memo(({ keys }: RankScatterMatrixProps) => {
 
   const options = useMemo(() => {
     const numVars = keys.length
-    if (numVars !== 2 && numVars !== 3) return null
+    if (numVars < 2 || numVars > 5) return null
 
     const datasetSource: any[][] = []
     const headerRow: any[] = ['Date']
@@ -61,7 +61,7 @@ export default memo(({ keys }: RankScatterMatrixProps) => {
     // Left padding: 50, right padding: 20
     // Top padding: 50, bottom padding: 50
     // Gap: 10%
-    const gap = 10
+    const gap = numVars > 3 ? 5 : 10
     const cellWidth = (100 - gap * (numVars - 1)) / numVars
     const cellHeight = (100 - gap * (numVars - 1)) / numVars
 

--- a/src/layout/RankScatterMatrix.types.ts
+++ b/src/layout/RankScatterMatrix.types.ts
@@ -1,1 +1,3 @@
-export interface RankScatterMatrixProps {}
+export interface RankScatterMatrixProps {
+  keys: string[];
+}

--- a/src/layout/RankScatterMatrix.types.ts
+++ b/src/layout/RankScatterMatrix.types.ts
@@ -1,0 +1,1 @@
+export interface RankScatterMatrixProps {}


### PR DESCRIPTION
**The Issue:** The existing correlation tools (network graph or bump chart) only showed the strength of the correlation coefficient, obscuring the actual shape of the relationship (non-linear patterns, clusters, outliers) between the rank values.
**Discovery Signal:** Implementation of "Correlation Rank Scatter Matrix" chart proposal.
**The Fix:** Added a new `RankScatterMatrix` component that renders a Scatter Plot Matrix (SPLOM) of the Spearman rank arrays when 2 or 3 biomarkers are selected.
**The Benefit:** Provides deeper statistical context by revealing the underlying distribution and relationship shape that drives the correlation score.

---
*PR created automatically by Jules for task [14635818898541834269](https://jules.google.com/task/14635818898541834269) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `RankScatterMatrix` chart that shows a scatter plot matrix of Spearman rank values for 2–5 selected biomarkers to reveal relationship shape (non-linear patterns, clusters, outliers). It appears in Scatter view when 2 to 5 biomarkers are selected.

- **New Features**
  - Lazy-loads `RankScatterMatrix` in `App.tsx` and renders it when `chartType === 'scatter'` with 2–5 `chartKeys`.
  - Builds a SPLOM via `echarts-for-react` using `rankedDataMapAtom` and `formattedLabels`; includes per-cell axes, tooltips with date and ranks, and `CHART_PALETTE` colors.
  - Skips invalid rows and hides the matrix if data is insufficient; supports 2×2 up to 5×5 layouts.

- **Bug Fixes**
  - Uses the passed `keys` (chartKeys) instead of a global filter atom to decide what to plot and when to render.

<sup>Written for commit fbbe431b1ab394d591ce1240a895516cf60ae6e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

