### PR TITLE
refactor(layout): remove unused tanstack table imports

### DIFF
--- a/src/layout/Table.tsx
+++ b/src/layout/Table.tsx
@@ -4,7 +4,7 @@ import cn from 'classnames'
 import { labels } from '../data'
 import { visibleDataAtom, notesAtom, filterTextAtom, tagAtom } from '../atom/dataAtom'
 import { useAtomValue } from 'jotai'
-import { useTable, createCoreRowModel, createFilteredRowModel, createColumnHelper, flexRender, ColumnDef, createGroupedRowModel, createExpandedRowModel, GroupingState, ExpandedState, tableFeatures, filterFns, columnFilteringFeature, rowExpandingFeature, columnGroupingFeature, rowSelectionFeature, columnVisibilityFeature, Row } from '@tanstack/react-table';
+import { useTable, createFilteredRowModel, createColumnHelper, flexRender, createGroupedRowModel, createExpandedRowModel, GroupingState, ExpandedState, tableFeatures, filterFns, columnFilteringFeature, rowExpandingFeature, columnGroupingFeature, rowSelectionFeature, columnVisibilityFeature } from '@tanstack/react-table';
 import {
   ChevronRightIcon,
   ChevronDownIcon,


### PR DESCRIPTION
**The Issue:**
`src/layout/Table.tsx` lines 7-8 contained several imports from `@tanstack/react-table` (`createCoreRowModel`, `ColumnDef`, and `Row`) that were declared but never used in the component. This creates unnecessary bundle overhead and clutters the code, violating structural cleanliness constraints.

**The Discovery Signal:**
Scan B: oxlint run across `src/` reported three instances of `correctness/no-unused-vars` specifically on line 7 of `src/layout/Table.tsx`.

**The Fix:**
Removed the unused imports (`createCoreRowModel`, `ColumnDef`, and `Row`) from the `@tanstack/react-table` import statement in `src/layout/Table.tsx`.

**The Benefit:**
Resolves all active oxlint warnings, ensuring a clean `npx oxlint src/` output. This reduces confusion for future developers, eliminates dead code surface, and improves overall code maintainability without altering any UI behavior or functionality.

---
*PR created automatically by Jules for task [15337798935153119038](https://jules.google.com/task/15337798935153119038) started by @fantasia949*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `@tanstack/react-table` imports (`createCoreRowModel`, `ColumnDef`, `Row`) from `src/layout/Table.tsx` to clear `oxlint` no-unused-vars warnings. This trims dead code and changes no behavior.

<sup>Written for commit 854c7471932333ba155d70186474f9a69d13f32e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/fantasia949/myhealth/pull/469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

