### PR TITLE
⚡ Bolt: Replace Array.map with a for-loop in CorrelationVolcanoPlot

### DIFF
--- a/src/layout/CorrelationVolcanoPlot.tsx
+++ b/src/layout/CorrelationVolcanoPlot.tsx
@@ -10,7 +10,11 @@ interface CorrelationVolcanoPlotProps {
 
 export default memo(({ correlations, alpha }: CorrelationVolcanoPlotProps) => {
   const options = useMemo<EChartsOption>(() => {
-    const data = correlations.map((c) => {
+    // Optimization: Replace Array.map() with a classic for-loop and dense array push
+    // to avoid closure allocation and function call overhead for each element.
+    const data = []
+    for (let i = 0; i < correlations.length; i++) {
+      const c = correlations[i]
       const name = c[0]
       const pValue = c[2]
       const coeff = c[3]
@@ -26,11 +30,11 @@ export default memo(({ correlations, alpha }: CorrelationVolcanoPlotProps) => {
         }
       }
 
-      return {
+      data.push({
         value: [coeff, logPValue, pValue, name],
         itemStyle: { color }
-      }
-    })
+      })
+    }
 
     const alphaThreshold = -Math.log10(alpha)
 


### PR DESCRIPTION
💡 What:
Replaced `Array.prototype.map()` with a classic `for` loop and `Array.prototype.push()` when building the `data` array for the volcano plot scatter series.

🎯 Why:
To avoid the closure allocation and function call overhead inherent to `.map()` for every single element, which can become a bottleneck when rendering large amounts of correlation data. This optimization aligns with the performance-obsessed goal of making the application measurably faster and more efficient.

📊 Impact:
Reduces intermediate allocations and function call overhead during the data processing phase for the correlation volcano plot.

🔬 Measurement:
Run the application and verify the correlation dialog functionality. Tests verify that functionality is unbroken.

---
*PR created automatically by Jules for task [18144775150504021675](https://jules.google.com/task/18144775150504021675) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `.map()` with a `for` loop and `push()` when building volcano plot data in `CorrelationVolcanoPlot` to remove per-item function/closure overhead. This reduces allocations and speeds up data prep for large correlation sets without changing behavior.

<sup>Written for commit d38f80e8e25ddf5ae1c54564973b7d16af77365f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

