### PR TITLE
Add zero-state fallback UI to ScatterChart and Chart components

### DIFF
--- a/proposals.md
+++ b/proposals.md
@@ -293,3 +293,66 @@ New `src/layout/QQPlot.tsx` alongside the existing statistical charts like `Boxp
 Available as an advanced statistical view toggle within the table row expansion alongside the Histogram and Boxplot.
 
 
+
+---
+
+**Proposal: Correlation Directionality Polar Scatter**
+
+**ECharts type:** `scatter` (polar coordinate system)
+
+**Codebase citation:**
+Uses `rankedDataMapAtom` from `src/atom/dataAtom.ts` and `correlationMethodAtom` from `src/atom/correlationAtom.ts`.
+
+**Which existing data it uses:**
+Calculates the pairwise correlation between the selected biomarker and all other biomarkers in `dataAtom` using the selected method (e.g., Spearman).
+
+**What it reveals that current charts don't:**
+By mapping the magnitude of the correlation to the radius and the directionality (positive vs. negative) to the angle, it allows users to visually separate biomarkers that move together from those that move inversely, which is difficult to parse in a dense linear scatter plot.
+
+**Where it would live:**
+New `src/layout/CorrelationPolarScatter.tsx`.
+
+**Trigger / entry point:**
+A "Directional View" toggle inside the correlation modal.
+
+---
+
+**Proposal: Optimal Range Boundary Proximity Scatter**
+
+**ECharts type:** `scatter`
+
+**Codebase citation:**
+Uses `extra.range` and `extra.optimality[]` from `src/processors/post/range.ts` aligned with `dataAtom`.
+
+**Which existing data it uses:**
+For each marker in `dataAtom`, it calculates how close the most recent value in `values[]` is to the upper or lower boundary of the `extra.range`, normalizing it as a percentage distance.
+
+**What it reveals that current charts don't:**
+Identifies biomarkers that are *technically* in-range but dangerously close to crossing the boundary, providing early warning signals before they actually trigger the `extra.optimality === true` boolean flag.
+
+**Where it would live:**
+New `src/layout/BoundaryProximityScatter.tsx`.
+
+**Trigger / entry point:**
+A "Boundary Risk" view in the main dashboard or statistical overview.
+
+---
+
+**Proposal: Longitudinal Out-of-Range Burden Stacked Bar Chart**
+
+**ECharts type:** `bar` (stacked)
+
+**Codebase citation:**
+Uses `extra.optimality[]` from `src/processors/post/range.ts` aligned with time `labels` from `src/data/index.ts` and `extra.tag` from `src/processors/post/tag.ts`.
+
+**Which existing data it uses:**
+Iterates through all biomarkers in `dataAtom` for each date in `labels`. Counts the total number of out-of-range markers (`extra.optimality[i] === true`), grouped and stacked by their `extra.tag` (e.g., `3-Liver`, `4-Lipid`).
+
+**What it reveals that current charts don't:**
+Shows the overall physiological burden over time. A spike in the bar indicates a cascading failure across multiple systems on a specific test date, broken down visually by which physiological system contributed most.
+
+**Where it would live:**
+New `src/layout/SystemicBurdenStackedBar.tsx`.
+
+**Trigger / entry point:**
+An "Overall System Burden" widget at the top of the dashboard.

--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -200,6 +200,14 @@ export default memo(({ keys }: ChartProps) => {
     updateChartOption(chartInstance, keys, yAxis)
   }, [keys, yAxis, chartInstance])
 
+  if (keys.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-[400px] w-full text-gray-500 italic border border-dashed border-[#3a3a3a80] rounded-lg">
+        No biomarkers selected.
+      </div>
+    )
+  }
+
   return (
     <ChartProvider data={chartData} echartsOptions={echartsOptions}>
       <Line

--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -171,5 +171,13 @@ export default memo(({ keys }: ScatterChartProps) => {
     [yAxes, chartData, keys],
   )
 
+  if (keys.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-[400px] w-full text-gray-500 italic border border-dashed border-[#3a3a3a80] rounded-lg">
+        No biomarkers selected.
+      </div>
+    )
+  }
+
   return <ReactECharts option={options} style={options.style} notMerge={true} theme="dark" />
 })


### PR DESCRIPTION
**The Issue:**
In `src/layout/ScatterChart.tsx` (lines 173-176) and `src/layout/Chart.tsx` (lines 202-205), when the components receive an empty `keys` array (i.e. no biomarkers are selected), they continue rendering the ECharts wrapper components with empty configuration arrays. This results in the ECharts canvas rendering an unhelpful, empty chart grid layout with naked axes lines but no data.

**Discovery Signal:**
Scan 6 (Edge Cases and Guards) identified that `ScatterChart.tsx` computes an empty `chartData` array if `keys` is empty, leading to a blank chart render.

**The Fix:**
Added an explicit early return statement in both `src/layout/ScatterChart.tsx` and `src/layout/Chart.tsx`. If `keys.length === 0`, the components now immediately return an informative fallback UI element `<div className="flex items-center justify-center h-[400px] w-full text-gray-500 italic border border-dashed border-[#3a3a3a80] rounded-lg">No biomarkers selected.</div>`. Crucially, these `if` statements are placed exactly after all React Hooks execution (`useMemo` and `useEffect`) to strictly respect React Hook sequence constraints.

**The Benefit:**
Massively improves the UX by preventing confusing, half-rendered, blank ECharts canvases from appearing when the user clears all biomarker selections. It explicitly guides the user that action is needed rather than looking like broken software state.

---
*PR created automatically by Jules for task [9359748348208719536](https://jules.google.com/task/9359748348208719536) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a clear empty state to `ScatterChart` and `Chart` when no biomarkers are selected. This prevents blank `echarts` canvases and guides users with a short message.

- **Bug Fixes**
  - Early return a centered fallback element when `keys.length === 0` in `src/layout/ScatterChart.tsx` and `src/layout/Chart.tsx` (after hooks to preserve order).
  - Avoids empty grid renders; normal rendering is unchanged when keys are present.

<sup>Written for commit e66f0e23f67a32601ca7a9ad9eb3811837c7cbb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

