### PR TITLE
refactor: Fix weak type annotation in `Chart.tsx`

### DIFF
--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -9,6 +9,7 @@ import { ChartProps } from './Chart.types'
 import type { EChartsReactProps } from 'echarts-for-react'
 import type { YAXisComponentOption, LineSeriesOption } from 'echarts'
 import type * as echarts from 'echarts'
+import type { Field } from '@echarts-readymade/core'
 
 const dimension = [
   {
@@ -116,7 +117,7 @@ export default memo(({ keys }: ChartProps) => {
     // which invalidates the downstream chartData useMemo dependency check.
     // ⚡ Bolt Optimization: Avoid pre-allocating 'holey' arrays. Use push() to maintain dense arrays for V8.
     const len = keys.length
-    const result: any[] = []
+    const result: Field[] = []
     for (let i = 0; i < len; i++) {
       result.push({
         fieldKey: 'v' + i,


### PR DESCRIPTION
**The Issue:**
`src/layout/Chart.tsx` line 120 (approx) — A weakly typed array `const result: any[] = []` was used to construct a configuration object array (`valueList`) inside a `useMemo`. This compromises TypeScript's type safety and allows incorrect object shapes to be passed to `echarts-readymade`.

**The Discovery Signal:**
Scan C: `src/layout/Chart.tsx` line 119 — Weakly-typed array `const result: any[] = []`.

**The Fix:**
Replaced `any[]` with `Field[]` by importing the strictly defined `Field` type from `@echarts-readymade/core` (the same library consuming the configuration).

**The Benefit:**
Eliminated a weak type assignment, enforcing strict type-checking on the `valueList` objects passed to `@echarts-readymade` components, preventing potential silent runtime errors caused by malformed chart dimension configurations.

---
*PR created automatically by Jules for task [14061873926544794176](https://jules.google.com/task/14061873926544794176) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Imported `Field` from `@echarts-readymade/core` and replaced a weakly typed `any[]` with `Field[]` in `src/layout/Chart.tsx` when building the value list. This enforces strict typing and prevents malformed chart field configs from reaching `@echarts-readymade`.

<sup>Written for commit 190720f5f54055a9228d79e796105f6677d013be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

