### PR TITLE
Fix GistViewer oxlint violation

### DIFF
--- a/src/layout/GistViewer.tsx
+++ b/src/layout/GistViewer.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react'
+import React, { Fragment, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import {
   XMarkIcon,
@@ -17,15 +17,6 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
   const [selectedFile, setSelectedFile] = useState<GistFile | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (isOpen) {
-      loadFiles()
-    } else {
-      // Reset state when closed
-      setSelectedFile(null)
-    }
-  }, [isOpen])
 
   const getTimestamp = (filename: string): number => {
     const match = filename.match(/^(?:biomarker_)?.*_(\d+)\.md$/)
@@ -88,7 +79,7 @@ export default function GistViewer({ isOpen, onClose }: GistViewerProps) {
   }
 
   return (
-    <Transition appear show={isOpen} as={Fragment}>
+    <Transition appear show={isOpen} as={Fragment} beforeEnter={() => loadFiles()} afterLeave={() => setSelectedFile(null)}>
       <Dialog as="div" className="relative z-50" onClose={onClose}>
         <Transition.Child
           as={Fragment}


### PR DESCRIPTION
**The Issue:**
`src/layout/GistViewer.tsx` lines 22-26. The component used a `useEffect` hook to synchronize its local state (`selectedFile`) and trigger data fetching (`loadFiles`) based on changes to the `isOpen` prop. This violates the `react-you-might-not-need-an-effect(no-adjust-state-on-prop-change)` rule, which is a structural anti-pattern that can lead to cascading re-renders and subtle timing bugs.

**The Discovery Signal:**
Scan B (oxlint Violations) — The `oxlint` rule `react-you-might-not-need-an-effect(no-adjust-state-on-prop-change)` flagged the `useEffect` block inside `GistViewer`.

**The Fix:**
- Removed the `useEffect` block that monitored `isOpen`.
- Replaced the synchronization logic by binding directly to the Headless UI `<Transition>` component's native lifecycle callbacks. Attached `beforeEnter={() => loadFiles()}` to handle data fetching when opening, and `afterLeave={() => setSelectedFile(null)}` to reset state when fully closed.
- Removed the unused `useEffect` import from React.

**The Benefit:**
Resolves an active linting error, eliminates unnecessary React render cycles caused by state synchronization, and improves the UX slightly by delaying the state teardown until after the closing animation has completed (preventing a visual pop).

---
*PR created automatically by Jules for task [15717492758519751699](https://jules.google.com/task/15717492758519751699) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an `oxlint` violation in GistViewer by removing prop-to-state syncing and using `@headlessui/react` Transition callbacks. Reduces unnecessary re-renders and smooths the close animation.

- **Refactors**
  - Removed the `useEffect` that synced `isOpen` to local state.
  - Moved logic to `<Transition>`: `beforeEnter={() => loadFiles()}` and `afterLeave={() => setSelectedFile(null)}`.
  - Removed unused `useEffect` import; clears `react-you-might-not-need-an-effect(no-adjust-state-on-prop-change)`.

<sup>Written for commit a6eb140d25cae958ce84c5c8404793920c1fcfea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

