### PR TITLE
🎨 Palette: Add row selection checkboxes to Table

### DIFF
--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -356,6 +356,16 @@ const columns: ColumnDef<DisplayedEntry, any>[] = [
         title="Select all rows"
       />
     ),
+    cell: ({ row }) => (
+      <input
+        type="checkbox"
+        className="w-4 h-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
+        checked={row.getIsSelected()}
+        onChange={row.getToggleSelectedHandler()}
+        aria-label={`Select row ${row.original?.name || ''}`}
+        title={`Select row ${row.original?.name || ''}`}
+      />
+    ),
   }),
   columnHelper.display({
     id: 'expand',


### PR DESCRIPTION
**The Issue:** The main data table only had a "Select All" checkbox in the header. While the row objects supported selection state (`row.getIsSelected()`), the user interface lacked a way to toggle individual rows visually.
**Discovery Signal:** Identified via UX exploration as missing interactivity that would benefit from TanStack Table's existing selection state capabilities.
**The Fix:** Added a `cell` property to the `selection` column definition in `src/layout/Table.tsx`. This cell renders a checkbox that connects to `row.getIsSelected()` and `row.getToggleSelectedHandler()`, styled to match the header and including an `aria-label` for screen reader accessibility.
**The Benefit:** Significant improvement to macro interactions. Users can now cherry-pick specific rows for bulk actions or calculations, making the data table far more intuitive and accessible.

---
*PR created automatically by Jules for task [5566808310347082352](https://jules.google.com/task/5566808310347082352) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add row-level selection checkboxes to the Table so users can select individual rows, not just use “Select all”. Each checkbox is wired to `row.getIsSelected()`/`row.getToggleSelectedHandler()` and includes ARIA labels and visible focus styles for accessibility.

<sup>Written for commit a9dc212cdd6ca6b0e8e2ff519699371869a461f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

