### PR TITLE
Fix weak type annotation in Chart2.tsx

### DIFF
--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -146,7 +146,7 @@ export default memo(({ keys }: ChartProps) => {
       // ⚡ Bolt Optimization: Avoid pre-allocating 'holey' arrays for generic types.
       // Pre-allocating Array<any[]>(len) creates sparse arrays which de-optimize modern V8 engines.
       // Replacing with standard array pushes and eliminating the slice operation improves performance.
-      const mappedData: any[] = []
+      const mappedData: [number, number, string, string, string][] = []
 
       for (let i = 0; i < len; i++) {
         const v0 = values0[i]


### PR DESCRIPTION
**The Issue:**
The array `mappedData` in `src/layout/Chart2.tsx` (line 149) was initialized with a weak type annotation (`any[]`). This bypassed TypeScript's strict type checking for the data being pushed into the array, creating a structural weakness where malformed tuples could be passed to the ECharts dataset without a compile-time error.

**The Discovery Signal:**
Scan C (Weak or Missing Type Annotations): Identified `mappedData: any[] = []` in `src/layout/Chart2.tsx`. 

**The Fix:**
Replaced the explicit `any[]` annotation with the precise tuple array type `[number, number, string, string, string][]`. This type was directly inferred from the surrounding code where `[v0, v1, formattedDate, unitX, unitY]` is pushed into the array.

**The Benefit:**
Improved code maintainability and type safety. The compiler will now enforce the exact 5-element tuple structure for `mappedData`, preventing unintended regressions or type mismatches from slipping through into ECharts configurations, all without inventing new type aliases.

---
*PR created automatically by Jules for task [10689265442981846616](https://jules.google.com/task/10689265442981846616) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the weak any[] annotation for mappedData in src/layout/Chart2.tsx with the exact tuple type [number, number, string, string, string][]. This enforces the 5-element structure and catches type errors before they reach ECharts.

<sup>Written for commit a282f9dcc728fd221e598ee659b84d1f9072ea42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

