### PR TITLE
Code Quality: Fix weak type annotation in Chart2

### DIFF
--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -166,7 +166,7 @@ export default memo(({ keys }: ChartProps) => {
     return []
   }, [dataMap, keys])
 
-  const options: any = useMemo(() => {
+  const options: EChartsOption = useMemo(() => {
     const { series, yAxis, xAxis } = echartsOptions
 
     const nextXAxis = [{ ...xAxis[0], name: keys[0] }, ...xAxis.slice(1)]


### PR DESCRIPTION
**The Issue:**
`src/layout/Chart2.tsx` line 169 — A weak type annotation (`const options: any = useMemo`) was used for the main ECharts configuration object. This breaks strict typing for the chart options and masks potential configuration errors.

**The Discovery Signal:**
Scan C (Weak or Missing Type Annotations) revealed an explicit `any` annotation in `src/layout/Chart2.tsx` line 169 for the `options` variable.

**The Fix:**
Replaced `const options: any` with `const options: EChartsOption` in `src/layout/Chart2.tsx`. The `EChartsOption` type was already imported from `echarts-for-react` on line 11 (`import type { EChartsOption } from 'echarts-for-react'`), making this a safe and exact substitution without requiring new imports.

**The Benefit:**
Enforces strict type checking for the ECharts configuration object, preventing runtime errors caused by invalid chart options, and eliminates a weak typing pattern from the codebase, satisfying the quality gates (`tsc --noEmit --strict` and `oxlint`).

---
*PR created automatically by Jules for task [16417391197602572400](https://jules.google.com/task/16417391197602572400) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the weak `any` annotation with `EChartsOption` for the `options` object in `src/layout/Chart2.tsx` to enforce strict typing and catch invalid chart configs. No behavior changes; improves type safety and satisfies strict TypeScript checks.

<sup>Written for commit e6838c22ba5a72cbdc4542756b43c5bed49c37be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

