### PR TITLE
refactor(types): replace weak any type with EChartsOption in SystemClustering

### DIFF
--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -3,6 +3,8 @@ import { Dialog, Transition } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import ReactECharts from 'echarts-for-react'
 import * as echarts from 'echarts'
+import type { EChartsOption } from 'echarts'
+import type { EChartsReactProps } from 'echarts-for-react'
 import * as ecStat from 'echarts-stat'
 import { useAtomValue } from 'jotai'
 import { noteValuesAtom, nonInferredDataAtom } from '../atom/dataAtom'
@@ -30,7 +32,7 @@ export const CHART_PALETTE = [
   '#2559B7',
 ]
 
-const echartsOptions: any = {
+const echartsOptions: EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'> = {
   style: { height: 600, width: '100%' },
   theme: 'dark',
   backgroundColor: 'transparent',


### PR DESCRIPTION
**The Issue:**
`src/layout/SystemClustering.tsx` line 33 used a weak `any` type (`const echartsOptions: any = {`) to define the ECharts configuration object. This bypasses TypeScript's strict structural checks for chart configurations, potentially hiding invalid properties or incompatible shapes.

**The Discovery Signal:**
Scan C: `src/layout/SystemClustering.tsx` line 33 — Weak or missing type annotation `const echartsOptions: any = {` for a complex object literal.

**The Fix:**
Imported `EChartsOption` from `echarts` and `EChartsReactProps` from `echarts-for-react`. Replaced the weak `any` type with a strict intersection type: `EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'>`.

**The Benefit:**
Eliminates a weak `any` cast, restoring strict type inference and autocomplete for the complex ECharts configuration object. Ensures that any future modifications to the chart configuration adhere strictly to the `EChartsOption` shape, preventing runtime UI regressions.

---
*PR created automatically by Jules for task [13308712458526279729](https://jules.google.com/task/13308712458526279729) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the weak `any` with a strict `EChartsOption`-based type for the System Clustering chart config to improve type safety and catch invalid options.

- **Refactors**
  - Imported `EChartsOption` from `echarts` and `EChartsReactProps` from `echarts-for-react`.
  - Typed `echartsOptions` in `src/layout/SystemClustering.tsx` as `EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'>`.

<sup>Written for commit a82d44656db32ac02b454e1ce0e8237493e0d791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

