### PR TITLE
🎨 Palette: add aria-controls to mobile menu toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** For data-dense tables powered by Headless UI/TanStack Table where bulk actions are frequent, relying solely on single-row selections forces users into repetitive workflows. Utilizing the table library's native `getIsAllRowsSelected` state within a simple column header improves macro interactions significantly while staying within accessibility guidelines (provided an `aria-label` is applied to the checkbox).
 **Action:** Next time working on a table component with row-level selection, proactively investigate if a "Select All" header toggle is missing, and if so, wire it up using the table's existing selection state manager.
+
+## 2024-06-22 - Add aria-controls to aria-expanded toggles
+
+**Learning:** When using `aria-expanded` on toggle buttons (like mobile menus), it is not enough to just announce the expanded state. Screen readers also need to know *what* container is being expanded. Always pair `aria-expanded` with `aria-controls="[container-id]"` and ensure the target container has a matching `id`.
+**Action:** Next time implementing or auditing a toggle button with `aria-expanded`, ensure `aria-controls` is present and correctly linked to the target element's `id`.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -58,12 +58,17 @@
 **Action:** When replacing array iterations with standard `for` loops in hot render cycles, always initialize standard JS arrays densely (`const arr = []`) and add elements using `.push(val)` or sequential direct assignment (`arr[i] = val` only when strictly sequential without gaps). Reserve pre-allocated sizing exclusively for TypedArrays.
 
 ## 2025-05-18 - Avoid Holey Arrays in React Loops
+
 **Learning:** Initializing arrays with `Array<Type>(length)` creates sparse (holey) arrays, which de-optimize iterations (like `for`, `map`, etc.) in the V8 engine due to missing memory slots. React render loops containing array manipulation suffer performance degradation.
 **Action:** When working with objects or mixed types in hot loops, do not pre-allocate using `Array(length)`. Instead, initialize an empty dense array (`[]`) and use `.push()`. Only use pre-allocated specific types like TypedArrays (`Float64Array`, `Int32Array`) for strictly numeric operations.
+
 ## 2026-06-07 - Refactoring 'holey' array allocations\n**Learning:** Found several instances where standard JS generic arrays were initialized via `Array<Type>(len)` within `useMemo` hooks (e.g. `src/layout/SystemClustering.tsx`, `src/layout/BoxplotChart.tsx`, `src/layout/BiomarkerCorrelationBumpChart.tsx`). This pre-allocation causes V8 to treat them as 'holey' (sparse) arrays, dropping performance compared to using sequential push operations into dense arrays `[]`.\n**Action:** When replacing array iterations with standard `for` loops in hot render cycles, always initialize standard JS arrays densely (`const arr = []`) and add elements using `.push(val)` or sequential direct assignment. Reserve pre-allocated sizing exclusively for TypedArrays.
+
 ## 2026-06-19 - Single-pass Set generation
+
 **Learning:** Chained operations like `new Set(array.map(x => x.prop))` create unnecessary intermediate arrays which must be immediately garbage collected. In hot render paths, this memory churn degrades performance.
 **Action:** Replace chained `.map()` and `new Set()` with a single-pass `for` loop that instantiates a `Set` and populates it via `.add()`. Use `Array.from()` to convert it back if necessary. This avoids intermediate array allocations.
+
 ## 2026-06-21 - Avoiding Array mapping and filtering before Map creation
 
 **Learning:** When attempting to find intersections or map items from an array of strings against an array of complex tuples, creating intermediate arrays via `.filter()` and `.map()` followed by instantiating a `new Map()` or `new Set()` introduces massive overhead. If the array of targets is tiny (e.g. length 2) relative to the source array (length N), it is faster to skip object/closure creation entirely and use a direct `O(K*N)` nested `for` loop. V8 optimizes dense nested loops far better than it handles intermediate array and object allocations.

--- a/proposals.md
+++ b/proposals.md
@@ -1,4 +1,3 @@
-
 **Proposal: Spearman Rank Velocity Line Chart**
 
 **ECharts type:** `line`
@@ -7,7 +6,7 @@
 Directly utilizes the pre-computed `rankedDataMapAtom` from `src/atom/dataAtom.ts`.
 
 **Which existing data it uses:**
-Takes the `Float64Array` rank arrays from `rankedDataMapAtom` for the selected biomarkers (via `visibleDataAtom`). Instead of plotting the raw values, it plots the rank position or the *change* in rank position over time.
+Takes the `Float64Array` rank arrays from `rankedDataMapAtom` for the selected biomarkers (via `visibleDataAtom`). Instead of plotting the raw values, it plots the rank position or the _change_ in rank position over time.
 
 **What it reveals that current charts don't:**
 Visualizes relative performance changes by abstracting away differing units and scales. It clearly shows when a biomarker's value significantly shifted in terms of its historical distribution, ignoring minor absolute fluctuations that don't change its rank, which highlights truly anomalous shifts.
