### PR TITLE
fix(chart): resolve stale axes on re-render in Chart.tsx

### DIFF
--- a/proposals.md
+++ b/proposals.md
@@ -62,3 +62,111 @@ Activated when exactly two or three biomarkers are visible (via search or tag fi
 ---
 
 Recommended implementation order: Proposal 3 first (correlation insight), then 1, then 2.
+---
+
+**Proposal 4 of 8: Predictive Power Scatter Plot**
+
+**ECharts type:** `scatter`
+
+**Codebase citation:**
+Uses `correlationMethodAtom` from `src/atom/correlationAtom.ts` and checks `extra.inferred` on `BioMarker[3]` from `src/types/biomarker.ts`.
+
+**Which existing data it uses:**
+It uses `nonInferredDataAtom` (measured markers) and cross-references them against inferred markers (where `extra.inferred === true`). It calculates the pairwise correlation (Pearson or Spearman, depending on `correlationMethodAtom`) between each measured marker and inferred markers.
+
+**What it reveals that current charts don't:**
+It visualizes which single measured biomarker (e.g., Glucose) is the strongest predictor of complex inferred metrics (e.g., HOMA-IR or PhenoAge). It helps the user understand *why* an inferred metric is changing by exposing its most correlated raw measurements over time, going beyond simple trendlines.
+
+**Where it would live:**
+New `src/layout/PredictivePowerChart.tsx`, accessible from a "Predictive Analysis" view or alongside the Correlation panel.
+
+**Trigger / entry point:**
+Activated when a user focuses on an inferred biomarker, potentially by clicking an "Analyze Predictors" button next to it.
+
+---
+
+**Proposal 5 of 8: Tag Group Synchrony Heatmap**
+
+**ECharts type:** `heatmap`
+
+**Codebase citation:**
+Uses the `tagKeys` exported from `src/processors/post/tag.ts` and `dataAtom`.
+
+**Which existing data it uses:**
+It aggregates values across all biomarkers within the same `extra.tag` group. It creates a matrix where rows are tag groups (e.g., `1-RBC`, `2-Metabolic`) and columns are dates (`formattedLabels`). The intensity represents the percentage of biomarkers within that group that were out of optimal range (`extra.optimality`).
+
+**What it reveals that current charts don't:**
+Highlights systemic health shifts by showing when entire physiological systems (like liver or kidney function) experienced widespread fluctuations synchronously, as opposed to isolated anomalies. This makes identifying systemic trends across time immediate.
+
+**Where it would live:**
+New `src/layout/SystemSynchronyHeatmap.tsx`, acting as a high-level summary overview.
+
+**Trigger / entry point:**
+Rendered in a main dashboard view or a "System Health Overview" tab to provide a macroscopic view before diving into individual charts.
+
+---
+
+**Proposal 6 of 8: Measurement Panel Co-Occurrence Matrix**
+
+**ECharts type:** `heatmap` (Adjacency Matrix)
+
+**Codebase citation:**
+Analyzes the `values` arrays (index 1) of the `BioMarker` tuples within `dataAtom` for null checks.
+
+**Which existing data it uses:**
+Iterates through all biomarkers in `dataAtom` and counts how often they were measured on the exact same date (by checking `values[i] !== null && values[i] !== undefined`). It generates a square matrix where the intensity represents the frequency of co-measurement.
+
+**What it reveals that current charts don't:**
+Visualizes the user's historical testing patterns—showing which lab panels were typically ordered together (e.g., showing a strong co-occurrence cluster for Thyroid markers). It helps identify disjointed testing histories where certain markers were tested in isolation, explaining data sparsity.
+
+**Where it would live:**
+New `src/layout/PanelCoOccurrenceMatrix.tsx`, in a settings or "Data Quality" view.
+
+**Trigger / entry point:**
+Available under a "Data Insights" or "Audit" section, independent of the main data visualization flows.
+
+---
+
+**Proposal 7 of 8: PhenoAge vs Total Out-of-Range Count Dual-Axis Line**
+
+**ECharts type:** `line` (Dual-Axis)
+
+**Codebase citation:**
+Uses the `a-PhenoAge` group and `extra.optimality` from `src/processors/post/range.ts` combined with `dataAtom`.
+
+**Which existing data it uses:**
+Calculates a rolling count of total out-of-range biomarkers (by summing `true` values in `extra.optimality` across all markers at each time point `i`). It then plots this total count on the left Y-axis, and the calculated "Pheno age" (filtered from `dataAtom` where name is "Pheno age") on the right Y-axis.
+
+**What it reveals that current charts don't:**
+Directly correlates the high-level inferred biological age score against the raw volume of physiological anomalies. It allows the user to see if their calculated biological age rises in lockstep with the sheer number of biomarkers falling out of range, validating the score's sensitivity.
+
+**Where it would live:**
+New `src/layout/PhenoAgeComparisonChart.tsx`, specialized for the PhenoAge view.
+
+**Trigger / entry point:**
+Automatically displayed when the `tagAtom` is set to `a-PhenoAge`.
+
+---
+
+**Proposal 8 of 8: Spearman Rank Velocity Line Chart**
+
+**ECharts type:** `line`
+
+**Codebase citation:**
+Directly utilizes the pre-computed `rankedDataMapAtom` from `src/atom/dataAtom.ts`.
+
+**Which existing data it uses:**
+Takes the `Float64Array` rank arrays from `rankedDataMapAtom` for the selected biomarkers (via `visibleDataAtom`). Instead of plotting the raw values, it plots the rank position or the *change* in rank position over time.
+
+**What it reveals that current charts don't:**
+Visualizes relative performance changes by abstracting away differing units and scales. It clearly shows when a biomarker's value significantly shifted in terms of its historical distribution, ignoring minor absolute fluctuations that don't change its rank, which highlights truly anomalous shifts.
+
+**Where it would live:**
+New `src/layout/RankVelocityChart.tsx`, accessible from individual marker details.
+
+**Trigger / entry point:**
+A toggle button on `LineChart.tsx` or `ScatterChart.tsx` that switches the Y-axis from "Absolute Value" to "Historical Rank Percentile".
+
+---
+
+Recommended implementation order: Proposal 4 first (correlation insight), then 5 (systemic insight), then 7, then 8, then 6.

--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useCallback, ElementRef } from 'react'
+import { memo, useMemo, useCallback, useState, useEffect, ElementRef } from 'react'
 import { useAtomValue } from 'jotai'
 import { dataMapAtom } from '../atom/dataAtom'
 import { ChartProvider, ChartContext } from '@echarts-readymade/core'
