### PR TITLE
fix: resolve oxlint violation by refactoring state sync in GistViewer

### DIFF
--- a/src/layout/GistViewer.tsx
+++ b/src/layout/GistViewer.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react'
+import React, { Fragment, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import {
   XMarkIcon,
@@ -17,15 +17,6 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
   const [selectedFile, setSelectedFile] = useState<GistFile | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (isOpen) {
-      loadFiles()
-    } else {
-      // Reset state when closed
-      setSelectedFile(null)
-    }
-  }, [isOpen])
 
   const getTimestamp = (filename: string): number => {
     const match = filename.match(/^(?:biomarker_)?.*_(\d+)\.md$/)
@@ -88,7 +79,13 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
   }
 
   return (
-    <Transition appear show={isOpen} as={Fragment}>
+    <Transition
+      appear
+      show={isOpen}
+      as={Fragment}
+      beforeEnter={loadFiles}
+      afterLeave={() => setSelectedFile(null)}
+    >
       <Dialog as="div" className="relative z-50" onClose={onClose}>
         <Transition.Child
           as={Fragment}


### PR DESCRIPTION
**The Issue:**
`src/layout/GistViewer.tsx` (lines 21-28) contained a structural anti-pattern where a `useEffect` hook was used to passively synchronize internal state (`isLoading`, `selectedFile`) based on changes to the `isOpen` prop. 

**The Discovery Signal:**
Scan B: Running `npx oxlint src/` yielded two priority warnings on `src/layout/GistViewer.tsx` for the `react-you-might-not-need-an-effect(no-adjust-state-on-prop-change)` rule, flagging that we were improperly adjusting state when a prop changed instead of using an event-driven approach.

**The Fix:**
I completely removed the offending `useEffect` and its `eslint` import. I instead bound the `loadFiles` function directly to the `<Transition>` component's `beforeEnter` hook to fetch data natively as the modal opens, and bound `setSelectedFile(null)` to the `afterLeave` hook to securely reset the active file when the modal fully finishes animating closed.

**The Benefit:**
Eliminates two active `oxlint` warnings (cleaner static analysis), removes an unnecessary render cycle caused by state chaining in a `useEffect`, and aligns the component with cleaner Headless UI lifecycle paradigms without changing any UI behaviors.

---
*PR created automatically by Jules for task [13713227016830231391](https://jules.google.com/task/13713227016830231391) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors GistViewer to use `@headlessui/react` `<Transition>` lifecycle instead of effect-based state sync, fixing the oxlint no-adjust-state-on-prop-change warning without changing behavior. Data loads on open; the selected file resets after close.

- **Refactors**
  - Removed `useEffect` that synced state on `isOpen` changes.
  - Load files via `<Transition beforeEnter>`; reset `selectedFile` via `<Transition afterLeave>`.
  - Eliminates two `oxlint` warnings and avoids an extra render.

<sup>Written for commit 8bbca3b47e8a41ec741a9bb2fdaa8e0f0ce12784. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

