### PR TITLE
🎨 Palette: Fix ECharts 6 Deprecations and Visualization Advisory

### DIFF
--- a/proposals.md
+++ b/proposals.md
@@ -166,3 +166,64 @@ New `src/layout/ChronicDurationGantt.tsx`.
 
 **Trigger / entry point:**
 A "Chronic Risk View" button above the main data table that replaces the table view with a horizontal duration chart.
+
+**Proposal: Optimality Recovery Time Distribution Bar**
+
+**ECharts type:** `bar`
+
+**Codebase citation:**
+Uses `extra.optimality[]` from `src/processors/post/range.ts` matched against `labels` from `src/data/index.ts`.
+
+**Which existing data it uses:**
+It processes `dataAtom` to find streaks where a biomarker goes out-of-range (`optimality[i] === true`) and measures the number of days (calculated from `labels`) until it returns to normal (`optimality[i] === false`).
+
+**What it reveals that current charts don't:**
+Highlights how quickly the user's body corrects imbalances. Instead of showing simply if a marker was out of bounds, it visualizes the *recovery speed*, helping identify systems losing their resilience over time (e.g., if recovery time for Glucose spikes is gradually lengthening).
+
+**Where it would live:**
+New `src/layout/RecoveryTimeBar.tsx`.
+
+**Trigger / entry point:**
+A "Resilience Analysis" button inside the individual biomarker view.
+
+---
+
+**Proposal: Historical Testing Interval Histogram**
+
+**ECharts type:** `bar` (histogram using `echarts-stat` transform)
+
+**Codebase citation:**
+Analyzes the `values` arrays of `BioMarker` tuples within `dataAtom` alongside the global `labels` array from `src/data/index.ts`.
+
+**Which existing data it uses:**
+For each biomarker, it iterates through `values` and calculates the time gap (in days or months derived from `labels`) between each non-null measurement (`values[i] !== null && values[i] !== undefined`). It then plots a histogram of these intervals.
+
+**What it reveals that current charts don't:**
+Visualizes the user's testing consistency for each biomarker. It can expose erratic testing behaviors, such as measuring Vitamin D frequently in summer but leaving large gaps in winter, which the standard time-series line chart masks due to `connectNulls: false`.
+
+**Where it would live:**
+New `src/layout/TestingIntervalHistogram.tsx`.
+
+**Trigger / entry point:**
+An "Audit Continuity" button within the main dashboard or table view.
+
+---
+
+**Proposal: Biomarker Normality Q-Q Scatter Plot**
+
+**ECharts type:** `scatter` (Q-Q plot format)
+
+**Codebase citation:**
+Utilizes `values` from `dataAtom` and standard statistical transformations.
+
+**Which existing data it uses:**
+It takes the valid numeric `values` for a single biomarker from `dataAtom` and calculates their theoretical quantiles against a normal distribution. It plots the empirical quantiles against these theoretical quantiles.
+
+**What it reveals that current charts don't:**
+The existing Boxplot and Histogram charts show basic distribution, but a Q-Q plot specifically highlights whether the data follows a normal distribution or has heavy tails/skewness. This is crucial for biomarkers where deviations from a normal distribution might indicate underlying chronic issues rather than random variation.
+
+**Where it would live:**
+New `src/layout/QQPlot.tsx` alongside the existing statistical charts like `BoxplotChart.tsx`.
+
+**Trigger / entry point:**
+Available as an advanced statistical view toggle within the table row expansion alongside the Histogram and Boxplot.

--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -104,7 +104,7 @@ const echartsOptions: EChartsOption = {
     {
       type: 'line',
       symbol: 'circle',
-      zIndex: -1,
+      zlevel: -1,
       showSymbol: false,
       lineStyle: {
         color: '#5470C688',
@@ -113,17 +113,13 @@ const echartsOptions: EChartsOption = {
       legendHoverLink: true,
       markPoint: {
         itemStyle: {
-          normal: {
-            color: 'transparent',
-          },
+          color: 'transparent',
         },
         label: {
-          normal: {
-            show: true,
-            textStyle: {
-              color: '#f0f0f0',
-              fontSize: 14,
-            },
+          show: true,
+          textStyle: {
+            color: '#f0f0f0',
+            fontSize: 14,
           },
         },
       },


### PR DESCRIPTION
**The Issue:**
In `src/layout/Chart2.tsx` lines 107-123, the `echartsOptions` configuration object uses deprecated ECharts 4 property structures (`zIndex` instead of `zlevel`, and deeply nested `normal` style wrappers for `markPoint.itemStyle` and `markPoint.label`). Modern strict typescript checking flags these as potential schema violations which may be dropped in future major updates.

**Discovery Signal:**
Scan 7 (Visual Consistency / Type Safety) identified the legacy structures which violated the ECharts 5/6 API definitions.

**The Fix:**
Updated `Chart2.tsx` to use `zlevel: -1` and directly assigned `color` and `show` properties to `itemStyle` and `label` without the `normal` wrapper. Additionally, appended three well-grounded visualization proposals to `proposals.md` per the advisory mandate.

**The Benefit:**
Ensures forward-compatibility with ECharts 6 strict schema, preventing silent rendering fallbacks, and formally logs 3 actionable chart concepts for the engineering roadmap.

---
*PR created automatically by Jules for task [6437302268960070147](https://jules.google.com/task/6437302268960070147) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `echarts` config with v6 by replacing deprecated fields in `Chart2.tsx` to avoid schema violations and silent fallbacks. Also adds three visualization proposals to `proposals.md` for future chart work.

- **Bug Fixes**
  - Replaced `zIndex` with `zlevel: -1` in the line series.
  - Removed `normal` wrappers in `markPoint.itemStyle` and `markPoint.label`; moved `color`, `show`, and `textStyle` to the root of each object.

<sup>Written for commit 50246d7b6a1b3d455af6db8c6c81549354947412. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