@@ -159,9 +159,14 @@ export default memo(({ keys }: ChartProps) => {
     return result
   }, [dataMap, keys, valueList])
 
+  const [chartInstance, setChartInstance] = useState<echarts.ECharts | null>(null)
+
   const handleRef = useCallback((node: ElementRef<typeof Line> | null) => {
-    const instance = node?.getEchartsInstance();
-    if (instance && !instance.isDisposed()) {
+    setChartInstance(node?.getEchartsInstance() || null)
+  }, [])
+
+  useEffect(() => {
+    if (chartInstance && !chartInstance.isDisposed()) {
       const len = keys.length
       const series: LineSeriesOption[] = []
       for (let i = 0; i < len; i++) {
@@ -170,7 +175,7 @@ export default memo(({ keys }: ChartProps) => {
           connectNulls: false,
         })
       }
-      instance.setOption(
+      chartInstance.setOption(
         {
           yAxis,
           grid: {
@@ -184,7 +189,7 @@ export default memo(({ keys }: ChartProps) => {
         { replaceMerge: ['series', 'yAxis'] },
       )
     }
-  }, [keys, yAxis])
+  }, [keys, yAxis, chartInstance])
 
   return (
     <ChartProvider data={chartData} echartsOptions={echartsOptions}>


### PR DESCRIPTION
**The Issue:**
In `src/layout/Chart.tsx` (lines ~162-187), the `useEffect`-like behavior of the ECharts configuration update relied on a `useCallback` reacting to prop changes. However, callback refs in React only fire on mount and unmount. This meant that when the `keys` or `yAxis` properties changed, the `setOption` callback didn't fire again, leaving the chart with stale axes.

**Discovery Signal:**
Scan 5: useEffect Dependency Correctness (Chart.tsx) triggered this fix, highlighting that the axes were becoming stale and not updating when the user switched biomarker selections.

**The Fix:**
Decoupled the instance capture from the reactive updates. The `ECharts` instance is now captured in a React state (`useState`) via the callback ref. A separate `useEffect` hook depends on `keys`, `yAxis`, and the `chartInstance` state to dynamically call `chartInstance.setOption(...)` whenever the selected markers change.

**The Benefit:**
Multi-axis line charts now accurately update their Y-axis scales, names, and series lines immediately when users select different biomarkers, fixing silent rendering failures.

*(Additionally, appended 5 new, codebase-grounded data visualization proposals to `proposals.md`.)*

---
*PR created automatically by Jules for task [278328919019508326](https://jules.google.com/task/278328919019508326) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale axes and series updates in `src/layout/Chart.tsx` so charts react correctly when biomarker selections change. Also adds five new data visualization proposals to `proposals.md`.

- **Bug Fixes**
  - Store the ECharts instance in React state via the callback ref.
  - Add a `useEffect` that depends on `keys`, `yAxis`, and the instance to call `setOption` with `replaceMerge: ['series', 'yAxis']`.
  - Replaces the non-reactive callback-ref update path, preventing axes from staying stale on re-render.

<sup>Written for commit 273fe9591577aa551a89868d18dd908cf2c2e951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

