### PR TITLE
Chart Engineer: Correlation Significance vs Effect Size Volcano Plot

### DIFF
--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -13,6 +13,7 @@ import { CorrelationProps } from './Correlation.types'
 import { CORRELATION_EXCLUDED_BIOMARKERS } from '../config/correlations'
 
 import FocusedCorrelationChart from './FocusedCorrelationChart'
+import CorrelationVolcanoPlot from './CorrelationVolcanoPlot'
 
 export default React.memo(({ target, onClose }: CorrelationProps) => {
   const data = useAtomValue(nonInferredDataAtom)
@@ -22,7 +23,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
   const [alternative, setAlternative] = useAtom(correlationAlternativeAtom)
   const [method, setMethod] = useAtom(correlationMethodAtom)
   const [isCopied, setIsCopied] = React.useState(false)
-  const [activeTab, setActiveTab] = React.useState<'chart' | 'table'>('chart')
+  const [activeTab, setActiveTab] = React.useState<'chart' | 'significance' | 'table'>('chart')
 
   const entries = React.useMemo(() => {
     if (!Array.isArray(data) || !target) {
@@ -97,9 +98,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
         if (count < 4) continue
 
         const result = calculatePearson(x.subarray(0, count), y.subarray(0, count), options)
-        if (result.pValue <= alpha) {
-          entries.push([item[0], result.statistic, result.pValue, result.pcorr])
-        }
+        entries.push([item[0], result.statistic, result.pValue, result.pcorr])
       }
     } else {
       // Spearman (existing optimization)
@@ -119,9 +118,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
         if (!targetRanks) continue
 
         const result = calculateSpearmanRanked(sourceRanks, targetRanks, options)
-        if (result.pValue <= alpha) {
-          entries.push([item[0], result.statistic, result.pValue, result.pcorr])
-        }
+        entries.push([item[0], result.statistic, result.pValue, result.pcorr])
       }
     }
 
@@ -129,6 +126,10 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
 
     return entries
   }, [data, dataMap, target, alpha, alternative, rankedDataMap, method])
