### PR TITLE
🎨 Palette: Add aria-controls to aria-expanded toggles in Table

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** When using `aria-expanded` on toggle buttons (like mobile menus), it is not enough to just announce the expanded state. Screen readers also need to know *what* container is being expanded. Always pair `aria-expanded` with `aria-controls="[container-id]"` and ensure the target container has a matching `id`.
 **Action:** Next time implementing or auditing a toggle button with `aria-expanded`, ensure `aria-controls` is present and correctly linked to the target element's `id`.
+
+## 2024-05-31 - Add aria-controls to aria-expanded toggles
+
+**Learning:** When using `aria-expanded` on toggle buttons (like accordion expanders or table row expanders), it is important for screen readers to know *what* container is being expanded. Always pair `aria-expanded` with `aria-controls="[container-id]"` and ensure the target container has a matching `id`.
+**Action:** Next time implementing or auditing a toggle button with `aria-expanded`, ensure `aria-controls` is present and correctly linked to the target element's `id`.

--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -4,7 +4,7 @@ import cn from 'classnames'
 import { labels } from '../data'
 import { visibleDataAtom, notesAtom, filterTextAtom, tagAtom } from '../atom/dataAtom'
 import { useAtomValue } from 'jotai'
-import { useTable, createCoreRowModel, createFilteredRowModel, createColumnHelper, flexRender, ColumnDef, createGroupedRowModel, createExpandedRowModel, GroupingState, ExpandedState, tableFeatures, filterFns, columnFilteringFeature, rowExpandingFeature, columnGroupingFeature, rowSelectionFeature, columnVisibilityFeature, Row } from '@tanstack/react-table';
+import { useTable, createFilteredRowModel, createColumnHelper, flexRender, createGroupedRowModel, createExpandedRowModel, GroupingState, ExpandedState, tableFeatures, filterFns, columnFilteringFeature, rowExpandingFeature, columnGroupingFeature, rowSelectionFeature, columnVisibilityFeature } from '@tanstack/react-table';
 import {
   ChevronRightIcon,
   ChevronDownIcon,
@@ -204,6 +204,7 @@ const TableRow = React.memo(
                 className="hover:text-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded p-1"
                 aria-label={isExpanded ? `Collapse chart for ${name}` : `Expand chart for ${name}`}
                 aria-expanded={isExpanded}
+                aria-controls={`expanded-chart-${safeNameId}`}
               >
                 {isExpanded ? (
                   <MinusIcon className="h-5 w-5" aria-hidden="true" />
@@ -311,7 +312,7 @@ const TableRow = React.memo(
           )}
         </tr>
         {isExpanded && (
-          <tr className="bg-gray-800">
+          <tr id={`expanded-chart-${safeNameId}`} className="bg-gray-800">
             <td colSpan={visibleLeafColumnsCount} className="border border-gray-700">
               <React.Suspense
                 fallback={


### PR DESCRIPTION
**💡 What:** Added `aria-controls` to the expand/collapse chart button within `TableRow` and set the matching `id` on the dynamically rendered `<tr>` containing the chart. Also removed unused imports from `@tanstack/react-table`.
**🎯 Why:** Screen readers need to know which container is controlled by an `aria-expanded` toggle. This provides a clear programmatic association.
**📸 Before/After:** N/A (Non-visual DOM change)
**♿ Accessibility:** Improves screen reader navigation and predictability by linking the expand button explicitly to the expanded content container.

---
*PR created automatically by Jules for task [7820373782178759791](https://jules.google.com/task/7820373782178759791) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added aria-controls to the row expand/collapse button and a matching id on the expanded chart row so screen readers can associate the toggle with its content. Also removed unused `@tanstack/react-table` imports.

<sup>Written for commit a282372d8ce7d3f9ffa56c1d74c6ecdeca00fabb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

