### PR TITLE
Code Quality: Fix weak type annotation in Chart2 mappedData array

### DIFF
--- a/src/layout/Chart2.tsx
+++ b/src/layout/Chart2.tsx
@@ -146,7 +146,7 @@ export default memo(({ keys }: ChartProps) => {
       // ⚡ Bolt Optimization: Avoid pre-allocating 'holey' arrays for generic types.
       // Pre-allocating Array<any[]>(len) creates sparse arrays which de-optimize modern V8 engines.
       // Replacing with standard array pushes and eliminating the slice operation improves performance.
-      const mappedData: any[] = []
+      const mappedData: [number, number, string, string, string][] = []
 
       for (let i = 0; i < len; i++) {
         const v0 = values0[i]


### PR DESCRIPTION
**The Issue:**
In `src/layout/Chart2.tsx` on line 149, an array used for charting data (`mappedData`) was initialized using the explicit weak type `any[]`. This bypasses TypeScript's safety mechanisms and makes subsequent iterations and operations on this array structurally unsafe.

**The Discovery Signal:**
Scan C (Weak or Missing Type Annotations): `src/layout/Chart2.tsx` line 149 — explicit `any[]` annotation on `mappedData` where a strict tuple shape is pushed within the iteration loop (`[v0, v1, formattedDate, unitX, unitY]`).

**The Fix:**
Replaced `const mappedData: any[] = []` with the exact tuple type inferred from the surrounding local `.push()` operation: `const mappedData: [number, number, string, string, string][] = []`.

**The Benefit:**
Eliminates an explicit generic bypass, enforcing strict type safety on data arrays fed into ECharts regression transformations without adding external imports or risking logic regressions. Improves static analysis reliability and protects against future structural breakages in the data pipeline.

---
*PR created automatically by Jules for task [14580107047117685876](https://jules.google.com/task/14580107047117685876) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `mappedData`’s `any[]` with the exact tuple type `[number, number, string, string, string][]` in `src/layout/Chart2.tsx` to enforce type safety. This prevents structural errors and improves static analysis for chart data.

<sup>Written for commit b264461914a8e58aeb524c967abbfef5a407d3c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

