### PR TITLE
Fix weak type in `SystemClustering.tsx`

### DIFF
--- a/src/layout/SystemClustering.tsx
+++ b/src/layout/SystemClustering.tsx
@@ -1,8 +1,9 @@
 import { memo, useMemo, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
-import ReactECharts from 'echarts-for-react'
+import ReactECharts, { EChartsReactProps } from 'echarts-for-react'
 import * as echarts from 'echarts'
+import { EChartsOption } from 'echarts'
 import * as ecStat from 'echarts-stat'
 import { useAtomValue } from 'jotai'
 import { noteValuesAtom, nonInferredDataAtom } from '../atom/dataAtom'
@@ -30,7 +31,7 @@ export const CHART_PALETTE = [
   '#2559B7',
 ]
 
-const echartsOptions: any = {
+const echartsOptions: EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'> = {
   style: { height: 600, width: '100%' },
   theme: 'dark',
   backgroundColor: 'transparent',


### PR DESCRIPTION
**The Issue:**
`src/layout/SystemClustering.tsx` lines 33-35 — the `echartsOptions` configuration object was weakly typed with an explicit `any`, masking potential type errors between React props and ECharts configuration.

**The Discovery Signal:**
Scan C: Weak or Missing Type Annotations found `const echartsOptions: any = { ... }`.

**The Fix:**
Replaced the `any` type with a strict inline intersection type (`EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'>`). Added the required imports from `echarts` and `echarts-for-react`.

**The Benefit:**
Restores type safety to the chart configuration without altering behavior, reducing the risk of invalid options being passed to ECharts or the React wrapper in future maintenance.

---
*PR created automatically by Jules for task [239859894903439407](https://jules.google.com/task/239859894903439407) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `any` on `echartsOptions` in `SystemClustering.tsx` with `EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'>`, adding the needed imports from `echarts` and `echarts-for-react`. This restores type safety for chart options with no runtime changes.

<sup>Written for commit 465f9a378f121f2be4ce3c3761aba68b3774ff5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