+
+  const significantEntries = React.useMemo(() => {
+    return entries ? entries.filter(e => e[2] <= alpha) : []
+  }, [entries, alpha])
 
   return (
     <Transition appear show={!!target} as={Fragment}>
@@ -165,12 +166,12 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                           Correlation Analysis: <span className="text-blue-400">{target}</span>
                         </Dialog.Title>
                         <div className="ml-3 flex items-center gap-2 shrink-0">
-                          {entries && entries.length > 0 && (
+                          {significantEntries.length > 0 && (
                             <button
                               type="button"
                               onClick={() => {
                                 const header = 'Biomarker\tP-Value\tCoeff\n'
-                                const rows = entries
+                                const rows = significantEntries
                                   .map(
                                     (entry) =>
                                       `${entry[0]}\t${entry[2].toFixed(6)}\t${entry[3].toFixed(4)}`,
@@ -286,6 +287,18 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                         </button>
                         <button
                           type="button"
+                          aria-pressed={activeTab === 'significance'}
+                          className={`w-full rounded-lg py-2.5 text-sm font-medium leading-5 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors ${
+                            activeTab === 'significance'
+                              ? 'bg-blue-600/80 text-white shadow'
+                              : 'text-gray-400 hover:bg-white/10 hover:text-white'
+                          }`}
+                          onClick={() => setActiveTab('significance')}
+                        >
+                          Significance View
+                        </button>
+                        <button
+                          type="button"
                           aria-pressed={activeTab === 'table'}
                           className={`w-full rounded-lg py-2.5 text-sm font-medium leading-5 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors ${
                             activeTab === 'table'
@@ -298,9 +311,15 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                         </button>
                       </div>
 
-                      {activeTab === 'chart' && entries && entries.length > 0 && (
+                      {activeTab === 'chart' && significantEntries.length > 0 && (
                         <div className="mb-8">
-                          <FocusedCorrelationChart correlations={entries} alpha={alpha} />
+                          <FocusedCorrelationChart correlations={significantEntries} alpha={alpha} />
+                        </div>
+                      )}
+
+                      {activeTab === 'significance' && entries && entries.length > 0 && (
+                        <div className="mb-8">
+                          <CorrelationVolcanoPlot correlations={entries} alpha={alpha} />
                         </div>
                       )}
 
@@ -329,8 +348,8 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
                             </tr>
                           </thead>
                           <tbody className="divide-y divide-gray-800">
-                            {entries && entries.length > 0 ? (
-                              entries.map((entry) => (
+                            {significantEntries.length > 0 ? (
+                              significantEntries.map((entry) => (
                                 <tr key={entry[0]} className="hover:bg-white/5 transition-colors">
                                   <td
                                     className="py-2 px-1 text-sm text-gray-200 truncate max-w-[200px]"

--- a/src/layout/CorrelationVolcanoPlot.tsx
+++ b/src/layout/CorrelationVolcanoPlot.tsx
@@ -1,0 +1,97 @@
+import { memo, useMemo } from 'react'
+import ReactECharts from 'echarts-for-react'
+import { CHART_PALETTE } from './Chart2'
+import type { EChartsOption } from 'echarts'
+
+interface CorrelationVolcanoPlotProps {
+  correlations: Array<[string, number, number, number]> // name, N, pValue, coeff
+  alpha: number
+}
+
+export default memo(({ correlations, alpha }: CorrelationVolcanoPlotProps) => {
+  const options = useMemo<EChartsOption>(() => {
+    const data = correlations.map((c) => {
+      const name = c[0]
+      const pValue = c[2]
+      const coeff = c[3]
+      const logPValue = pValue === 0 ? 10 : -Math.log10(pValue) // cap to avoid Infinity if exact 0
+
+      let color = '#888888' // Default Gray for insignificant
+
+      if (pValue <= alpha) {
+        if (coeff > 0) {
+          color = CHART_PALETTE[7] // Blue for positive significant
+        } else if (coeff < 0) {
+          color = CHART_PALETTE[0] // Red for negative significant
+        }
+      }
+
+      return {
+        value: [coeff, logPValue, pValue, name],
+        itemStyle: { color }
+      }
+    })
+
+    const alphaThreshold = -Math.log10(alpha)
+
+    return {
+      style: { height: 400, width: '100%' },
+      theme: 'dark',
+      backgroundColor: 'transparent',
+      grid: {
+        left: '5%',
+        right: '5%',
+        bottom: '10%',
+        top: '10%',
+        containLabel: true,
+      },
+      tooltip: {
+        trigger: 'item',
+        formatter: (params: any) => {
+          const p = params.data.value
+          return `${p[3]}<br/>Correlation: <strong>${p[0].toFixed(4)}</strong><br/>P-Value: <strong>${p[2].toExponential(2)}</strong>`
+        },
+      },
+      xAxis: {
+        name: 'Correlation Coefficient (Effect Size)',
+        nameLocation: 'middle',
+        nameGap: 30,
+        type: 'value',
+        min: -1,
+        max: 1,
+        splitLine: {
+          lineStyle: { color: '#333', type: 'dashed' },
+        },
+      },
+      yAxis: {
+        name: '-log10(p-value) (Significance)',
+        nameLocation: 'middle',
+        nameGap: 40,
+        type: 'value',
+        splitLine: {
+          lineStyle: { color: '#333', type: 'dashed' },
+        },
+      },
+      series: [
+        {
+          type: 'scatter',
+          data: data,
+          symbolSize: 8,
+          markLine: {
+            silent: true,
+            lineStyle: { type: 'dashed', color: '#ccc' },
+            data: [
+              { xAxis: 0, label: { formatter: ' ' } },
+              { yAxis: alphaThreshold, label: { formatter: `alpha=${alpha}` } },
+            ],
+          },
+        },
+      ],
+    } as any // cast because style and theme are passed to ReactECharts, strict EChartsOption doesn't have style
+  }, [correlations, alpha])
+
+  if (correlations.length === 0) return null
+
+  // @ts-ignore
+  return <ReactECharts option={options} style={options.style} theme="dark" notMerge={true} />
+})


### PR DESCRIPTION
**The Issue:**
The existing correlation view only displayed significant findings (`pValue <= alpha`), which is useful for focused analysis but fails to provide a comprehensive statistical overview of all pairs. Specifically, it lacked a view that visually separates strong but noisy correlations from highly significant ones (a Volcano plot), making it harder to discern the distribution of significance versus effect size.

**Discovery Signal:**
User proposal for "Correlation Significance vs Effect Size Volcano Plot".

**The Fix:**
1. Modified the `entries` computation logic in `src/layout/Correlation.tsx` to collect *all* pairwise correlation results (both Pearson and Spearman) instead of filtering them prematurely. 
2. Retained a filtered `significantEntries` array for use in the existing "Chart View" (`FocusedCorrelationChart`), "Table View", and copy-to-clipboard functionalities to ensure they still only display significant findings as originally intended.
3. Added a new "Significance View" tab to the correlation dialog.
4. Created a new `CorrelationVolcanoPlot.tsx` component (ECharts scatter plot). It plots correlation coefficient (effect size) on the X-axis against `-log10(p-value)` (significance) on the Y-axis. The threshold line for significance is driven dynamically by `correlationAlphaAtom`, highlighting significant positive correlations in blue, significant negative correlations in red, and the rest in gray.

**The Benefit:**
A new "Significance View" is now available via a toggle, displaying a Volcano plot of all cross-correlations for a given biomarker. This gives users immediate, visual separation between strong-but-noisy correlations and highly significant ones, allowing them to better contextualize statistical patterns before diving into the details.

---
*PR created automatically by Jules for task [11759687835369447366](https://jules.google.com/task/11759687835369447366) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Significance View with a volcano plot to visualize correlation effect size vs -log10(p-value) for all pairs. Existing Chart and Table views remain limited to significant results to preserve current behavior.

- **New Features**
  - Compute all Pearson/Spearman pairs; keep a `significantEntries` subset for Chart/Table and copy.
  - Add Significance View tab with `CorrelationVolcanoPlot.tsx` (ECharts scatter).
  - X = correlation coefficient, Y = -log10(p). Dynamic alpha line from `correlationAlphaAtom`. Blue = significant positive, red = significant negative, gray = not significant.

<sup>Written for commit 3f4e57ae65e04020320a9079d31915901f7e5070. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

