### PR TITLE
🔧 Code Quality: Fix explicit any[] weak type in RadarChart indicators

### DIFF
--- a/src/layout/RadarChart.tsx
+++ b/src/layout/RadarChart.tsx
@@ -6,7 +6,15 @@ import { RadarChartProps } from './RadarChart.types'
 
 export default memo(({ data, tag }: RadarChartProps) => {
   const options: EChartsOption & Pick<EChartsReactProps, 'style' | 'theme'> = useMemo(() => {
-    const indicators: any[] = []
+    const indicators: {
+      name: string
+      max: number
+      min: number
+      _actualValue: number
+      _unit: string
+      _range: string
+      _isNotOptimal: boolean
+    }[] = []
     const values: number[] = []
 
     // Optimization: Replace Array.forEach with a traditional for-loop to eliminate closure


### PR DESCRIPTION
**The Issue:**
In `src/layout/RadarChart.tsx` at line 9, the `indicators` array is initialized with an explicit `any[]` weak type (`const indicators: any[] = []`), masking the true structure of the data objects being pushed into it and subverting TypeScript compiler checks.

**Discovery Signal:**
Scan C (Weak or Missing Type Annotations) flagged `src/layout/RadarChart.tsx` line 9 for the explicit `any[]` annotation on `indicators`.

**The Fix:**
Replaced `const indicators: any[] = []` with a strict inferred object array type: `const indicators: { name: string; max: number; min: number; _actualValue: number; _unit: string; _range: string; _isNotOptimal: boolean }[] = []`, matching the precise shape of the objects constructed in the loop below it.

**The Benefit:**
Eliminates weak typing inside the `RadarChart` component, giving the TypeScript compiler full visibility into the `indicators` array structure. This reduces the risk of accidental typos when accessing properties like `_actualValue` and `_unit` downstream, increasing the structural integrity of the codebase while strictly adhering to local type inference rules (zero new external imports).

---
*PR created automatically by Jules for task [2564852513640949409](https://jules.google.com/task/2564852513640949409) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `indicators` array `any[]` in `src/layout/RadarChart.tsx` with a precise object type to enforce TypeScript checks and prevent property typos.

<sup>Written for commit 19d0d1eb6e75c39eeba3d6d322ee1b7c9f9a0974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

