### PR TITLE
⚡ Bolt: Optimize array shifting in sampling data pipeline

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -68,3 +68,6 @@
 
 **Learning:** When attempting to find intersections or map items from an array of strings against an array of complex tuples, creating intermediate arrays via `.filter()` and `.map()` followed by instantiating a `new Map()` or `new Set()` introduces massive overhead. If the array of targets is tiny (e.g. length 2) relative to the source array (length N), it is faster to skip object/closure creation entirely and use a direct `O(K*N)` nested `for` loop. V8 optimizes dense nested loops far better than it handles intermediate array and object allocations.
 **Action:** When filtering a large dataset for a tiny, strictly bounded number of elements (like 2 selected items), avoid `.filter()`, `Set`, and `Map`. Use a direct nested loop to locate and push the items.
+## 2026-06-23 - Replaced unshift in hot loop with push and reverse
+**Learning:** Using `Array.prototype.unshift()` inside a loop causes V8 to shift all existing elements on every insertion, making it an O(N^2) operation. This scales poorly in data processing pipelines.
+**Action:** Always prefer `.push()` followed by `.reverse()` or building the array backwards by index rather than using `.unshift()` inside a loop.

--- a/src/processors/enrich/sampling.ts
+++ b/src/processors/enrich/sampling.ts
@@ -20,13 +20,17 @@ export default (entries: BioMarker[]): BioMarker[] => {
               actualNum++
             }
           }
-          output.unshift((sum / actualNum).toFixed(2))
+
+          // ⚡ Bolt Optimization: Replace O(N^2) .unshift() with O(1) .push()
+          // Calling .unshift() inside a loop forces V8 to shift all existing elements
+          // in the array on every iteration. Pushing and reversing at the end is O(N).
+          output.push((sum / actualNum).toFixed(2))
 
           if (count && output.length >= count) {
             break
           }
         }
-        return output
+        return output.reverse()
       }
     }
   }


### PR DESCRIPTION
**The Issue:**
The `getSamples` function in `src/processors/enrich/sampling.ts` used `output.unshift()` inside a `for` loop to build the sample output array backwards. Calling `.unshift()` inside a loop forces the JavaScript engine (V8) to re-index and shift all existing array elements on every insertion, resulting in an O(N²) time complexity.

**Discovery Signal:**
Manual code inspection for V8 performance de-optimizations in hot loops.

**The Fix:**
Replaced `output.unshift(val)` with `output.push(val)`. Because the array is built forwards in memory, it doesn't incur the shifting overhead. At the end of the loop, a single `output.reverse()` call is used to restore the correct order before returning.

**The Benefit:**
Changes the time complexity of sample extraction from O(N²) to O(N) by eliminating array shifting. This yields a measurable reduction in CPU cycle overhead and prevents potential main thread hitching during data pipeline enrichment, without altering any functionality.

---
*PR created automatically by Jules for task [7457126726251935494](https://jules.google.com/task/7457126726251935494) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized `getSamples` by replacing looped `.unshift()` with `.push()` and a final `.reverse()`, reducing array construction from O(N²) to O(N) and lowering CPU usage in the enrichment pipeline without changing behavior.

<sup>Written for commit 37eedc825600c77dd1b9d8e6ca606fb8b3fa6301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

