### PR TITLE
Code Quality: Enforce strict EChartsOption typing in RadarChart

### DIFF
--- a/src/layout/RadarChart.tsx
+++ b/src/layout/RadarChart.tsx
@@ -1,9 +1,11 @@
 import { memo, useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
+import type { EChartsReactProps } from 'echarts-for-react'
+import type { EChartsOption } from 'echarts'
 import { RadarChartProps } from './RadarChart.types'
 
 export default memo(({ data, tag }: RadarChartProps) => {
-  const options = useMemo(() => {
+  const options: EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'> = useMemo(() => {
     const indicators: any[] = []
     const values: number[] = []
 
@@ -141,7 +143,7 @@ export default memo(({ data, tag }: RadarChartProps) => {
 
   return (
     <div className="w-full flex justify-center my-4">
-      <ReactECharts option={options} style={options.style as any} notMerge={true} theme="dark" />
+      <ReactECharts option={options} style={options.style} notMerge={true} theme="dark" />
     </div>
   )
 })


### PR DESCRIPTION
**The Issue:**
`src/layout/RadarChart.tsx` lines 6 and 144. The `options` object returned by `useMemo` lacked an explicit type annotation, resulting in an inferred type that didn't strictly match the expected interface of `ReactECharts` (`echarts-for-react`). Consequently, an unsafe `as any` type assertion was used on line 144 to force the style prop to compile (`style={options.style as any}`).

**The Discovery Signal:**
Scan C (Weak or Missing Type Annotations). A grep for `as any` revealed the cast in `src/layout/RadarChart.tsx`, which was required due to the untyped `options` variable.

**The Fix:**
- Imported `EChartsOption` from `echarts` and `EChartsReactProps` from `echarts-for-react`.
- Added an explicit type annotation to the `options` variable: `const options: EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'>`.
- Removed the `as any` cast from the `style` prop passed to `<ReactECharts />`.

**The Benefit:**
Eliminated an unsafe `as any` cast by strongly typing the ECharts configuration object. This improves type safety, prevents accidental structural changes to the chart configuration that might violate the `EChartsOption` interface, and serves as a better reference for how to type ECharts options containing React-specific container props like `style` or `theme`.

---
*PR created automatically by Jules for task [8256687436624471406](https://jules.google.com/task/8256687436624471406) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces strict typing for `RadarChart` ECharts options to remove an unsafe `as any` and improve type safety. Explicitly types `options` as `EChartsOption` from `echarts` intersected with `Pick<EChartsReactProps, 'style' | 'theme'>` from `echarts-for-react`, and passes `style` directly to `<ReactECharts />`.

<sup>Written for commit 9d100d4f199f677ed3d1f73ad596cc413e588d2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

