### PR TITLE
Fix `no-event-handler` effect anti-pattern in Chart.tsx

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useState, useCallback, ElementRef } from 'react'
+import { memo, useMemo, useCallback, ElementRef } from 'react'
 import { useAtomValue } from 'jotai'
 import { dataMapAtom } from '../atom/dataAtom'
 import { ChartProvider, ChartContext } from '@echarts-readymade/core'
@@ -159,16 +159,9 @@ export default memo(({ keys }: ChartProps) => {
     return result
   }, [dataMap, keys, valueList])
 
-  const [echartsInstance, setEchartsInstance] = useState<any>(null)
-
   const handleRef = useCallback((node: ElementRef<typeof Line> | null) => {
-    setEchartsInstance(node?.getEchartsInstance() || null)
-  }, [])
-
-  useEffect(() => {
-    if (echartsInstance && !echartsInstance.isDisposed()) {
-      // Optimization: Replace array map in the render loop with a classic for-loop.
-      // ⚡ Bolt Optimization: Avoid pre-allocating 'holey' arrays. Use push() to maintain dense arrays for V8.
+    const instance = node?.getEchartsInstance();
+    if (instance && !instance.isDisposed()) {
       const len = keys.length
       const series: LineSeriesOption[] = []
       for (let i = 0; i < len; i++) {
@@ -177,7 +170,7 @@ export default memo(({ keys }: ChartProps) => {
           connectNulls: false,
         })
       }
-      echartsInstance.setOption(
+      instance.setOption(
         {
           yAxis,
           grid: {
@@ -191,7 +184,7 @@ export default memo(({ keys }: ChartProps) => {
         { replaceMerge: ['series', 'yAxis'] },
       )
     }
-  }, [keys, yAxis, echartsInstance])
+  }, [keys, yAxis])
 
   return (
     <ChartProvider data={chartData} echartsOptions={echartsOptions}>


### PR DESCRIPTION
**The Issue:**
`src/layout/Chart.tsx` lines 168-191. The component was tracking the resolved `echarts` instance via a generic `useState<any>` and syncing changes using a `useEffect`. This is an anti-pattern that creates an unnecessary extra render cycle and risks stale closures when using external library instances in React.

**Discovery Signal:**
Scan B: `src/layout/Chart.tsx` line 169 — oxlint rule `react-you-might-not-need-an-effect(no-event-handler)` reports "Avoid using state and effects as an event handler. Instead, call the code that uses 'echartsInstance' directly when the event occurs."

**The Fix:**
Removed the `echartsInstance` state entirely and merged the `setOption` configuration block directly into the `handleRef` `useCallback`. This perfectly mimics the native DOM mount timing and relies safely on the dependency array `[keys, yAxis]` to trigger updates.

**The Benefit:**
Eliminates a complete render cycle on component mount and updates, guarantees deterministic chart initialization timing, removes a weak `useState<any>` type, and entirely clears the `oxlint` rule violation without suppression comments.

---
*PR created automatically by Jules for task [14980159545497246737](https://jules.google.com/task/14980159545497246737) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `no-event-handler` effect anti-pattern in `src/layout/Chart.tsx` by configuring the ECharts instance directly in the ref callback. This removes an extra render and ensures deterministic chart initialization while clearing the oxlint warning.

- **Refactors**
  - Removed `useState`/`useEffect` that tracked `echartsInstance`.
  - Moved `setOption` into `handleRef` `useCallback` with dependencies `[keys, yAxis]`.

<sup>Written for commit 20f004387136ec2b7dc0233e88d0392d3aec9aa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