@@ -49,10 +48,10 @@ Triggered via a "Volatility Analysis" toggle in the main Dashboard next to the t
 Uses `correlationAlphaAtom` from `src/atom/correlationAtom.ts` and `extra.tag` from `src/processors/post/tag.ts`.
 
 **Which existing data it uses:**
-It calculates the pairwise correlation between the *aggregated average percent-to-optimal* scores for each tag group (e.g., aggregating all `1-RBC` markers vs all `3-Liver` markers) using the methods in `correlationAtom`.
+It calculates the pairwise correlation between the _aggregated average percent-to-optimal_ scores for each tag group (e.g., aggregating all `1-RBC` markers vs all `3-Liver` markers) using the methods in `correlationAtom`.
 
 **What it reveals that current charts don't:**
-The existing correlation tools map individual biomarkers to each other or to supplements. This graph maps *entire physiological systems* against each other to reveal macro-level cascades (e.g., proving that liver stress strongly correlates with lipid metabolism degradation in this specific user's history).
+The existing correlation tools map individual biomarkers to each other or to supplements. This graph maps _entire physiological systems_ against each other to reveal macro-level cascades (e.g., proving that liver stress strongly correlates with lipid metabolism degradation in this specific user's history).
 
 **Where it would live:**
 New `src/layout/SystemCorrelationGraph.tsx` alongside `BiomarkerCorrelationGraph.tsx`.
@@ -73,7 +72,7 @@ Uses `extra.optimality[]` from `src/processors/post/range.ts` matched against `l
 It processes `dataAtom` and identifies continuous streaks where `extra.optimality` is `true`. It maps these periods into horizontal duration bars for each biomarker.
 
 **What it reveals that current charts don't:**
-Instead of showing discrete points where a biomarker was out of range, it emphasizes the *continuous duration* of chronic issues. A single bad reading might be noise, but a Gantt chart instantly highlights which biomarker has been out of optimal bounds continuously for the longest period of time.
+Instead of showing discrete points where a biomarker was out of range, it emphasizes the _continuous duration_ of chronic issues. A single bad reading might be noise, but a Gantt chart instantly highlights which biomarker has been out of optimal bounds continuously for the longest period of time.
 
 **Where it would live:**
 New `src/layout/ChronicDurationGantt.tsx`.
@@ -83,7 +82,6 @@ A "Chronic Risk View" button above the main data table that replaces the table v
 
 ---
 
-
 **Proposal: Optimality Survival Step Chart**
 
 **ECharts type:** `line` (with `step: 'end'`)
@@ -92,7 +90,7 @@ A "Chronic Risk View" button above the main data table that replaces the table v
 Relies on `extra.optimality[]` from `src/processors/post/range.ts` aligned with time `labels` from `src/data/index.ts`.
 
 **Which existing data it uses:**
-Iterates through `dataAtom` to track the first date each biomarker transitioned into an out-of-range state (`extra.optimality[i] === true`). It plots a declining step function starting at 100% representing the proportion of biomarkers that have *never* breached their optimal range over time.
+Iterates through `dataAtom` to track the first date each biomarker transitioned into an out-of-range state (`extra.optimality[i] === true`). It plots a declining step function starting at 100% representing the proportion of biomarkers that have _never_ breached their optimal range over time.
 
 **What it reveals that current charts don't:**
 Provides a macroscopic "health span" indicator. Instead of viewing daily fluctuations, it shows the systemic accumulation of clinical abnormalities, indicating whether a user's health is remaining stable or cascading into multiple out-of-range markers simultaneously.
@@ -116,7 +114,7 @@ Uses `correlationMethodAtom` from `src/atom/correlationAtom.ts` and `extra.optim
 For every biomarker in `dataAtom`, it computes its average absolute correlation coefficient with all other biomarkers. It plots each biomarker where the X-axis is this average correlation (centrality) and the Y-axis is the historical out-of-range frequency (derived by counting `true` values in `extra.optimality[]`).
 
 **What it reveals that current charts don't:**
-Identifies "keystone" vulnerabilities—biomarkers that are both highly volatile/abnormal *and* strongly coupled to the rest of the systemic network. Prioritizing interventions on these specific markers could yield the highest cascading health benefits.
+Identifies "keystone" vulnerabilities—biomarkers that are both highly volatile/abnormal _and_ strongly coupled to the rest of the systemic network. Prioritizing interventions on these specific markers could yield the highest cascading health benefits.
 
 **Where it would live:**
 New `src/layout/KeystoneCentralityScatter.tsx` accessed via the correlation tools.
@@ -145,8 +143,6 @@ New `src/layout/QQPlot.tsx` alongside the existing statistical charts like `Boxp
 **Trigger / entry point:**
 Available as an advanced statistical view toggle within the table row expansion alongside the Histogram and Boxplot.
 
-
-
 ---
 
 **Proposal: Correlation Directionality Polar Scatter**
@@ -167,7 +163,6 @@ New `src/layout/CorrelationPolarScatter.tsx`.
 
 **Trigger / entry point:**
 A "Directional View" toggle inside the correlation modal.
-
 
 ---
 

--- a/src/layout/Chart.tsx
+++ b/src/layout/Chart.tsx
@@ -81,7 +81,7 @@ const echartsOptions: EChartsReactProps = {
 const updateChartOption = (
   chartInstance: echarts.ECharts | null,
   keys: string[],
-  yAxis: YAXisComponentOption[]
+  yAxis: YAXisComponentOption[],
 ) => {
   if (chartInstance && !chartInstance.isDisposed()) {
     const len = keys.length

--- a/src/layout/Correlation.tsx
+++ b/src/layout/Correlation.tsx
@@ -128,7 +128,7 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
   }, [data, dataMap, target, alpha, alternative, rankedDataMap, method])
 
   const significantEntries = React.useMemo(() => {
-    return entries ? entries.filter(e => e[2] <= alpha) : []
+    return entries ? entries.filter((e) => e[2] <= alpha) : []
   }, [entries, alpha])
 
   return (
@@ -313,7 +313,10 @@ export default React.memo(({ target, onClose }: CorrelationProps) => {
 
                       {activeTab === 'chart' && significantEntries.length > 0 && (
                         <div className="mb-8">
-                          <FocusedCorrelationChart correlations={significantEntries} alpha={alpha} />
+                          <FocusedCorrelationChart
+                            correlations={significantEntries}
+                            alpha={alpha}
+                          />
                         </div>
                       )}
 

--- a/src/layout/CorrelationVolcanoPlot.tsx
+++ b/src/layout/CorrelationVolcanoPlot.tsx
@@ -28,7 +28,7 @@ export default memo(({ correlations, alpha }: CorrelationVolcanoPlotProps) => {
 
       return {
         value: [coeff, logPValue, pValue, name],
-        itemStyle: { color }
+        itemStyle: { color },
       }
     })
 

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -261,6 +261,7 @@ export default React.memo<NavProps>(
               aria-label={show ? 'Close menu' : 'Open menu'}
               title={show ? 'Close menu' : 'Open menu'}
               aria-expanded={show}
+              aria-controls="mobile-menu-content"
             >
               {show ? (
                 <XMarkIcon className="h-6 w-6" aria-hidden="true" />
@@ -327,6 +328,7 @@ export default React.memo<NavProps>(
             </div>
 
             <div
+              id="mobile-menu-content"
               className={cn('w-full lg:flex lg:flex-1 lg:items-center lg:gap-4 lg:h-8', {
                 'hidden lg:flex': !show,
                 'grid grid-cols-3 gap-2': show,


### PR DESCRIPTION
**The Issue:** The mobile menu toggle button in `Nav.tsx` used `aria-expanded` but did not use `aria-controls` to programmatically associate the toggle button with the menu content container it opens.
**Discovery Signal:** Accessibility audit
**The Fix:** Added `aria-controls="mobile-menu-content"` to the mobile menu button and added `id="mobile-menu-content"` to the corresponding content container `div`.
**The Benefit:** Screen reader users can now explicitly identify and navigate to the content area that expands when the mobile menu toggle is activated.

💡 What: Added `aria-controls` and `id` linking for the mobile menu toggle.
🎯 Why: To create a direct programmatic relationship between the toggle button and the expandable menu content.
♿ Accessibility: Improves screen reader experience by associating the toggle button directly with the region it controls.

---
*PR created automatically by Jules for task [16068501869604136686](https://jules.google.com/task/16068501869604136686) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Link the mobile menu toggle to its content with `aria-controls`/`id` in `Nav` to improve screen reader navigation. This explicitly associates the button with the region it opens for better accessibility.

- **Refactors**
  - Minor formatting/lint updates in `Correlation.tsx` and `Chart.tsx` after merging `main` (no behavior changes).

<sup>Written for commit 403474836ea4e4f8710a50b78e99f5ae8aac5ac8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

