### PR TITLE
Chart Engineer: Fix Chart2 ECharts API type safety and append visualization proposals

### DIFF
--- a/proposals.md
+++ b/proposals.md
@@ -166,3 +166,66 @@ New `src/layout/ChronicDurationGantt.tsx`.
 
 **Trigger / entry point:**
 A "Chronic Risk View" button above the main data table that replaces the table view with a horizontal duration chart.
+
+---
+
+**Proposal: Tag-Level Range Velocity Bar Chart**
+
+**ECharts type:** `bar`
+
+**Codebase citation:**
+Uses `extra.tag` from `src/processors/post/tag.ts` and `extra.range` boundaries applied to `BioMarker[1]` from `src/atom/dataAtom.ts`.
+
+**Which existing data it uses:**
+Aggregates `BioMarker` values by their associated `extra.tag` strings. For each tag group, it calculates the average normalized rate of change (e.g., slope) from the first to the last available time point (`labels`), using the `extra.range` boundaries to normalize differing units into a common scale.
+
+**What it reveals that current charts don't:**
+Instantly highlights which overall physiological systems (e.g., Kidney, Liver) are improving or degrading the fastest longitudinally, rather than just showing absolute values of individual markers.
+
+**Where it would live:**
+New `src/layout/TagVelocityBarChart.tsx`, embedded within a "System Health Trajectory" summary view.
+
+**Trigger / entry point:**
+A standalone component rendered at the top of the dashboard summarizing longitudinal systemic progression.
+
+---
+
+**Proposal: Optimality Survival Step Chart**
+
+**ECharts type:** `line` (with `step: 'end'`)
+
+**Codebase citation:**
+Relies on `extra.optimality[]` from `src/processors/post/range.ts` aligned with time `labels` from `src/data/index.ts`.
+
+**Which existing data it uses:**
+Iterates through `dataAtom` to track the first date each biomarker transitioned into an out-of-range state (`extra.optimality[i] === true`). It plots a declining step function starting at 100% representing the proportion of biomarkers that have *never* breached their optimal range over time.
+
+**What it reveals that current charts don't:**
+Provides a macroscopic "health span" indicator. Instead of viewing daily fluctuations, it shows the systemic accumulation of clinical abnormalities, indicating whether a user's health is remaining stable or cascading into multiple out-of-range markers simultaneously.
+
+**Where it would live:**
+New `src/layout/OptimalitySurvivalChart.tsx`.
+
+**Trigger / entry point:**
+An "Overall Health Span" dashboard widget that provides a high-level summary before jumping into specific biomarker graphs.
+
+---
+
+**Proposal: Keystones Biomarker Centrality Scatter Plot**
+
+**ECharts type:** `scatter`
+
+**Codebase citation:**
+Uses `correlationMethodAtom` from `src/atom/correlationAtom.ts` and `extra.optimality[]` from `src/processors/post/range.ts`.
+
+**Which existing data it uses:**
+For every biomarker in `dataAtom`, it computes its average absolute correlation coefficient with all other biomarkers. It plots each biomarker where the X-axis is this average correlation (centrality) and the Y-axis is the historical out-of-range frequency (derived by counting `true` values in `extra.optimality[]`).
+
+**What it reveals that current charts don't:**
+Identifies "keystone" vulnerabilities—biomarkers that are both highly volatile/abnormal *and* strongly coupled to the rest of the systemic network. Prioritizing interventions on these specific markers could yield the highest cascading health benefits.
+
+**Where it would live:**
+New `src/layout/KeystoneCentralityScatter.tsx` accessed via the correlation tools.
+
+**Trigger / entry point:**
+A "Prioritization View" toggle within the Correlation modal.

--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -99,12 +99,12 @@ const echartsOptions: EChartsOption = {
       symbolSize: 40,
       legendHoverLink: true,
       large: false,
-      zIndex: 2,
+      z: 2,
     },
     {
       type: 'line',
       symbol: 'circle',
-      zIndex: -1,
+      z: -1,
       showSymbol: false,
       lineStyle: {
         color: '#5470C688',
@@ -113,17 +113,13 @@ const echartsOptions: EChartsOption = {
       legendHoverLink: true,
       markPoint: {
         itemStyle: {
-          normal: {
-            color: 'transparent',
-          },
+          color: 'transparent',
         },
         label: {
-          normal: {
-            show: true,
-            textStyle: {
-              color: '#f0f0f0',
-              fontSize: 14,
-            },
+          show: true,
+          textStyle: {
+            color: '#f0f0f0',
+            fontSize: 14,
           },
         },
       },


### PR DESCRIPTION
**The Issue:**
In `src/layout/Chart2.tsx` (lines 99-130), the `echartsOptions` configuration object uses deprecated ECharts v4 properties. Specifically, it uses `zIndex` instead of `z` for stacking order, and nested `normal` blocks within `markPoint.itemStyle` and `markPoint.label`. While this didn't crash the chart, it violates strict type safety with `EChartsOption` and is not standard in ECharts 6.

**Discovery Signal:**
Scan 7 — Visual Consistency & Type Safety Review (Chart2.tsx deprecated ECharts option structures)

**The Fix:**
- Replaced `zIndex: 2` with `z: 2` in the `scatter` series.
- Replaced `zIndex: -1` with `z: -1` in the `line` series.
- Removed the deprecated `normal` wrapper object inside `markPoint.itemStyle` and `markPoint.label`, lifting `color`, `show`, and `textStyle` to the parent level.
- Appended 3 novel visualization ideas to `proposals.md` that are grounded in the codebase and not previously proposed (Tag-Level Range Velocity Bar Chart, Optimality Survival Step Chart, Keystones Biomarker Centrality Scatter Plot).

**The Benefit:**
Ensures forward-compatibility with ECharts 6 and resolves hidden strict TS type violations without introducing visual regressions. Provides new health-specific visualization concepts for future development.

---
*PR created automatically by Jules for task [7313636224666018118](https://jules.google.com/task/7313636224666018118) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Chart2 with ECharts v6 and `EChartsOption` types: changed `zIndex` -> `z` in the scatter series and `zlevel` -> `z` in the line series. Added three visualization proposals to `proposals.md` (Tag-Level Range Velocity Bar, Optimality Survival Step, Keystone Centrality Scatter).

<sup>Written for commit 609f1af3ffe8762715adc9ff9446993491d5eb4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

