### PR TITLE
Fix ScatterChart Y-axis legibility and weak typing

### DIFF
--- a/proposals.md
+++ b/proposals.md
@@ -104,3 +104,45 @@ New `src/layout/LongitudinalRankParallel.tsx`, included in the statistical tools
 
 **Trigger / entry point:**
 An "Evolution Matrix" toggle in the Data Correlation tools section.
+
+---
+
+**Proposal: Measurement Frequency vs. Anomaly Rate Scatter**
+
+**ECharts type:** `scatter`
+
+**Codebase citation:**
+`extra.optimality[]` pre-computed by `src/processors/post/range.ts` and `BioMarker[1]` lengths from `visibleDataAtom`.
+
+**Which existing data it uses:**
+Uses the length of non-null measurements in `BioMarker[1]` to calculate frequency, and counts the `true` values in `extra.optimality[]` to calculate the anomaly rate, reading from `visibleDataAtom`.
+
+**What it reveals that current charts don't:**
+Identifies biomarkers that are rarely tested but frequently abnormal when they are measured, highlighting potential testing blind spots or interventions that are neglected.
+
+**Where it would live:**
+New `src/layout/MeasurementAnomalyScatter.tsx`, rendered in the main dashboard when "Prioritization View" is enabled.
+
+**Trigger / entry point:**
+Triggered via the existing "Prioritization View" toggle in the main dashboard, filtering data based on `tagAtom` if one is active.
+
+---
+
+**Proposal: Tag-Group Measurement Density Calendar**
+
+**ECharts type:** `calendar` + `heatmap`
+
+**Codebase citation:**
+`tagAtom` and `labels[]` from `src/data/index.ts`.
+
+**Which existing data it uses:**
+Reads the currently selected `tagAtom` to filter biomarkers, then maps the non-null data points in `BioMarker[1]` to their corresponding dates in `labels[]` to aggregate daily measurement counts.
+
+**What it reveals that current charts don't:**
+Shows the density of testing for specific physiological systems (e.g. `2-Metabolic`) on a calendar layout, revealing specific months or seasons where testing is clustered or neglected.
+
+**Where it would live:**
+New `src/layout/TagMeasurementCalendar.tsx`, rendered in a new modal or collapsible section on the main dashboard.
+
+**Trigger / entry point:**
+The existing tag filter buttons in `Nav.tsx` already set `tagAtom`; the calendar auto-renders when a single tag is active, showing the measurement density for that specific group.

--- a/src/layout/ScatterChart.tsx
+++ b/src/layout/ScatterChart.tsx
@@ -89,6 +89,7 @@ export default memo(({ keys }: ScatterChartProps) => {
         position: isEven ? 'left' : 'right',
         offset: sideOffset,
         nameLocation: 'middle',
+        nameRotate: isEven ? 90 : -90,
         nameGap: 50,
         axisLine: {
           show: true,
@@ -126,7 +127,7 @@ export default memo(({ keys }: ScatterChartProps) => {
 
       const values = bioMarker[1]
       const unit = bioMarker[2]
-      const validData = []
+      const validData: [string, number, string][] = []
 
       const numLabels = labels.length
       // Assuming labels length matches values length


### PR DESCRIPTION
**The Issue:**
In `src/layout/ScatterChart.tsx` (lines ~89-94), the Y-axis config was missing `nameRotate`, defaulting to horizontal text which causes long axis names (e.g. Vietnamese labels like "Bilirubin toàn phần") to overlap with axis ticks, leading to poor legibility on multi-axis charts. Also, `validData` was initialized as `any[]` which allows type regressions.

**Discovery Signal:**
Scan 3 — Multi-Axis Legibility (ScatterChart & Chart) and Weak Types Pattern from memory. 

**The Fix:**
Added `nameRotate: isEven ? 90 : -90` to the Y-axis configuration to rotate axis names appropriately based on their side (preventing upside-down text on the right side). Enforced explicit `[string, number, string][]` typing for the `validData` array. Appended 2 new visualization proposals to `proposals.md` leveraging existing `visibleDataAtom`, `tagAtom`, and `extra.optimality[]` mappings. 

**The Benefit:**
Y-axis labels are now vertically aligned for multi-axis legibility without label overlap. The local chart array is strictly typed for improved long-term maintainability. 

---
*PR created automatically by Jules for task [15140771437727524454](https://jules.google.com/task/15140771437727524454) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Y‑axis label overlap in `ScatterChart` by rotating axis names per side and strengthens typing for plotted data. Also adds two visualization proposals to `proposals.md`.

- **Bug Fixes**
  - Rotate Y‑axis names with `nameRotate: isEven ? 90 : -90` to prevent overlap and upside‑down text on right axes.
  - Type `validData` as `[string, number, string][]` instead of `any[]` to preserve the expected data shape.

<sup>Written for commit dc37e56be1c8b01a01c9bcca8e8db4aff600c4a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

