### PR TITLE
Chart Engineer: Add Chart2 empty state fallback and visualization proposals

### DIFF
--- a/proposals.md
+++ b/proposals.md
@@ -252,3 +252,64 @@ Automatically generated when a user clicks on a highly correlated node in the `B
 ---
 
 
+
+**Proposal: Biomarker Volatility vs. Age Area Scatter Plot**
+
+**ECharts type:** `scatter` (Area scatter with size/color variation)
+
+**Codebase citation:**
+Uses `dataAtom` from `src/atom/dataAtom.ts` and date indices inferred from `labels` in `src/data/index.ts`.
+
+**Which existing data it uses:**
+It calculates the variance or standard deviation (volatility) of each valid biomarker in `dataAtom` over its available time points. It plots each biomarker as a bubble, where the X-axis is the total timeline span (e.g., number of years measured), and the Y-axis is the volatility score.
+
+**What it reveals that current charts don't:**
+Identifies which biomarkers fluctuate wildly compared to those that remain stable throughout a patient's measurement history. The current multi-axis line chart shows absolute values but makes it hard to compare normalized stability across different scales simultaneously.
+
+**Where it would live:**
+New `src/layout/VolatilityScatter.tsx`.
+
+**Trigger / entry point:**
+Triggered via a "Volatility Analysis" toggle in the main Dashboard next to the tag filters.
+
+---
+
+**Proposal: Cross-System Correlation Force Graph**
+
+**ECharts type:** `graph` (Force Directed)
+
+**Codebase citation:**
+Uses `correlationAlphaAtom` from `src/atom/correlationAtom.ts` and `extra.tag` from `src/processors/post/tag.ts`.
+
+**Which existing data it uses:**
+It calculates the pairwise correlation between the *aggregated average percent-to-optimal* scores for each tag group (e.g., aggregating all `1-RBC` markers vs all `3-Liver` markers) using the methods in `correlationAtom`.
+
+**What it reveals that current charts don't:**
+The existing correlation tools map individual biomarkers to each other or to supplements. This graph maps *entire physiological systems* against each other to reveal macro-level cascades (e.g., proving that liver stress strongly correlates with lipid metabolism degradation in this specific user's history).
+
+**Where it would live:**
+New `src/layout/SystemCorrelationGraph.tsx` alongside `BiomarkerCorrelationGraph.tsx`.
+
+**Trigger / entry point:**
+Available as a specific "System Level" toggle inside the global Correlation modal.
+
+---
+
+**Proposal: Out-of-Range Duration Gantt Chart**
+
+**ECharts type:** `custom` (Gantt Chart style)
+
+**Codebase citation:**
+Uses `extra.optimality[]` from `src/processors/post/range.ts` matched against `labels` from `src/data/index.ts`.
+
+**Which existing data it uses:**
+It processes `dataAtom` and identifies continuous streaks where `extra.optimality` is `true`. It maps these periods into horizontal duration bars for each biomarker.
+
+**What it reveals that current charts don't:**
+Instead of showing discrete points where a biomarker was out of range, it emphasizes the *continuous duration* of chronic issues. A single bad reading might be noise, but a Gantt chart instantly highlights which biomarker has been out of optimal bounds continuously for the longest period of time.
+
+**Where it would live:**
+New `src/layout/ChronicDurationGantt.tsx`.
+
+**Trigger / entry point:**
+A "Chronic Risk View" button above the main data table that replaces the table view with a horizontal duration chart.

--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -160,10 +160,10 @@ export default memo(({ keys }: ChartProps) => {
           mappedData.push([v0, v1, formattedDate, unitX, unitY])
         }
       }
-      return { data: mappedData }
+      return mappedData
     }
 
-    return { data: [] }
+    return []
   }, [dataMap, keys])
 
   const options: any = useMemo(() => {
@@ -175,15 +175,15 @@ export default memo(({ keys }: ChartProps) => {
     const dataset: DatasetComponentOption[] = [
       {
         dimensions: [keys[0], keys[1], 'Date', 'unitX', 'unitY'],
-        source: mappedScatterData.data,
+        source: mappedScatterData,
       },
     ]
 
     let regressionExpression = ''
 
     // Guard against regression transform crash on <2 points
-    if (mappedScatterData.data.length >= 2) {
-      const regRes = (ecStat as any).regression('linear', mappedScatterData.data)
+    if (mappedScatterData.length >= 2) {
+      const regRes = (ecStat as any).regression('linear', mappedScatterData)
       regressionExpression = regRes.expression
 
       dataset.push({
@@ -198,7 +198,7 @@ export default memo(({ keys }: ChartProps) => {
     const nextSeries = [
       series[0],
       // Only include the regression series if dataset contains it
-      ...(mappedScatterData.data.length >= 2
+      ...(mappedScatterData.length >= 2
         ? [
             {
               ...series[1],
@@ -256,6 +256,14 @@ export default memo(({ keys }: ChartProps) => {
   }, [mappedScatterData, keys])
 
   // console.log("ch2", options.series[0].data, options.series[1].data);
+
+  if (mappedScatterData.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-[400px] w-full text-gray-500 italic border border-dashed border-[#3a3a3a80] rounded-lg">
+        Not enough overlapping data points to render correlation.
+      </div>
+    )
+  }
 
   return (
     <div>


### PR DESCRIPTION
**The Issue:**
If the selected biomarkers in `Chart2.tsx` lack overlapping valid measurements, the `mappedScatterData` becomes empty, resulting in a blank canvas without user feedback.
**Discovery Signal:**
Scan 6 (Edge Cases and Guards) identified that `Chart2.tsx` lacked an informative fallback state when `mappedScatterData` is empty. 
**The Fix:**
Refactored `mappedScatterData` to directly return the array (rather than an object wrapping the array). Implemented a conditional early return that displays an informative, styled empty state `div` when `mappedScatterData.length === 0`. Additionally, 3 new data visualization proposals anchored to the codebase were appended to `proposals.md`.
**The Benefit:**
Users receive clear visual feedback when selected correlations lack sufficient overlapping data, improving UX and resolving the silent blank canvas rendering issue.

---
*PR created automatically by Jules for task [7694034083558067574](https://jules.google.com/task/7694034083558067574) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an empty state to `Chart2` when selected biomarkers have no overlapping measurements, fixing the blank chart. Also switches scatter data to a plain array and adds three visualization proposals.

- **Bug Fixes**
  - Show a styled empty state when `mappedScatterData.length === 0` in `src/layout/Chart2.tsx`.
  - Run regression only when there are 2+ points to avoid transform errors.

- **Refactors**
  - Return `mappedScatterData` as a native array and update dataset/regression callers accordingly.
  - Append three chart proposals to `proposals.md` with codebase references.

<sup>Written for commit 4d131810b7dad8dfa78fac7c0983b64386c53ad6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

