### PR TITLE
🎨 Palette: improve LineChart optimal range parsing and add visual proposals

### DIFF
--- a/proposals.md
+++ b/proposals.md
@@ -189,3 +189,66 @@ New `src/layout/SystemicBurdenStackedBar.tsx`.
 
 **Trigger / entry point:**
 An "Overall System Burden" widget at the top of the dashboard.
+
+---
+
+**Proposal: Rank Velocity Line Chart**
+
+**ECharts type:** `line`
+
+**Codebase citation:**
+Uses `rankedDataMapAtom` from `src/atom/dataAtom.ts`.
+
+**Which existing data it uses:**
+It utilizes the `Float64Array` rank arrays produced by `rankedDataMapAtom` alongside the shared `labels` from `src/data/index.ts` to plot the progression of a biomarker's rank over time, instead of its raw absolute value.
+
+**What it reveals that current charts don't:**
+The current `LineChart.tsx` shows absolute value trends, which can make it hard to distinguish true systemic degradation from simple volatility within the normal bounds. Showing rank velocity visualizes when a biomarker has truly broken its historical percentiles, filtering out the noise of normal day-to-day variance.
+
+**Where it would live:**
+New `src/layout/RankVelocityChart.tsx`.
+
+**Trigger / entry point:**
+Could be rendered as a toggle state within the existing `Chart.tsx` view or row expansion to switch the Y-axis interpretation from absolute values to rank progression.
+
+---
+
+**Proposal: Correlation Directionality Polar Scatter**
+
+**ECharts type:** `scatter` (polar coordinate system)
+
+**Codebase citation:**
+Utilizes `rankedDataMapAtom` from `src/atom/dataAtom.ts` and `correlationMethodAtom` from `src/atom/correlationAtom.ts`.
+
+**Which existing data it uses:**
+Computes the pairwise correlations between the target biomarker and all other biomarkers, plotting the correlation magnitude (radius) against the sign/direction (angle) in a polar graph.
+
+**What it reveals that current charts don't:**
+While `Chart2.tsx` plots an exact 1:1 regression on Cartesian axes, a polar correlation scatter can simultaneously plot the relationships of *many* markers against a central target. This instantly segregates biomarkers that move symbiotically (positive correlation angles) from those that move antagonistically (negative correlation angles) in a single dense view.
+
+**Where it would live:**
+New `src/layout/PolarCorrelationScatter.tsx`.
+
+**Trigger / entry point:**
+A new "Polar Comparison" tab within the biomarker Correlation Modal.
+
+---
+
+**Proposal: Out-of-Range Duration Gantt Chart**
+
+**ECharts type:** `custom` (styled as Gantt duration bars)
+
+**Codebase citation:**
+Uses `extra.optimality[]` from `src/processors/post/range.ts` combined with `labels` from `src/data/index.ts`.
+
+**Which existing data it uses:**
+Processes `visibleDataAtom` to isolate the specific indices where `extra.optimality[i] === true`. It merges contiguous `true` periods into duration blocks along a shared X-axis timeline.
+
+**What it reveals that current charts don't:**
+Current multi-axis timeline charts (`Chart.tsx`, `ScatterChart.tsx`) show magnitude effectively, but tracking exactly how long a system has been chronically failing requires tracing the line against a boundary. A Gantt duration block specifically emphasizes the *chronicity* of an issue by collapsing magnitude and focusing purely on the duration spent outside optimal bounds.
+
+**Where it would live:**
+New `src/layout/OptimalityDurationGantt.tsx`.
+
+**Trigger / entry point:**
+A "Chronic Risk View" button added to the main Dashboard view options, rendering in place of `ScatterChart.tsx`.

--- a/src/layout/LineChart.tsx
+++ b/src/layout/LineChart.tsx
@@ -91,6 +91,10 @@ export default memo(({ name, values, rangeStr }: LineChartProps) => {
         min = parseFloat(rangeStr.slice(2))
       } else if (rangeStr.startsWith('<=')) {
         max = parseFloat(rangeStr.slice(2))
+      } else if (rangeStr.startsWith('>')) {
+        min = parseFloat(rangeStr.slice(1))
+      } else if (rangeStr.startsWith('<')) {
+        max = parseFloat(rangeStr.slice(1))
       }
 
       const validMin = min !== undefined && !Number.isNaN(min)


### PR DESCRIPTION
**The Issue:**
In `src/layout/LineChart.tsx` (lines 90-95), the `rangeStr` parser successfully handled `>=` and `<=` prefixes to configure the `markArea` boundaries. However, it lacked conditions for strictly less-than (`<`) or strictly greater-than (`>`) prefixes. If a biomarker had a range string like `<5`, it would silently fail to parse, resulting in an undefined boundary and a missing optimal zone on the chart.

**Discovery Signal:**
Scan 6 (Edge Cases and Guards) combined with code review logic identified that the parser was incomplete for all mathematical inequality operators defined in `src/processors/post/range.ts`.

**The Fix:**
Added explicit `else if` conditions to slice correctly for `>` and `<` prefixes, ensuring that single-bound optimal ranges correctly extract the boundary value and assign it to the correct `yAxis` `markArea` property.

**The Benefit:**
Ensures that all valid biomarker optimal ranges are rendered faithfully on the LineChart row expansion, improving the diagnostic utility of the single-biomarker view. Also appended 3 new codebase-grounded chart proposals to `proposals.md`.

---
*PR created automatically by Jules for task [17485510587448936970](https://jules.google.com/task/17485510587448936970) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LineChart range parsing to support '<' and '>' so single-bound biomarker ranges render the correct markArea. Adds three visualization proposals to `proposals.md`.

- **Bug Fixes**
  - Handle '<' and '>' in `rangeStr` and map to `markArea` min/max.
  - Restores optimal zones for single-sided ranges (e.g., `<5`, `>120`).

- **New Features**
  - Added proposals: Rank Velocity Line Chart, Correlation Directionality Polar Scatter, Out-of-Range Duration Gantt Chart.

<sup>Written for commit 6bba890e142b09c17f9f9d16be5adb0d3ac972cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

